### PR TITLE
Fix card index mismatch causing wrong device names in UI

### DIFF
--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -298,14 +298,10 @@ function getConnectionInfo(deviceId) {
         }
         return `Sink: ${device.name}`;
     } else {
-        // Hardware device: get card description if available
-        let cardName = device.name;
-        if (device.cardIndex !== null && device.cardIndex !== undefined && soundCards.length > 0) {
-            const card = soundCards.find(c => c.index === device.cardIndex);
-            if (card) {
-                cardName = card.description || card.name;
-            }
-        }
+        // Hardware device: use device.name directly (already correct from PulseAudio sink description)
+        // (Previous code tried to look up card by cardIndex, but cardIndex is ALSA card number
+        // while card.index is PulseAudio card index - different numbering systems!)
+        const cardName = device.name;
         // Show "Device: cardName (alias)" or just "Device: cardName"
         if (device.alias) {
             return `Device: ${cardName} (${device.alias})`;
@@ -823,8 +819,9 @@ async function refreshDevices(currentDeviceId = null) {
                     // Custom sink: show "Sink: name (description)" if description exists
                     displayName = device.alias ? `Sink: ${device.name} (${device.alias})` : `Sink: ${device.name}`;
                 } else {
-                    // Hardware device: show "Device: card_desc (alias)" if alias set
-                    const cardName = cardDescriptions.get(device.cardIndex) || device.name;
+                    // Hardware device: use device.name directly (already correct from PulseAudio)
+                    // (cardDescriptions map uses PulseAudio index but device.cardIndex is ALSA card number)
+                    const cardName = device.name;
                     displayName = device.alias ? `Device: ${cardName} (${device.alias})` : `Device: ${cardName}`;
                 }
                 if (device.isDefault) displayName += ' (default)';
@@ -3100,8 +3097,11 @@ function renderSoundCards() {
         const busIcon = getBusTypeIcon(busType);
         const busLabel = getBusTypeLabel(busType);
 
-        // Find the device associated with this card using cardIndex (1:1 relationship)
-        const device = soundCardDevices.find(d => d.cardIndex === card.index);
+        // Find the device associated with this card by matching name patterns
+        // Card name: alsa_card.pci-0000_01_00.0 -> Device id: alsa_output.pci-0000_01_00.0.analog-stereo
+        // (Previous code used cardIndex === card.index, but cardIndex is ALSA number and card.index is PulseAudio index)
+        const cardBase = card.name.replace('alsa_card.', '');
+        const device = soundCardDevices.find(d => d.id && d.id.includes(cardBase));
         const deviceAlias = device?.alias || '';
         const deviceId = device?.id || '';
 

--- a/src/MultiRoomAudio/wwwroot/js/wizard.js
+++ b/src/MultiRoomAudio/wwwroot/js/wizard.js
@@ -533,14 +533,10 @@ const Wizard = {
             const alias = this.deviceState[device.id]?.alias || device.alias || '';
             const portHint = parseUsbPortHint(device.identifiers?.busPath);
 
-            // Get card description for hardware devices, use device name for sinks
-            let displayName = device.name;
-            if (device.cardIndex !== null && device.cardIndex !== undefined && this.cards.length > 0) {
-                const card = this.cards.find(c => c.index === device.cardIndex);
-                if (card) {
-                    displayName = card.description || card.name;
-                }
-            }
+            // Use device.name directly - it already contains the correct name from PulseAudio sink description
+            // (Previous code tried to look up card by cardIndex, but cardIndex is ALSA card number
+            // while card.index is PulseAudio card index - different numbering systems!)
+            const displayName = device.name;
 
             return `
                 <div class="list-group-item position-relative ${isHidden ? 'device-hidden' : ''}" id="device-row-${escapeHtml(device.id)}">


### PR DESCRIPTION
## Summary

Fixes a bug where audio devices display with wrong names in the wizard and main app UI due to mismatched index types between ALSA and PulseAudio.

**Root cause:** The code used `device.cardIndex` (ALSA card number) to look up cards by `card.index` (PulseAudio card index). These are different numbering systems that don't always align.

**Example:** Intel PCH device with `cardIndex: 1` would match USB card with `index: 1`, displaying "USB Audio Device" instead of "HDA Intel PCH".

## Changes

- **wizard.js**: Use `device.name` directly instead of buggy card lookup
- **app.js**: Use `device.name` directly in `getConnectionInfo()` and `refreshDevices()`  
- **app.js**: Match cards to devices by name pattern instead of index in `renderSoundCards()`

## Additional Benefit

This fix also makes device matching resilient to ALSA index reordering across reboots or device plug/unplug events, since we now match by hardware-stable identifiers (PCI bus path, USB device path) rather than dynamic indices.

## Testing

1. Run the onboarding wizard - Step 3 should show correct device names
2. Check Sound Card Settings modal - device aliases should work correctly
3. Device dropdowns should show correct names
4. Reboot or plug/unplug USB devices - names should remain correctly matched

🤖 Generated with [Claude Code](https://claude.ai/code)