### PR TITLE
Add editable alias field to sound card modal

### DIFF
--- a/src/MultiRoomAudio/Audio/Mock/MockAudioBackend.cs
+++ b/src/MultiRoomAudio/Audio/Mock/MockAudioBackend.cs
@@ -230,8 +230,10 @@ public class MockAudioBackend : IBackend
 
         return deviceConfigs.Select(config =>
         {
-            // Find the corresponding card by index
-            var card = cards.FirstOrDefault(c => c.Index == config.Index);
+            // Find the corresponding card by CardIndex
+            var card = config.CardIndex.HasValue
+                ? cards.FirstOrDefault(c => c.Index == config.CardIndex.Value)
+                : null;
             var channelCount = card != null
                 ? GetChannelCountForProfile(card.ActiveProfile)
                 : config.MaxChannels;
@@ -268,7 +270,8 @@ public class MockAudioBackend : IBackend
                     VendorId: config.VendorId,
                     ProductId: config.ProductId,
                     AlsaLongCardName: config.Description
-                )
+                ),
+                CardIndex: config.CardIndex
             );
         }).ToList();
     }

--- a/src/MultiRoomAudio/Audio/PulseAudio/PulseAudioDeviceEnumerator.cs
+++ b/src/MultiRoomAudio/Audio/PulseAudio/PulseAudioDeviceEnumerator.cs
@@ -216,6 +216,22 @@ public static partial class PulseAudioDeviceEnumerator
         // Extract stable device identifiers from Properties section
         var identifiers = ParseDeviceIdentifiers(block);
 
+        // Extract card index from alsa.card or device.card property
+        int? cardIndex = null;
+        var alsaCardMatch = AlsaCardRegex().Match(block);
+        if (alsaCardMatch.Success)
+        {
+            cardIndex = int.Parse(alsaCardMatch.Groups[1].Value);
+        }
+        else
+        {
+            var deviceCardMatch = DeviceCardRegex().Match(block);
+            if (deviceCardMatch.Success)
+            {
+                cardIndex = int.Parse(deviceCardMatch.Groups[1].Value);
+            }
+        }
+
         var isDefault = sinkName.Equals(defaultSink, StringComparison.OrdinalIgnoreCase);
 
         return new AudioDevice(
@@ -229,7 +245,8 @@ public static partial class PulseAudioDeviceEnumerator
             IsDefault: isDefault,
             Identifiers: identifiers,
             ChannelMap: channelMap,
-            SampleFormat: sampleFormat
+            SampleFormat: sampleFormat,
+            CardIndex: cardIndex
         );
     }
 
@@ -297,4 +314,11 @@ public static partial class PulseAudioDeviceEnumerator
 
     [GeneratedRegex(@"alsa\.long_card_name\s*=\s*""([^""]+)""", RegexOptions.Multiline)]
     private static partial Regex AlsaLongCardNameRegex();
+
+    // Regex patterns for card index (links device to sound card)
+    [GeneratedRegex(@"alsa\.card\s*=\s*""(\d+)""", RegexOptions.Multiline)]
+    private static partial Regex AlsaCardRegex();
+
+    [GeneratedRegex(@"device\.card\s*=\s*""(\d+)""", RegexOptions.Multiline)]
+    private static partial Regex DeviceCardRegex();
 }

--- a/src/MultiRoomAudio/Models/DeviceInfo.cs
+++ b/src/MultiRoomAudio/Models/DeviceInfo.cs
@@ -80,7 +80,8 @@ public record AudioDevice(
     string? Alias = null,
     bool Hidden = false,
     string[]? ChannelMap = null,  // Channel names in device order, e.g., ["front-left", "front-right", "rear-left", ...]
-    string? SampleFormat = null   // PulseAudio sample format, e.g., "s16le", "s24le", "s32le", "float32le"
+    string? SampleFormat = null,  // PulseAudio sample format, e.g., "s16le", "s24le", "s32le", "float32le"
+    int? CardIndex = null         // PulseAudio card index this device belongs to (from alsa.card or device.card property)
 )
 {
     /// <summary>

--- a/src/MultiRoomAudio/Models/MockHardwareModels.cs
+++ b/src/MultiRoomAudio/Models/MockHardwareModels.cs
@@ -87,6 +87,12 @@ public class MockAudioDeviceConfig
     /// PulseAudio device index.
     /// </summary>
     public int Index { get; set; }
+
+    /// <summary>
+    /// Card index this device belongs to.
+    /// Links the device to a MockAudioCardConfig by its Index.
+    /// </summary>
+    public int? CardIndex { get; set; }
 }
 
 /// <summary>

