### PR TITLE
Fix lock recursion error when skipping/completing onboarding

### DIFF
--- a/src/MultiRoomAudio/Services/OnboardingService.cs
+++ b/src/MultiRoomAudio/Services/OnboardingService.cs
@@ -87,13 +87,13 @@ public class OnboardingService : YamlFileService<OnboardingState>
             Logger.LogInformation(
                 "Onboarding completed: {DeviceCount} devices configured, {PlayerCount} players created",
                 devicesConfigured, playersCreated);
-
-            Save();
         }
         finally
         {
             Lock.ExitWriteLock();
         }
+
+        Save();
     }
 
     /// <summary>
@@ -112,12 +112,13 @@ public class OnboardingService : YamlFileService<OnboardingState>
             Data.AppVersion = null;
 
             Logger.LogInformation("Onboarding state reset");
-            Save();
         }
         finally
         {
             Lock.ExitWriteLock();
         }
+
+        Save();
     }
 
     /// <summary>
@@ -136,12 +137,13 @@ public class OnboardingService : YamlFileService<OnboardingState>
             Data.AppVersion = GetAppVersion();
 
             Logger.LogInformation("Onboarding skipped");
-            Save();
         }
         finally
         {
             Lock.ExitWriteLock();
         }
+
+        Save();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Fix `LockRecursionException` when skipping, completing, or resetting onboarding

## Problem
`ReaderWriterLockSlim` doesn't support acquiring a read lock while holding a write lock. The `Skip()`, `Reset()`, and `MarkCompleted()` methods held a write lock and called `Save()`, which tried to acquire a read lock for serialization.

## Fix
Move `Save()` calls outside the write lock block in all three methods.

## Test plan
- [ ] Skip onboarding - should complete without error
- [ ] Complete onboarding - should complete without error
- [ ] Reset onboarding - should complete without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)