### PR TITLE
Defer DOM updates during user interaction and add real-time volume slider

### DIFF
--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -10,6 +10,20 @@ let currentBuildVersion = null; // Stored build version for comparison
 let isUserInteracting = false; // Track if user is dragging a slider
 let pendingUpdate = null; // Store pending updates during interaction
 
+// Debounced volume change for real-time slider updates
+let volumeDebounceTimers = {}; // Per-player debounce timers
+function setVolumeDebounced(name, volume) {
+    // Clear existing timer for this player
+    if (volumeDebounceTimers[name]) {
+        clearTimeout(volumeDebounceTimers[name]);
+    }
+    // Set new timer - 100ms debounce for responsive feel without flooding API
+    volumeDebounceTimers[name] = setTimeout(() => {
+        setVolume(name, volume);
+        delete volumeDebounceTimers[name];
+    }, 100);
+}
+
 /**
  * Check if user is actively interacting with player tiles.
  * Only checks for transient interactions that have clear start/end:
@@ -1741,7 +1755,7 @@ function renderPlayers() {
                             <div class="d-flex align-items-center">
                                 <input type="range" class="form-range form-range-sm flex-grow-1 volume-slider" min="0" max="100" value="${player.volume}"
                                     onchange="setVolume('${escapeJsString(name)}', this.value)"
-                                    oninput="this.nextElementSibling.textContent = this.value + '%'">
+                                    oninput="this.nextElementSibling.textContent = this.value + '%'; setVolumeDebounced('${escapeJsString(name)}', this.value)">
                                 <span class="volume-display ms-2 small">${player.volume}%</span>
                                 <button class="btn card-mute-toggle ms-2"
                                         title="${getPlayerMuteDisplayState(player).label}"


### PR DESCRIPTION
## Summary
Fixes UI issues with player tiles interrupting user interactions.

### Changes

**PR #117: Defer DOM updates during interaction**
- Add `isUserInteractingWithPlayers()` helper to detect slider drag and open dropdowns
- Defer `renderPlayers()` calls during interaction to prevent DOM replacement
- Apply deferred updates when interaction ends

**PR #117 fix: Remove focus check (Codex feedback)**
- Focus check caused refresh starvation after button clicks
- Only transient interactions (slider drag, dropdown) now defer updates

**PR #118: Preserve other player updates in pendingUpdate**
- Instead of clearing pendingUpdate, update only the affected player
- Preserves updates for other players received during interaction

**PR #119: Real-time volume changes while dragging**
- Add debounced `setVolumeDebounced()` with 100ms debounce
- Volume now changes in real-time while dragging slider

## Test plan
- [ ] Drag volume slider for 10+ seconds - should not jump/reset
- [ ] Volume changes in real-time while dragging
- [ ] Open player dropdown, wait 6+ seconds, click option - should work
- [ ] Click Stop/Restart buttons - should respond reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)