### PR TITLE
Expand HID relay documentation with Docker device mapping details

### DIFF
--- a/docs/12V-TRIGGERS.md
+++ b/docs/12V-TRIGGERS.md
@@ -22,6 +22,7 @@ Automatically power on/off amplifiers when audio playback starts and stops using
 - 1, 2, 4, or 8 channel variants available
 - Channel count auto-detected from device name (e.g., "USBRelay4")
 - No drivers required on Linux
+- **Docker note:** Requires both `/dev/bus/usb` (for device discovery) AND `/dev/hidraw*` (for device control)—see [Docker Setup](#docker-setup)
 
 ### FTDI Relay Boards
 
@@ -40,22 +41,56 @@ Automatically power on/off amplifiers when audio playback starts and stops using
 
 ### USB HID Boards
 
+USB HID relay boards require **two** device mappings to work correctly:
+
+1. **`/dev/bus/usb`** — Required for device discovery (finding connected boards)
+2. **`/dev/hidraw*`** — Required for device control (actually operating the relays)
+
 ```yaml
 services:
   multiroom-audio:
     devices:
-      - /dev/bus/usb:/dev/bus/usb
+      - /dev/bus/usb:/dev/bus/usb    # Required: device discovery
+      - /dev/hidraw0:/dev/hidraw0    # Required: relay control
+      - /dev/hidraw1:/dev/hidraw1    # Add one line per HID relay board
 ```
 
-Or pass through specific hidraw devices:
+> **Why both?** The USB bus lets us enumerate and identify relay boards by their USB port location. But Linux exposes HID device control through the `/dev/hidraw*` interface, not through `/dev/bus/usb`. Without the hidraw mapping, boards appear in the UI but can't actually be controlled.
 
-```yaml
-    devices:
-      - /dev/hidraw0:/dev/hidraw0
-      - /dev/hidraw1:/dev/hidraw1
+#### Finding Your hidraw Devices
+
+```bash
+# List all hidraw devices
+ls -la /dev/hidraw*
+
+# Find which hidraw corresponds to your relay board (VID 16c0, PID 05df)
+for dev in /dev/hidraw*; do
+  info=$(udevadm info -a "$dev" 2>/dev/null | grep -E 'ATTRS\{idVendor\}|ATTRS\{idProduct\}' | head -2)
+  if echo "$info" | grep -q '16c0' && echo "$info" | grep -q '05df'; then
+    echo "Relay board found at: $dev"
+  fi
+done
 ```
 
-> **Important:** Keep the same device number on both sides of the mapping (e.g., `/dev/hidraw0:/dev/hidraw0`, not `/dev/hidraw0:/dev/hidraw3`). The hidraw numbers may change after a host reboot—check `ls /dev/hidraw*` and update your compose.yml if needed.
+#### Hidraw Numbers Can Change After Reboot
+
+The `/dev/hidraw*` numbers are assigned dynamically based on device enumeration order. They typically remain stable across reboots **as long as the same HID devices are present**. However, if you add or remove any HID device (keyboard, mouse, another relay board, etc.), the numbers may shift.
+
+When this happens:
+
+1. The board will show as "Disconnected" in the UI with an error message
+2. **Check the application logs** — they will tell you exactly which hidraw device the board now uses
+3. Update your `compose.yml` with the new device mapping
+4. Restart the container
+
+Example log message when a board is found but can't be opened:
+
+```text
+HID relay board found but cannot open: USBRelay4 at /sys/.../hidraw/hidraw2.
+Add '- /dev/hidraw2:/dev/hidraw2' to your compose.yml devices section.
+```
+
+> **Important:** Always keep the same device number on both sides of the mapping (e.g., `/dev/hidraw2:/dev/hidraw2`, not `/dev/hidraw2:/dev/hidraw0`). The internal board identification uses a hash of the USB port path, not the hidraw number, so changing physical USB ports will require reconfiguring the board in the UI.
 
 ### FTDI Boards
 
@@ -175,17 +210,30 @@ Each board can be configured with power-on and power-off behavior:
 
 ## Board Identification
 
-Boards are identified by:
+Boards are identified using stable identifiers that persist across reboots:
 
-1. **Serial Number** (preferred)—stable across reboots and USB port changes
-2. **USB Port Path** (fallback)—format: `USB:1-2.3`
-3. **Serial Port** (Modbus)—format: `MODBUS:/dev/ttyUSB0`
+| Board Type | ID Format | Example | Stability |
+| ---------- | --------- | ------- | --------- |
+| **USB HID** | `HID:<hash>` | `HID:CA88BCAC` | Stable if board stays in same USB port |
+| **FTDI** | Serial number | `A12345` | Stable regardless of USB port |
+| **Modbus** | `MODBUS:<hash>` | `MODBUS:7F3A2B1C` | Stable if board stays in same USB port |
+
+### How HID Board Identification Works
+
+USB HID relay boards often lack unique serial numbers—many boards from the same batch have identical or garbage serial data. To work around this, we identify HID boards by computing a hash of their **USB port path** (e.g., `usb1/1-3`).
+
+This means:
+
+- **Same USB port = same board ID** — You can unplug and replug the board and it will reconnect automatically
+- **Different USB port = different board ID** — Moving a board to a different USB port will make it appear as a new board in the UI
+- **Hidraw number doesn't matter** — The hidraw number (e.g., `/dev/hidraw2`) can change without affecting board identification; you just need to update the Docker device mapping
 
 ## Troubleshooting
 
 ### Board Not Detected
 
 **USB HID:**
+
 ```bash
 # Check if device is connected
 lsusb | grep 16c0
@@ -196,12 +244,14 @@ ls -la /dev/hidraw*
 ```
 
 **FTDI:**
+
 ```bash
 lsusb | grep 0403
 # Should show: 0403:6001 Future Technology Devices International
 ```
 
 **Modbus/CH340:**
+
 ```bash
 lsusb | grep 1a86
 # Should show: 1a86:7523 QinHeng Electronics CH340 serial converter
@@ -210,12 +260,35 @@ dmesg | grep ttyUSB
 # Should show: ch341-uart converter now attached to ttyUSB0
 ```
 
+### HID Board Shows "Disconnected" (Docker)
+
+If your HID relay board appears in the UI but shows as disconnected with an error, this usually means the hidraw device mapping is missing or outdated.
+
+**Check the logs first** — The application will tell you exactly what to do:
+
+```text
+HID relay board found but cannot open: USBRelay4 at /sys/.../hidraw/hidraw2.
+Add '- /dev/hidraw2:/dev/hidraw2' to your compose.yml devices section.
+```
+
+**Common causes:**
+
+1. **Missing hidraw mapping** — You have `/dev/bus/usb` but forgot the `/dev/hidraw*` mapping
+2. **Hidraw number changed** — A HID device was added/removed since you configured the container
+3. **Wrong hidraw number** — The mapping exists but points to the wrong device
+
+**Solution:**
+
+1. Check the logs to find the correct hidraw device
+2. Update your `compose.yml` with the correct mapping
+3. Restart the container
+
 ### Relay Not Responding
 
 1. **Test manually** using the Test button in the UI
-2. **Check permissions**—ensure container has access to device
+2. **Check permissions** — ensure container has access to device
 3. **Review logs** for error messages
-4. **Verify wiring**—relay boards typically need separate power supply
+4. **Verify wiring** — relay boards typically need separate power supply
 
 ### Multiple Boards with Same Serial
 


### PR DESCRIPTION
## Summary

- Documents that USB HID relay boards require **both** `/dev/bus/usb` (for enumeration) AND `/dev/hidraw*` (for device control) in Docker
- Explains how to find which hidraw device corresponds to your relay board
- Clarifies when hidraw numbers can change (adding/removing HID devices like keyboards/mice)
- Documents the hash-based board identification system for HID boards
- Adds new troubleshooting section for "HID Board Shows Disconnected" scenario

## Test plan

- [ ] Review documentation for accuracy and clarity
- [ ] Verify the bash commands for finding hidraw devices work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)