### PR TITLE
[hassio-addon-dev] Add relay and mock hardware config options PR 2/2

### DIFF
--- a/multiroom-audio-dev/config.yaml
+++ b/multiroom-audio-dev/config.yaml
@@ -15,6 +15,8 @@ arch:
 audio: true
 host_network: true
 udev: true
+uart: true
+usb: true
 # Explicit device mapping for audio access
 devices:
   - "/dev/snd:/dev/snd"
@@ -38,9 +40,15 @@ panel_title: Multi-Room Audio (Dev)
 # User-configurable options
 options:
   log_level: info
+  relay_devices: []
+  mock_hardware: false
 
 schema:
   log_level: list(debug|info|warning|error)
+  relay_serial_port: device(subsystem=tty)?
+  relay_devices:
+    - str?
+  mock_hardware: bool?
 
 # Watchdog - auto-restart if health check fails
 watchdog: http://[HOST]:[PORT:8096]/api/health


### PR DESCRIPTION
## Summary
- Add `uart: true` and `usb: true` for serial/USB relay board access (HID and CH340/Modbus devices)
- Add `relay_devices` option for Modbus/CH340 serial devices
- Add `relay_serial_port` schema for FTDI devices (optional)
- Add `mock_hardware` option to enable simulated hardware for testing

These config options are needed for the dev add-on UI to expose the relay and mock hardware toggles that were added in the dev branch code.

## Test plan
- [ ] Install dev add-on from repo
- [ ] Verify relay_devices and mock_hardware options appear in add-on Configuration tab
- [ ] Toggle mock_hardware and verify simulated devices appear after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)