### PR TITLE
Auto-track devices and cards at startup and on discovery

### DIFF
--- a/src/MultiRoomAudio/Services/PlayerManagerService.cs
+++ b/src/MultiRoomAudio/Services/PlayerManagerService.cs
@@ -429,6 +429,26 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
 
             _logger.LogInformation("Found {Count} audio output device(s)", devices.Count);
 
+            // Track all devices with identifiers for persistence
+            var newDevicesFound = false;
+            foreach (var device in devices)
+            {
+                if (device.Identifiers != null)
+                {
+                    var deviceKey = ConfigurationService.GenerateDeviceKey(device);
+                    if (_config.EnsureDeviceTracked(deviceKey, device))
+                    {
+                        newDevicesFound = true;
+                    }
+                }
+            }
+
+            // Save once if any new devices were discovered
+            if (newDevicesFound)
+            {
+                _config.SaveDevices();
+            }
+
             // Get device configurations to check for volume limits
             var deviceConfigs = _config.GetAllDeviceConfigurations();
 


### PR DESCRIPTION
## Summary
- Automatically persist all devices and cards to YAML config files at startup
- Track new hot-plugged devices/cards when UI fetches device/card lists
- Only write to disk when NEW entries are discovered (avoids unnecessary writes)

## Problem
Previously, devices and cards were only persisted to `devices.yaml` and `card-profiles.yaml` when users explicitly changed settings (alias, hidden, profile, etc). This meant:
- New devices wouldn't appear in config files until interacted with
- The bus-path based device identification (from previous PR) wasn't being utilized for new devices

## Solution
Added `EnsureDeviceTracked()` and `EnsureCardTracked()` methods that:
- Check if device/card already exists in config
- Only create new entries for undiscovered devices/cards
- Return `true` if new entry was created (to batch saves)

Tracking happens:
- **At startup**: devices in Phase 3 (`InitializeHardwareAsync`), cards in Phase 1 (`InitializeAsync`)
- **On hot-plug**: when UI fetches device/card lists via API

## Test plan
- [ ] Restart add-on with multiple USB audio devices connected
- [ ] Verify all devices appear in `devices.yaml` immediately (without opening Audio Devices dialog)
- [ ] Verify all cards appear in `card-profiles.yaml` immediately
- [ ] Hot-plug a new USB audio device, refresh UI, verify it's tracked
- [ ] Verify no duplicate writes when devices already exist in config

🤖 Generated with [Claude Code](https://claude.com/claude-code)