### PR TITLE
Add robust reconnection with mDNS watch and WaitingForServer state

### DIFF
--- a/src/MultiRoomAudio/Models/PlayerStatus.cs
+++ b/src/MultiRoomAudio/Models/PlayerStatus.cs
@@ -14,7 +14,8 @@ public enum PlayerState
     Paused,
     Stopped,
     Error,
-    Reconnecting
+    Reconnecting,
+    WaitingForServer
 }
 
 /// <summary>

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -945,7 +945,7 @@ async function showPlayerStats(name) {
             <div class="col-md-6">
                 <h6 class="text-muted text-uppercase small">Status</h6>
                 <table class="table table-sm">
-                    <tr><td><strong>State</strong></td><td><span class="badge bg-${getStateBadgeClass(player.state)}">${player.state}</span></td></tr>
+                    <tr><td><strong>State</strong></td><td><span class="badge bg-${getStateBadgeClass(player.state)}">${getStateDisplayName(player)}</span></td></tr>
                     <tr><td><strong>Clock Synced</strong></td><td>${player.isClockSynced ? '<i class="fas fa-check text-success"></i> Yes' : '<i class="fas fa-times text-danger"></i> No'}</td></tr>
                     <tr><td><strong>Muted</strong></td><td>${player.isMuted ? 'Yes' : 'No'}</td></tr>
                     <tr><td><strong>Output Latency</strong></td><td>${player.outputLatencyMs}ms</td></tr>
@@ -1066,7 +1066,7 @@ function renderPlayers() {
 
                         <div class="status-container mb-3">
                             <span class="status-indicator ${stateClass}"></span>
-                            <span class="badge bg-${stateBadgeClass}">${player.state}</span>
+                            <span class="badge bg-${stateBadgeClass}">${getStateDisplayName(player)}</span>
                             <small class="text-muted ms-2">${escapeHtml(getDeviceDisplayName(player.device))}</small>
                         </div>
 
@@ -1202,7 +1202,9 @@ function getStateClass(state) {
         'Starting': 'status-starting',
         'Connecting': 'status-connecting',
         'Stopped': 'status-stopped',
-        'Error': 'status-error'
+        'Error': 'status-error',
+        'Reconnecting': 'status-connecting',
+        'WaitingForServer': 'status-connecting'
     };
     return stateMap[state] || 'status-stopped';
 }
@@ -1216,9 +1218,19 @@ function getStateBadgeClass(state) {
         'Connecting': 'info',
         'Created': 'secondary',
         'Stopped': 'secondary',
-        'Error': 'danger'
+        'Error': 'danger',
+        'Reconnecting': 'warning',
+        'WaitingForServer': 'info'
     };
     return stateMap[state] || 'secondary';
+}
+
+function getStateDisplayName(player) {
+    if (player.state === 'WaitingForServer') return 'Waiting for mDNS discovery';
+    if (player.state === 'Reconnecting' && player.reconnectionAttempts) {
+        return `Reconnecting (attempt ${player.reconnectionAttempts})`;
+    }
+    return player.state;
 }
 
 // Alert helpers


### PR DESCRIPTION
## Summary
- **Disable SDK `AutoReconnect`** — The app manages its own reconnection with fresh mDNS discovery and clean player contexts, which handles server address changes better than the SDK's built-in retry-same-URI approach.
- **Map all SDK connection states to app `PlayerState`** — `Connecting`, `Handshaking`, `Reconnecting`, `Disconnected`, and `Disconnecting` now propagate to the UI instead of being ignored.
- **Concurrent reconnection with mDNS watch** — When players disconnect, an mDNS watch (`ServerFound` + `ServerUpdated` events) detects server reappearance and triggers immediate concurrent reconnection via `SemaphoreSlim` signal + `Task.WhenAll`, replacing the old sequential polling loop.
- **`WaitingForServer` state for mDNS-dependent startup** — Players that start before a server is available enter a passive wait mode (no active retries, `NextRetryTime = DateTime.MaxValue`) until mDNS discovers a server. UI shows "Waiting for mDNS discovery" badge.
- **Suppress transient error states during reconnection** — Override `Error`/`Stopped`/`Starting`/`Connecting` states with `Reconnecting` or `WaitingForServer` in the API response to prevent red error flash in UI.
- **Initial connection failure queuing** — Players that fail their first connection attempt are now queued for reconnection instead of staying in `Error` state permanently.

## Dependency
> **Required together with** chrisuthe/windowsSpin#7 — The SDK's `SendMessageAsync` fix is needed to detect connection loss promptly (triggers `HandleConnectionLostAsync` when WebSocket closes but receive loop is still blocking). Both PRs must be merged together.

## Test plan
- [ ] Start app with no server running → all players show "Waiting for mDNS discovery"
- [ ] Start the server → all players connect concurrently within ~15 seconds
- [ ] Kill the server → players transition to "Reconnecting" within ~10 seconds
- [ ] Restart the server → mDNS watch triggers immediate reconnection (no backoff wait)
- [ ] Verify no red error flash between reconnection attempts
- [ ] Verify explicit-server players use active backoff retries (not passive mDNS wait)
- [ ] Verify single-player stop/start/restart still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)