### PR TITLE
Remove relay options from config.yaml

### DIFF
--- a/multiroom-audio-dev/config.yaml
+++ b/multiroom-audio-dev/config.yaml
@@ -41,16 +41,11 @@ panel_title: Multi-Room Audio (Dev)
 # User-configurable options
 options:
   log_level: info
-  relay_serial_port: null
-  relay_devices: []
   mock_hardware: false
   enable_advanced_formats: false
 
 schema:
   log_level: list(debug|info|warning|error)
-  relay_serial_port: device(subsystem=tty)?
-  relay_devices:
-    - str?
   mock_hardware: bool?
   enable_advanced_formats: bool?
 


### PR DESCRIPTION
Removed relay_serial_port and relay_devices options from configuration.