--- a/src/MultiRoomAudio/Services/MockHardwareConfigService.cs
+++ b/src/MultiRoomAudio/Services/MockHardwareConfigService.cs
@@ -333,6 +333,7 @@ public class MockHardwareConfigService
                 ProductId = "a170",
                 BusPath = "/devices/pci0000:00/0000:00:1f.3/sound/card0",
                 Index = 0,
+                CardIndex = 0,
                 IsDefault = true,
                 MaxChannels = 2
             },
@@ -346,6 +347,7 @@ public class MockHardwareConfigService
                 ProductId = "8275",
                 BusPath = "/devices/pci0000:00/0000:00:1c.4/0000:05:04.0/sound/card1",
                 Index = 1,
+                CardIndex = 1,
                 MaxChannels = 8
             },
             // Schiit Modi 3 USB DAC
@@ -359,6 +361,7 @@ public class MockHardwareConfigService
                 BusPath = "/devices/pci0000:00/0000:00:14.0/usb1/1-2/1-2:1.0/sound/card2",
                 Serial = "0001",
                 Index = 2,
+                CardIndex = 2,
                 MaxChannels = 2
             },
             // Focusrite Scarlett 2i2 USB audio interface
@@ -372,6 +375,7 @@ public class MockHardwareConfigService
                 BusPath = "/devices/pci0000:00/0000:00:14.0/usb1/1-3/1-3:1.0/sound/card3",
                 Serial = "Y7XXXXXX00XXXX",
                 Index = 3,
+                CardIndex = 3,
                 MaxChannels = 2
             },
             // JBL Flip 5 Bluetooth speaker
@@ -382,6 +386,7 @@ public class MockHardwareConfigService
                 Description = "JBL Flip 5",
                 Serial = "00:1A:7D:DA:71:13",
                 Index = 4,
+                CardIndex = 4,
                 MaxChannels = 2
             },
             // Sony WH-1000XM4 Bluetooth headphones
@@ -392,6 +397,7 @@ public class MockHardwareConfigService
                 Description = "WH-1000XM4",
                 Serial = "38:18:4C:E9:85:B2",
                 Index = 5,
+                CardIndex = 5,
                 MaxChannels = 2
             },
             // NVIDIA HDMI audio (PCI device - GPU)
@@ -404,6 +410,7 @@ public class MockHardwareConfigService
                 ProductId = "0fb9",
                 BusPath = "/devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card6",
                 Index = 6,
+                CardIndex = 6,
                 MaxChannels = 2
             }
         };

--- a/src/MultiRoomAudio/wwwroot/css/style.css
+++ b/src/MultiRoomAudio/wwwroot/css/style.css
@@ -727,6 +727,37 @@ h1, h2, h3, h4, h5, h6 {
     text-align: center;
 }
 
+/* Sound Card Alias Input - inline editable styling */
+.card-alias-input {
+    max-width: 280px;
+    margin-top: 0.25rem;
+    margin-bottom: 0.25rem;
+    font-size: 0.875rem;
+    color: var(--bs-body-color);
+    background-color: transparent;
+    border: 1px solid transparent;
+    padding: 0.25rem 0.5rem;
+    border-radius: var(--radius-sm);
+    transition: border-color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.card-alias-input::placeholder {
+    color: var(--bs-secondary-color);
+    font-style: italic;
+}
+
+.card-alias-input:hover {
+    border-color: var(--bs-border-color);
+    background-color: var(--bs-tertiary-bg);
+}
+
+.card-alias-input:focus {
+    border-color: var(--accent-primary);
+    background-color: var(--bs-body-bg);
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+    outline: none;
+}
+
 /* ============================================
    Forms
    ============================================ */


### PR DESCRIPTION
## Summary
- Expose the existing device alias mechanism in the sound card settings modal
- Aliases set here now correctly appear in hardware dropdowns (e.g., Create Remap Sink)
- Add CardIndex property to AudioDevice for reliable card-to-device matching

## Changes
- Add `CardIndex` property to `AudioDevice` model
- Parse `alsa.card`/`device.card` from PulseAudio sink properties
- Update frontend to use `cardIndex` instead of unreliable name pattern matching
- Refresh global devices after saving aliases so dropdowns update immediately

## Test plan
- [x] Set alias in Sound Cards modal, verify it appears in Create Remap Sink dropdown
- [x] Verify alias persists after page refresh
- [x] Verify wizard alias setting still works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)