### PR TITLE
Feature/autostart reconnection fix

### DIFF
--- a/src/MultiRoomAudio/Services/PlayerManagerService.cs
+++ b/src/MultiRoomAudio/Services/PlayerManagerService.cs
@@ -2060,6 +2060,13 @@ public class PlayerManagerService : IHostedService, IAsyncDisposable, IDisposabl
 
         try
         {
+            // Check if player exists and remove it first (cleanup failed state)
+            if (_players.ContainsKey(name))
+            {
+                _logger.LogDebug("Removing existing failed player '{Name}' before reconnection attempt", name);
+                await RemoveAndDisposePlayerAsync(name);
+            }
+
             var request = new PlayerCreateRequest
             {
                 Name = state.Config.Name,


### PR DESCRIPTION
## Summary

Fixes critical bug where players that fail mDNS discovery during container autostart never attempt to reconnect automatically, requiring manual restart intervention.

## Problem

When the container starts before Music Assistant (or if mDNS discovery times out during boot), players enter ERROR state and remain there indefinitely:

**[note: my music assistant was never down, this was caused by a race condition in how long on reboot the networking stack comes up realtive to the container].**

1. `CreatePlayerAsync()` starts connection in fire-and-forget background task
2. Connection failures are caught internally and only set player state to ERROR
3. The autostart catch block never triggers because no exception propagates
4. Players sit in ERROR state with no retry attempts
5. Users must manually restart each player

**User Impact:** After server reboot, all 5 players show as ERROR and never recover, requiring manual intervention for each player.

## Solution

Implemented two fixes:

### 1. Post-Startup Connection Monitoring
Added detection logic in `StartAsync()` (lines 485-506):

- Waits 8 seconds after autostart attempts complete (6s mDNS timeout + 2s buffer)
- Scans all autostarted players for failed connections
- Identifies players in ERROR state that never connected (`ConnectedAt == null`)
- Queues them for automatic reconnection with exponential backoff

### 2. Clean Player Disposal Before Reconnection
Fixed race condition in `TryReconnectPlayerAsync()` (lines 2040-2045):

- Checks if player exists before reconnection attempt
- Removes and disposes failed player instance cleanly
- Creates fresh player instance with new connection attempt
- Prevents "Player already exists" errors during reconnection

## Expected Behavior After Fix

**Scenario: Container starts before Music Assistant**

| Time | Event |
|------|-------|
| T+0s | Container starts, hardware volume init |
| T+6s | All players fail mDNS discovery (timeout) |
| T+8s | Post-startup scan detects failures |
| T+8s | All players queued for reconnection |
| **T+13s** | **First automatic reconnection attempt** |
| T+13s | Players connect successfully (if MA running) |

**Retry Schedule (if still failing):**
- Attempt 1: 5s delay
- Attempt 2: 10s delay
- Attempt 3: 20s delay
- Attempt 4: 40s delay
- Attempt 5: 80s delay
- Attempt 6+: 120s delay (unlimited retries)

## Testing

Tested with 5 autostart players, Music Assistant unavailable at boot:

```
11:25:42 - All 5 players fail mDNS discovery
11:25:50 - Post-startup scan: "PlayerManagerService started with 5 active players, 5 pending reconnection" ✅
11:25:55 - First reconnection attempt (5s later)
11:25:55 - "Removing existing failed player 'Basement' before reconnection attempt"
11:26:00 - "Discovered new server: ... at ws://192.168.1.63:8927/sendspin"
11:26:01 - All 5 players connected successfully ✅
11:26:01 - "Player 'Basement' reconnected successfully after 1 attempt(s)"
```

**Recovery time: ~20 seconds from boot to all players connected**

## Changes

- `src/MultiRoomAudio/Services/PlayerManagerService.cs`:
  - Added post-startup scan logic (23 lines)
  - Added player disposal before reconnection (7 lines)

## Commits

1. `4aa69b4` - Fix: Queue failed autostart players for automatic reconnection
2. `a70cadd` - Fix: Remove failed player before reconnection attempt

## Breaking Changes

None. This fix only affects error handling paths that previously didn't work correctly.

## Related Issues

Addresses boot-time race condition where container starts before Music Assistant begins mDNS announcements, or where announcements are missed due to operating system / docker startup issues.

---

## For Maintainer Review

Key areas to review:

1. **8-second delay** in `StartAsync()` - chosen to accommodate 6s mDNS timeout + buffer. Could be reduced if desired.
2. **Disposal logic** in `TryReconnectPlayerAsync()` - ensures clean slate for reconnection attempts
3. **Log messages** - added INFO/WARNING logs for visibility into reconnection behavior

This fix makes the reconnection logic actually work as originally intended. The infrastructure was already there (exponential backoff, retry counting), but failed players were never entering the queue.