### PR TITLE
Use bus path as primary key for device/card config persistence

### DIFF
--- a/src/MultiRoomAudio/Audio/Mock/MockCardEnumerator.cs
+++ b/src/MultiRoomAudio/Audio/Mock/MockCardEnumerator.cs
@@ -64,6 +64,15 @@ public static class MockCardEnumerator
             var isMuted = _muteStates.GetValueOrDefault(config.Index, false);
             var maxVolume = _maxVolumes.TryGetValue(config.Index, out var vol) ? vol : (int?)null;
 
+            // Generate fake device identifiers based on card index (simulates stable USB bus path)
+            var identifiers = new DeviceIdentifiers(
+                Serial: $"mock_serial_{config.Index:D4}",
+                BusPath: $"pci-mock-usb-0:{config.Index}:1.0",
+                VendorId: "mock",
+                ProductId: $"{config.Index:D4}",
+                AlsaLongCardName: $"Mock Card {config.Index} at usb-mock-{config.Index}"
+            );
+
             return new PulseAudioCard(
                 Index: config.Index,
                 Name: config.Name,
@@ -71,6 +80,7 @@ public static class MockCardEnumerator
                 Description: config.Description,
                 Profiles: profiles,
                 ActiveProfile: activeProfile,
+                Identifiers: identifiers,
                 IsMuted: isMuted,
                 BootMuted: null,
                 BootMuteMatchesCurrent: false,

--- a/src/MultiRoomAudio/Audio/PulseAudio/PulseAudioCardEnumerator.cs
+++ b/src/MultiRoomAudio/Audio/PulseAudio/PulseAudioCardEnumerator.cs
@@ -2,6 +2,8 @@ using System.Diagnostics;
 using System.Text.RegularExpressions;
 using MultiRoomAudio.Models;
 
+// DeviceIdentifiers is used for card identifier extraction
+
 namespace MultiRoomAudio.Audio.PulseAudio;
 
 /// <summary>
@@ -206,13 +208,45 @@ public static partial class PulseAudioCardEnumerator
         var activeMatch = ActiveProfileRegex().Match(block);
         var activeProfile = activeMatch.Success ? activeMatch.Groups[1].Value.Trim() : "";
 
+        // Extract stable device identifiers
+        var identifiers = ParseCardIdentifiers(block);
+
         return new PulseAudioCard(
             Index: index,
             Name: cardName,
             Driver: driver,
             Description: description,
             Profiles: profiles,
-            ActiveProfile: activeProfile
+            ActiveProfile: activeProfile,
+            Identifiers: identifiers
+        );
+    }
+
+    /// <summary>
+    /// Extracts stable device identifiers from the Properties section of a pactl card block.
+    /// These identifiers persist across reboots and can be used to re-match cards.
+    /// </summary>
+    private static DeviceIdentifiers? ParseCardIdentifiers(string block)
+    {
+        var serialMatch = DeviceSerialRegex().Match(block);
+        var busPathMatch = DeviceBusPathRegex().Match(block);
+        var vendorIdMatch = DeviceVendorIdRegex().Match(block);
+        var productIdMatch = DeviceProductIdRegex().Match(block);
+        var alsaLongCardNameMatch = AlsaLongCardNameRegex().Match(block);
+
+        // Only create identifiers if we found at least one useful property
+        if (!serialMatch.Success && !busPathMatch.Success && !vendorIdMatch.Success &&
+            !productIdMatch.Success && !alsaLongCardNameMatch.Success)
+        {
+            return null;
+        }
+
+        return new DeviceIdentifiers(
+            Serial: serialMatch.Success ? serialMatch.Groups[1].Value : null,
+            BusPath: busPathMatch.Success ? busPathMatch.Groups[1].Value : null,
+            VendorId: vendorIdMatch.Success ? vendorIdMatch.Groups[1].Value : null,
+            ProductId: productIdMatch.Success ? productIdMatch.Groups[1].Value : null,
+            AlsaLongCardName: alsaLongCardNameMatch.Success ? alsaLongCardNameMatch.Groups[1].Value : null
         );
     }
 
@@ -385,4 +419,20 @@ public static partial class PulseAudioCardEnumerator
 
     [GeneratedRegex(@"^[a-zA-Z0-9_\-.:+]+$")]
     private static partial Regex ProfileNameValidationRegex();
+
+    // Regex patterns for stable device identifiers (from Properties section)
+    [GeneratedRegex(@"device\.serial\s*=\s*""([^""]+)""", RegexOptions.Multiline)]
+    private static partial Regex DeviceSerialRegex();
+
+    [GeneratedRegex(@"device\.bus_path\s*=\s*""([^""]+)""", RegexOptions.Multiline)]
+    private static partial Regex DeviceBusPathRegex();
+
+    [GeneratedRegex(@"device\.vendor\.id\s*=\s*""([^""]+)""", RegexOptions.Multiline)]
+    private static partial Regex DeviceVendorIdRegex();
+
+    [GeneratedRegex(@"device\.product\.id\s*=\s*""([^""]+)""", RegexOptions.Multiline)]
+    private static partial Regex DeviceProductIdRegex();
+
+    [GeneratedRegex(@"alsa\.long_card_name\s*=\s*""([^""]+)""", RegexOptions.Multiline)]
+    private static partial Regex AlsaLongCardNameRegex();
 }

--- a/src/MultiRoomAudio/Models/CardModels.cs
+++ b/src/MultiRoomAudio/Models/CardModels.cs
@@ -64,6 +64,8 @@ public record PulseAudioCard(
     List<CardProfile> Profiles,
     /// <summary>Currently active profile name.</summary>
     string ActiveProfile,
+    /// <summary>Stable device identifiers (serial, bus path, etc.) for persistent matching.</summary>
+    DeviceIdentifiers? Identifiers = null,
     /// <summary>Whether the card is currently muted (based on sinks).</summary>
     bool? IsMuted = null,
     /// <summary>Boot mute preference if configured.</summary>


### PR DESCRIPTION
## Summary
- Changes key generation priority from serial-first to bus path-first for both `devices.yaml` and `card-profiles.yaml`
- This handles identical USB devices (same/no serial) in different ports correctly
- Settings are now tied to the USB port, not the physical device

## Problem
Many cheap USB audio devices don't implement unique serial numbers - they use the product name as "serial" (e.g., `0d8c_USB_Sound_Device`). Multiple identical devices would collide on the same key.

Additionally, `card-profiles.yaml` was using raw PulseAudio card names (e.g., `alsa_card.usb-...`) while `devices.yaml` used generated keys (`serial_...`), causing inconsistency.

## Changes
- `GenerateDeviceKey()` now uses bus path as first priority
- Added `GenerateCardKey()` with same logic for cards  
- `PulseAudioCard` now includes `DeviceIdentifiers`
- `CardProfileService` uses stable keys with auto-migration
- `ConfigurationService` migrates old `serial_` keys to `path_` keys
- `MockCardEnumerator` generates fake identifiers for testing

## Migration
Automatic on startup - old keys are converted to new format when the corresponding device/card is connected.

## Test plan
- [ ] Start app with existing `card-profiles.yaml` in old format
- [ ] Verify logs show migration messages
- [ ] Check `card-profiles.yaml` has new key format
- [ ] Change a card profile in UI
- [ ] Restart app - verify profile is restored correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)