### PR TITLE
Fix deadlock when USB audio device is unplugged

### DIFF
--- a/src/MultiRoomAudio/Audio/PulseAudio/PulseAudioPlayer.cs
+++ b/src/MultiRoomAudio/Audio/PulseAudio/PulseAudioPlayer.cs
@@ -682,8 +682,19 @@ public class PulseAudioPlayer : IAudioPlayer
                 _logger.LogDebug("PulseAudio stream disconnected (expected): {State}. Sink: {Sink}",
                     state, _sinkName ?? "default");
             else
+            {
                 _logger.LogWarning("PulseAudio stream disconnected: {State}. Error: {Error}. Sink: {Sink}",
                     state, errorMsg, _sinkName ?? "default");
+
+                // Fire error event so PlayerManagerService can auto-stop the player.
+                // This handles device removal (USB unplug) - with DontMove flag, PA fails the
+                // stream instead of moving it to a fallback sink.
+                // IMPORTANT: Must dispatch off the PA thread - this callback runs with the
+                // mainloop lock held, and the error handler will try to stop the player
+                // which needs to acquire the same lock, causing a deadlock.
+                var error = $"Audio device lost: {errorMsg}";
+                ThreadPool.QueueUserWorkItem(_ => OnError(error));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix deadlock when USB audio device is unplugged during playback
- Dispatch `OnError()` to thread pool instead of calling directly from PulseAudio callback
- The callback runs with the mainloop lock held, and the error handler tries to stop the player which needs the same lock, causing a deadlock

## Test plan
- [ ] Start playback on a USB audio device
- [ ] Unplug the USB device while playing
- [ ] Verify player stops gracefully without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)