### PR TITLE
Restore missing HidSharp NuGet package reference

### DIFF
--- a/src/MultiRoomAudio/MultiRoomAudio.csproj
+++ b/src/MultiRoomAudio/MultiRoomAudio.csproj
@@ -32,6 +32,9 @@
 
     <!-- Health checks -->
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
+
+    <!-- USB HID support for HID relay boards -->
+    <PackageReference Include="HidSharp" Version="2.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- The `HidSharp` package reference was accidentally dropped from the csproj during the merge of `main` into `dev` (commit `95a1421`)
- This breaks the CI build — `HidRelayBoard.cs` uses `HidSharp` types (`HidDevice`, `HidStream`, etc.)
- Re-adds the missing `<PackageReference Include="HidSharp" Version="2.1.0" />` line

## Test plan
- [ ] CI `build-test` job passes (was failing with 7 CS0246 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)