### PR TITLE
Clean up stale SDK version comments and add GroupId to diagnostics

### DIFF
--- a/src/MultiRoomAudio/Services/PlayerManagerService.cs
+++ b/src/MultiRoomAudio/Services/PlayerManagerService.cs
@@ -1870,20 +1870,18 @@ public class PlayerManagerService : IHostedService, IAsyncDisposable, IDisposabl
     }
 
     /// <summary>
-    /// Logs GroupState events for debugging.
-    /// SDK 5.4.0: GroupState now represents the average volume displayed to controllers,
-    /// NOT individual player volume commands. Volume control is handled by PlayerStateChanged.
+    /// Handles GroupState events from the SDK.
+    /// GroupState contains group-level data (average volume, muted, metadata).
+    /// This is for logging/diagnostics — individual player commands come via PlayerStateChanged.
     /// </summary>
     private EventHandler<GroupState> CreateGroupStateHandler(
         string name, PlayerContext context)
     {
         return (_, group) =>
         {
-            // SDK 5.4.0: GroupState represents average volume shown to controllers, not player commands
-            // Log for debugging but don't take action - PlayerStateChanged handles player control
             _logger.LogDebug(
-                "GROUPSTATE Player '{Name}': group average vol={GroupVol}% muted={GroupMuted} (local vol={LocalVol}%)",
-                name, group.Volume, group.Muted, context.Config.Volume);
+                "GROUPSTATE Player '{Name}': GroupId={GroupId} vol={GroupVol}% muted={GroupMuted} (local vol={LocalVol}%)",
+                name, group.GroupId, group.Volume, group.Muted, context.Config.Volume);
         };
     }
 
@@ -1984,8 +1982,6 @@ public class PlayerManagerService : IHostedService, IAsyncDisposable, IDisposabl
                 context.Pipeline.SetMuted(playerState.Muted);
                 context.Player.IsMuted = playerState.Muted;
                 context.LastConfirmedMuted = playerState.Muted;
-
-                // Note: SDK 5.4.0 auto-acknowledges, no manual echo needed
 
                 _ = BroadcastStatusAsync();
             }


### PR DESCRIPTION
## Summary
- Remove outdated "SDK 5.4.0" references from comments and XML docs in `PlayerManagerService.cs`
- Add `GroupId` to `CreateGroupStateHandler` log output for grouping diagnostics
- Rewrite `CreateGroupStateHandler` XML summary to describe actual purpose

## Context
These comments referenced SDK 5.4.0 behavior notes that are no longer relevant after the SDK 6.0.0 update. The added `GroupId` in the log output helps diagnose grouping issues when multiple players are involved.

No functional changes — logging and comments only.

## Test plan
- [x] Build succeeds
- [x] Verified log output includes GroupId in GROUPSTATE messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)