### PR TITLE
Fix header dropdown buttons turning white when active

### DIFF
--- a/src/MultiRoomAudio/wwwroot/css/style.css
+++ b/src/MultiRoomAudio/wwwroot/css/style.css
@@ -120,6 +120,15 @@ h1, h2, h3, h4, h5, h6 {
     color: #fff;
 }
 
+.header-gradient .btn-outline-light:focus,
+.header-gradient .btn-outline-light:active,
+.header-gradient .btn-outline-light.show {
+    background: rgba(255, 255, 255, 0.15);
+    border-color: rgba(255, 255, 255, 0.4);
+    color: #fff;
+    box-shadow: none;
+}
+
 .header-gradient .btn-light {
     background: #fff;
     color: #1e293b;


### PR DESCRIPTION
## Summary

Fixes header dropdown buttons (Documentation, Settings) turning white with white text when clicked or when dropdown is open.

Fixes #75

## Root Cause

The CSS only overrides `.btn-outline-light` normal and `:hover` states. Bootstrap's default styling for `:focus`, `:active`, and `.show` (dropdown open) states fills the button with white background, making the white text invisible against the header gradient.

## Fix

Add CSS rules for focus, active, and show states to maintain transparent/semi-transparent background:

```css
.header-gradient .btn-outline-light:focus,
.header-gradient .btn-outline-light:active,
.header-gradient .btn-outline-light.show {
    background: rgba(255, 255, 255, 0.15);
    border-color: rgba(255, 255, 255, 0.4);
    color: #fff;
    box-shadow: none;
}
```

## Testing

1. Click Documentation dropdown - button stays readable
2. Click Settings dropdown - button stays readable
3. Tab through buttons (focus state) - stays readable
4. Move mouse away while dropdown is open - stays readable

🤖 Generated with [Claude Code](https://claude.ai/code)