### PR TITLE
Remove 'Default Device' option from player device dropdown

### DIFF
--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -884,7 +884,7 @@ async function refreshDevices(currentDeviceId = null) {
         const selects = document.querySelectorAll('#audioDevice, #editAudioDevice');
         selects.forEach(select => {
             const currentValue = select.value;
-            select.innerHTML = '<option value="">Default Device</option>';
+            select.innerHTML = '<option value="" disabled selected>Select a device...</option>';
             visibleDevices.forEach(device => {
                 const option = document.createElement('option');
                 option.value = device.id;
@@ -1031,6 +1031,11 @@ async function savePlayer() {
         return;
     }
 
+    if (!device) {
+        showAlert('Please select an audio device', 'warning');
+        return;
+    }
+
     // Disable submit button to prevent double-click
     const submitBtn = document.getElementById('playerModalSubmit');
     submitBtn.disabled = true;
@@ -1040,7 +1045,7 @@ async function savePlayer() {
             // Edit mode: Use PUT to update config, then restart if needed
             const updatePayload = {
                 name: name !== editingName ? name : undefined,  // Only include if changed
-                device: device || '',  // Empty string = default device
+                device: device,  // Device is required
                 serverUrl: serverUrl || ''  // Empty string = mDNS discovery
                 // Note: volume is NOT included here - we update startup volume separately
                 // so it doesn't affect current playback
@@ -1120,7 +1125,7 @@ async function savePlayer() {
             // Add mode: Create new player
             const payload = {
                 name,
-                device: device || null,
+                device,  // Device is required
                 serverUrl: serverUrl || null,
                 volume,
                 persist: true


### PR DESCRIPTION
## Summary
- Replace "Default Device" dropdown option with "Select a device..." placeholder
- Add validation requiring device selection before saving a player
- Clean up fallback logic for empty device values

## Rationale
In multi-room audio setups, PulseAudio's "default sink" concept doesn't apply - each player should be pinned to a specific output device. The "Default Device" option caused confusion since:
- Users expected it to mean "automatically detect" rather than "follow PA default"
- The PA default can change unexpectedly when devices connect/disconnect
- It's duplicative when users should always explicitly choose a device

## Test plan
- [ ] Open Add Player modal - dropdown shows "Select a device..." placeholder
- [ ] Try to save without selecting a device - should show warning
- [ ] Select a device and save - should work normally
- [ ] Edit existing player - device dropdown works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)