### PR TITLE
Add sink identifier migration with identity verification

### DIFF
--- a/src/MultiRoomAudio/Models/SinkModels.cs
+++ b/src/MultiRoomAudio/Models/SinkModels.cs
@@ -163,6 +163,23 @@ public class SinkIdentifiersConfig
 
     /// <summary>Last known sink name (may become stale after reboot).</summary>
     public string? LastKnownSinkName { get; set; }
+
+    /// <summary>
+    /// Card profile name (e.g., "output:analog-surround-71") from card-profiles.yaml.
+    /// Used to ensure the correct profile is active when resolving the sink.
+    /// </summary>
+    public string? CardProfile { get; set; }
+
+    /// <summary>
+    /// Checks if this identifier config has at least one stable identifier.
+    /// </summary>
+    public bool HasStableIdentifier()
+    {
+        return !string.IsNullOrEmpty(BusPath) ||
+               !string.IsNullOrEmpty(AlsaLongCardName) ||
+               !string.IsNullOrEmpty(Serial) ||
+               (!string.IsNullOrEmpty(VendorId) && !string.IsNullOrEmpty(ProductId));
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

This PR adds robust sink identifier migration to handle ALSA card renumbering across reboots.

**Key features:**
- Proactively extract and store stable identifiers (BusPath, CardProfile) for custom sinks
- Identity verification prevents sinks pointing to wrong device after ALSA renumbering
- Works for both remap sinks and combine sink slaves
- Self-healing: automatically corrects stale sink names on every startup

## Problem Solved

When ALSA card indices shift (e.g., USB device insertion causes PCIe cards to renumber), sink configurations could:
1. Point to non-existent sinks (if name changed)
2. **Point to wrong device** (if name still exists but belongs to different hardware)

## Solution: Three Layers of Protection

| Layer | Trigger | Action |
|-------|---------|--------|
| **Proactive Enrichment** | Sink exists, no identifiers | Extract BusPath, CardProfile, save |
| **Stale Name Resolution** | Sink name doesn't exist | Resolve via identifiers, update name |
| **Identity Verification** | Sink exists but wrong device | Detect via BusPath mismatch, resolve to correct device |

## Example Scenario

```
Before reboot: PCIe A=card_0, PCIe B=card_1, USB=card_3
After reboot:  USB=card_0, PCIe A=card_1, PCIe B=card_2

Old behavior: card_0 exists → no check → WRONG device!
New behavior: card_0 exists but BusPath differs → resolve → correct device
```

## Changes

- **SinkModels.cs**: Add `CardProfile` field and `HasStableIdentifier()` helper
- **CustomSinksService.cs**:
  - Add proactive identifier extraction in `MigrateConfigurations()`
  - Add `IdentifiersMatch()` helper for identity verification
  - Update `ResolveSinkByIdentifiers()` to prefer matching CardProfile
  - Use lazy DI resolution for CardProfileService to avoid circular dependency

## Expected YAML After Migration

```yaml
zone1:
  master_sink: alsa_output.alsa_card_0.analog-surround-71
  master_sink_identifiers:
    bus_path: /devices/pci0000:00/.../sound/card0
    alsa_long_card_name: Asus Virtuoso 66 at 0xe000, irq 16
    card_profile: output:analog-surround-71
    last_known_sink_name: alsa_output.alsa_card_0.analog-surround-71
```

## Testing Done

- Tested v4 → v5 migration with 8-zone remap sink configuration
- Verified all zones enriched with correct BusPath and CardProfile
- Confirmed identifiers match between custom-sinks.yaml and card-profiles.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)