### PR TITLE
Revert sync correction threshold from 30ms back to 15ms

### DIFF
--- a/src/MultiRoomAudio/Audio/BufferedAudioSampleSource.cs
+++ b/src/MultiRoomAudio/Audio/BufferedAudioSampleSource.cs
@@ -104,10 +104,9 @@ public sealed class BufferedAudioSampleSource : IAudioSampleSource
     private readonly int _sampleRate;
 
     // Correction threshold - within tolerance is acceptable, beyond that we correct.
-    // Increased from 15ms to 30ms to tolerate VM scheduler jitter on USB passthrough audio.
-    // Observed sync error oscillates ±22ms in VMs; 30ms deadband prevents constant corrections
-    // while staying below the ~40-50ms threshold where multi-room delay becomes audible.
-    private const long CorrectionThresholdMicroseconds = 30_000;  // 30ms deadband
+    // 15ms deadband tolerates PulseAudio latency measurement jitter while staying
+    // below the ~20-30ms threshold where multi-room delay becomes audible.
+    private const long CorrectionThresholdMicroseconds = 15_000;  // 15ms deadband
 
     // Correction rate limits (frames between corrections)
     private const int MinCorrectionInterval = 10;   // Most aggressive: correct every 10 frames


### PR DESCRIPTION
## Summary
- Reverts the sync correction threshold from 30ms back to 15ms
- The 30ms threshold was too permissive for tight multi-room sync
- 15ms provides good tolerance for PulseAudio latency jitter while staying below the audible delay threshold (~20-30ms)

## Test plan
- [ ] Verify multi-room sync remains tight with multiple players
- [ ] Confirm no excessive correction oscillation under normal conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)