### PR TITLE
Remove uneeded serial code.

### DIFF
--- a/docs/12V-TRIGGERS.md
+++ b/docs/12V-TRIGGERS.md
@@ -166,26 +166,6 @@ USB relay boards should work automatically when connected. If not detected:
 2. Restart the add-on after connecting the board
 3. For Modbus boards, ensure the serial port is visible in hardware settings
 
-### Optional: Explicit Device Configuration
-
-For more granular control, you can configure specific devices in the add-on Configuration tab:
-
-| Option | Description |
-|--------|-------------|
-| **Relay Serial Port** | Dropdown to select a serial port for Modbus/CH340 boards |
-| **Relay Devices** | List of additional device paths (e.g., `/dev/hidraw0` for HID boards) |
-
-Example YAML configuration:
-
-```yaml
-log_level: info
-relay_serial_port: /dev/ttyUSB0
-relay_devices:
-  - /dev/hidraw0
-```
-
-This is optional—by default, the add-on has access to all USB and serial devices.
-
 ## Configuration
 
 ### Enable Triggers

--- a/docs/HAOS_ADDON_GUIDE.md
+++ b/docs/HAOS_ADDON_GUIDE.md
@@ -345,8 +345,6 @@ Settings persist across restarts and are applied automatically at startup.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `log_level` | string | `info` | Verbosity: debug, info, warning, error |
-| `relay_serial_port` | device | null | Serial port for Modbus/CH340 relay board |
-| `relay_devices` | list | `[]` | Device paths for HID/FTDI relay boards |
 
 ---
 

--- a/multiroom-audio-dev/DOCS.md
+++ b/multiroom-audio-dev/DOCS.md
@@ -47,8 +47,6 @@ When reporting issues with dev builds, please include:
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `log_level` | string | `info` | Logging verbosity (debug, info, warning, error) |
-| `relay_serial_port` | device | null | Serial port for Modbus/CH340 relay board |
-| `relay_devices` | list | `[]` | Device paths for HID/FTDI relay boards |
 | `mock_hardware` | bool | `false` | Enable mock audio devices and relay boards for testing without hardware |
 | `enable_advanced_formats` | bool | `false` | Show format selection UI (players default to flac-48000 regardless) |
 

--- a/multiroom-audio-dev/config.yaml
+++ b/multiroom-audio-dev/config.yaml
@@ -41,16 +41,11 @@ panel_title: Multi-Room Audio (Dev)
 # User-configurable options
 options:
   log_level: info
-  relay_serial_port: null
-  relay_devices: []
   mock_hardware: false
   enable_advanced_formats: false
 
 schema:
   log_level: list(debug|info|warning|error)
-  relay_serial_port: device(subsystem=tty)?
-  relay_devices:
-    - str?
   mock_hardware: bool?
   enable_advanced_formats: bool?
 

--- a/multiroom-audio/DOCS.md
+++ b/multiroom-audio/DOCS.md
@@ -60,22 +60,11 @@ multi-room audio from a single server.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `log_level` | string | `info` | Logging verbosity (debug, info, warning, error) |
-| `relay_serial_port` | device | null | Serial port for Modbus/CH340 relay board (dropdown) |
-| `relay_devices` | list | `[]` | Additional device paths for HID/FTDI relay boards |
 
 ### Example Configuration
 
 ```yaml
 log_level: info
-```
-
-### Example with Relay Boards
-
-```yaml
-log_level: info
-relay_serial_port: /dev/ttyUSB0
-relay_devices:
-  - /dev/hidraw0
 ```
 
 ## Audio Device Setup

--- a/multiroom-audio/config.yaml
+++ b/multiroom-audio/config.yaml
@@ -41,14 +41,9 @@ panel_title: Multi-Room Audio
 # User-configurable options
 options:
   log_level: info
-  relay_serial_port: null
-  relay_devices: []
 
 schema:
   log_level: list(debug|info|warning|error)
-  relay_serial_port: device(subsystem=tty)?
-  relay_devices:
-    - str?
 
 # Watchdog - auto-restart if health check fails
 watchdog: http://[HOST]:[PORT:8096]/api/health


### PR DESCRIPTION
Summary
Removes relay_serial_port and relay_devices options from both production and dev HAOS add-on config.yaml files
Fixes "Missing required option 'relay_serial_port'" error that prevents the add-on from starting
Updates DOCS.md and trigger documentation to remove references to the removed options
Root Cause
The relay_serial_port: null default value fails the HA supervisor's device() type validator. These options were never read by the application — relay boards are discovered automatically via USB enumeration (RealRelayDeviceEnumerator), and serial/USB device access is provided by uart: true and usb: true flags which remain unchanged.
Test plan
 Install updated dev add-on in HAOS
 Verify add-on starts without "Missing required option" error
 Verify relay boards are still discovered and functional
 Verify Configuration tab no longer shows relay_serial_port dropdown