### PR TITLE
5.1.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,9 +4,11 @@
 # Force Unix line endings for shell scripts
 *.sh text eol=lf
 
-# Force Unix line endings for Docker files
+# Force Unix line endings for Docker files and Linux config
 Dockerfile* text eol=lf
 docker-compose*.yml text eol=lf
+*.conf text eol=lf
+*.pa text eol=lf
 
 # Windows files
 *.bat text eol=crlf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,7 @@ new ErrorResponse(false, "Error message")
 | `SUPERVISOR_TOKEN` | (HAOS only) | Auto-set by Home Assistant supervisor |
 | `MOCK_HARDWARE` | `false` | Enable mock relay boards for testing without hardware |
 | `ENABLE_ADVANCED_FORMATS` | `false` | Show format selection UI (dev-only). All players default to flac-48000 regardless. |
+| `BUFFER_SECONDS` | `30` | Audio buffer size in seconds (5-30, step 5). Lower values reduce RAM on constrained hardware. |
 
 **Audio Configuration Notes:**
 - `PA_SAMPLE_RATE` and `PA_SAMPLE_FORMAT` only apply in standalone Docker mode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Transform a single Docker host with multiple USB audio devices into a multi-room
 - **Reference Add-ons:**
   - [home-assistant/addons/vlc](https://github.com/home-assistant/addons/tree/master/vlc) - Official VLC add-on (audio player pattern)
 - **SDK Documentation:**
-  - SendSpin.SDK v7.2.1 - Sendspin protocol handling
+  - SendSpin.SDK v7.3.0 - Sendspin protocol handling
 
 ---
 
@@ -270,7 +270,7 @@ squeezelite-docker/
 ## NuGet Packages
 
 ```xml
-<PackageReference Include="SendSpin.SDK" Version="7.2.1" />
+<PackageReference Include="SendSpin.SDK" Version="7.3.0" />
 <PackageReference Include="YamlDotNet" Version="16.3.0" />
 <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.0" />
 <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.22" />

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Transform a single Docker host with multiple USB audio devices into a multi-room
 - **Reference Add-ons:**
   - [home-assistant/addons/vlc](https://github.com/home-assistant/addons/tree/master/vlc) - Official VLC add-on (audio player pattern)
 - **SDK Documentation:**
-  - SendSpin.SDK v6.1.1 - Sendspin protocol handling
+  - SendSpin.SDK v7.2.1 - Sendspin protocol handling
 
 ---
 
@@ -270,7 +270,7 @@ squeezelite-docker/
 ## NuGet Packages
 
 ```xml
-<PackageReference Include="SendSpin.SDK" Version="6.1.1" />
+<PackageReference Include="SendSpin.SDK" Version="7.2.1" />
 <PackageReference Include="YamlDotNet" Version="16.3.0" />
 <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.0" />
 <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.22" />

--- a/docs/plans/2026-03-05-adjustable-buffer-design.md
+++ b/docs/plans/2026-03-05-adjustable-buffer-design.md
@@ -1,0 +1,80 @@
+# Configurable Audio Buffer Size Design
+
+**Date**: 2026-03-05
+**Branch**: task/feat-adjustable-buffer
+
+---
+
+## Overview
+
+Add a global setting to configure the audio buffer size (5-30 seconds) to accommodate
+resource-constrained hardware like Raspberry Pi running many players.
+
+## Setting
+
+- **Scope**: Global (applies to all players)
+- **Storage**: Environment variable `BUFFER_SECONDS` with config persistence
+- **Range**: 5-30 seconds, step 5
+- **Default**: 30 seconds
+- **Restart required**: Yes, changing buffer size requires player restart since buffers are allocated at player creation
+
+## UI - Settings Page
+
+Slider control labeled "Audio Buffer Size" showing current value (e.g., "15 seconds").
+
+Below the slider, a memory usage table with explanatory note:
+
+> **Memory Usage Estimate**
+>
+> Audio is buffered as decoded PCM float32 regardless of the codec used
+> (FLAC, Opus, PCM). Memory usage depends on sample rate, not codec.
+>
+> | Sample Rate | Per Player | Total (N players) |
+> |-------------|-----------|-------------------|
+> | 48 kHz      | X MB      | Y MB              |
+> | 96 kHz      | X MB      | Y MB              |
+> | 192 kHz     | X MB      | Y MB              |
+
+- Player count (N) updates dynamically based on current player count
+- Memory values recalculate as slider moves
+- Formula: `buffer_seconds * sample_rate * 2 channels * 4 bytes / 1,048,576` = MB per player
+
+## Implementation
+
+### EnvironmentService
+- Read `BUFFER_SECONDS` env var
+- Default: 30
+- Clamp to range 5-30
+- Expose as `BufferSeconds` property (int)
+
+### PlayerManagerService
+- Replace `const int LocalBufferCapacityMs = 30_000` with value from `EnvironmentService.BufferSeconds * 1000`
+- Read once at construction, used for all player creation
+
+### Settings API
+- `GET /api/settings/buffer` - Returns current buffer size and player count
+- `PUT /api/settings/buffer` - Updates buffer size, persists to config, returns restart-required flag
+
+### Config Persistence
+- Store in existing config mechanism (ConfigurationService or similar)
+- Load on startup, override env var if present
+
+### Settings UI
+- Slider: range 5-30, step 5, with numeric display
+- Memory table: recalculates on slider change
+- Save button: calls PUT, shows "restart players to apply" message
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `EnvironmentService.cs` | Add `BufferSeconds` property, read from env/config |
+| `PlayerManagerService.cs` | Use `EnvironmentService.BufferSeconds * 1000` instead of constant |
+| `ConfigurationService.cs` | Persist buffer setting |
+| Settings API endpoint | GET/PUT for buffer size |
+| `wwwroot/js/app.js` | Slider + memory table on settings page |
+
+## Out of Scope
+
+- Per-player buffer sizes
+- Live buffer resize without player restart

--- a/docs/plans/2026-03-05-adjustable-buffer-plan.md
+++ b/docs/plans/2026-03-05-adjustable-buffer-plan.md
@@ -1,0 +1,623 @@
+# Configurable Audio Buffer Size - Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a global setting (5-30 seconds, step 5) to configure the audio buffer size, with a settings UI showing per-sample-rate memory estimates.
+
+**Architecture:** New `BufferSeconds` property on `EnvironmentService` backed by `settings.yaml` via `ConfigurationService`. New REST endpoint `GET/PUT /api/settings/buffer`. New "System" settings modal in the web UI with a slider and memory table. `PlayerManagerService` reads buffer size once at construction.
+
+**Tech Stack:** C# ASP.NET Core 8.0, YamlDotNet, vanilla JS
+
+---
+
+### Task 1: Add BufferSeconds to EnvironmentService
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Services/EnvironmentService.cs`
+
+**Step 1: Add constant, field, and property**
+
+Add after line 30 (after `AdvancedFormatsEnv` constant):
+
+```csharp
+private const string BufferSecondsEnv = "BUFFER_SECONDS";
+private const int DefaultBufferSeconds = 30;
+private const int MinBufferSeconds = 5;
+private const int MaxBufferSeconds = 30;
+```
+
+Add a mutable field (unlike the other readonly fields, this one can be updated at runtime via the settings API):
+
+```csharp
+private int _bufferSeconds;
+```
+
+Add public property after `EnableAdvancedFormats` (around line 119):
+
+```csharp
+/// <summary>
+/// Audio buffer size in seconds (5-30, step 5). Applies to all players.
+/// Changing this requires a player restart.
+/// </summary>
+public int BufferSeconds
+{
+    get => _bufferSeconds;
+    set => _bufferSeconds = Math.Clamp(value, MinBufferSeconds, MaxBufferSeconds);
+}
+```
+
+**Step 2: Add detection method**
+
+Add after `DetectAdvancedFormats()` method:
+
+```csharp
+private int DetectBufferSeconds()
+{
+    // Check environment variable first
+    var bufferSecondsValue = Environment.GetEnvironmentVariable(BufferSecondsEnv);
+    if (!string.IsNullOrEmpty(bufferSecondsValue))
+    {
+        if (int.TryParse(bufferSecondsValue, out var parsed))
+        {
+            var clamped = Math.Clamp(parsed, MinBufferSeconds, MaxBufferSeconds);
+            _logger.LogDebug("{EnvVar} detected: {Value} (clamped to {Clamped})",
+                BufferSecondsEnv, bufferSecondsValue, clamped);
+            return clamped;
+        }
+        else
+        {
+            _logger.LogWarning("{EnvVar} value '{Value}' is not a valid integer, using default {Default}",
+                BufferSecondsEnv, bufferSecondsValue, DefaultBufferSeconds);
+        }
+    }
+    else
+    {
+        _logger.LogDebug("{EnvVar} environment variable not set", BufferSecondsEnv);
+    }
+
+    // Check HAOS options
+    if (_isHaos && _haosOptions != null)
+    {
+        if (_haosOptions.TryGetValue("buffer_seconds", out var element))
+        {
+            try
+            {
+                var haosValue = element.GetInt32();
+                var clamped = Math.Clamp(haosValue, MinBufferSeconds, MaxBufferSeconds);
+                _logger.LogDebug("Buffer seconds from HAOS options: {Value} (clamped to {Clamped})",
+                    haosValue, clamped);
+                return clamped;
+            }
+            catch (InvalidOperationException)
+            {
+                _logger.LogWarning("HAOS option 'buffer_seconds' is not an integer value");
+            }
+        }
+    }
+
+    return DefaultBufferSeconds;
+}
+```
+
+**Step 3: Call detection in constructor**
+
+Add after the `_enableAdvancedFormats` detection block (after line 101), before the closing `}` of the constructor:
+
+```csharp
+// Detect buffer seconds setting
+_bufferSeconds = DetectBufferSeconds();
+_logger.LogInformation("Audio buffer size: {BufferSeconds} seconds", _bufferSeconds);
+```
+
+**Step 4: Add SettingsConfigPath property**
+
+Add after `MockHardwareConfigPath` property (around line 150):
+
+```csharp
+/// <summary>
+/// Full path to settings.yaml configuration file (global settings).
+/// </summary>
+public string SettingsConfigPath => Path.Combine(_configPath, "settings.yaml");
+```
+
+**Step 5: Build and verify**
+
+Run:
+```bash
+cd /c/CodeProjects/Multi-SendSpin-Player-Container-feat-adjustable-buffer && dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj
+```
+Expected: Build succeeded
+
+**Step 6: Commit**
+
+```bash
+git add src/MultiRoomAudio/Services/EnvironmentService.cs
+git commit -m "feat: add BufferSeconds property to EnvironmentService
+
+Read from BUFFER_SECONDS env var or HAOS options, default 30s, clamped 5-30s.
+Mutable at runtime for settings API updates."
+```
+
+---
+
+### Task 2: Wire BufferSeconds into PlayerManagerService
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Services/PlayerManagerService.cs`
+
+**Step 1: Replace constant with readonly field**
+
+Find:
+```csharp
+private const int LocalBufferCapacityMs = 30_000;
+```
+
+Replace with:
+```csharp
+private readonly int _localBufferCapacityMs;
+```
+
+**Step 2: Initialize in constructor**
+
+In the constructor (which already receives `EnvironmentService environment`), add:
+
+```csharp
+_localBufferCapacityMs = environment.BufferSeconds * 1000;
+_logger.LogInformation("Audio buffer capacity: {BufferMs}ms ({BufferSeconds}s)",
+    _localBufferCapacityMs, environment.BufferSeconds);
+```
+
+**Step 3: Update usage**
+
+Find all references to `LocalBufferCapacityMs` and replace with `_localBufferCapacityMs`. There should be one usage in the buffer factory lambda where the timed buffer is created.
+
+**Step 4: Build and verify**
+
+Run:
+```bash
+cd /c/CodeProjects/Multi-SendSpin-Player-Container-feat-adjustable-buffer && dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj
+```
+Expected: Build succeeded
+
+**Step 5: Commit**
+
+```bash
+git add src/MultiRoomAudio/Services/PlayerManagerService.cs
+git commit -m "feat: use configurable buffer size from EnvironmentService
+
+Replace hardcoded 30_000ms constant with value from EnvironmentService.BufferSeconds."
+```
+
+---
+
+### Task 3: Settings Persistence in ConfigurationService
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Services/ConfigurationService.cs`
+- Modify: `src/MultiRoomAudio/Models/` (add GlobalSettings model inline or in existing file)
+
+**Step 1: Add GlobalSettings model**
+
+Add a simple model class. Check if there's an existing Models file that makes sense; otherwise add it at the top of ConfigurationService.cs or in a new minimal model file:
+
+```csharp
+public class GlobalSettings
+{
+    public int BufferSeconds { get; set; } = 30;
+}
+```
+
+**Step 2: Add settings load/save to ConfigurationService**
+
+Add a field:
+```csharp
+private GlobalSettings _globalSettings = new();
+```
+
+Add a public property:
+```csharp
+public GlobalSettings GlobalSettings => _globalSettings;
+```
+
+Add load method:
+```csharp
+public GlobalSettings LoadSettings(string settingsPath)
+{
+    if (!File.Exists(settingsPath))
+    {
+        _logger.LogDebug("No settings.yaml found at {Path}, using defaults", settingsPath);
+        _globalSettings = new GlobalSettings();
+        return _globalSettings;
+    }
+
+    try
+    {
+        var yaml = File.ReadAllText(settingsPath);
+        _globalSettings = _deserializer.Deserialize<GlobalSettings>(yaml) ?? new GlobalSettings();
+        _logger.LogInformation("Loaded global settings from {Path}: BufferSeconds={BufferSeconds}",
+            settingsPath, _globalSettings.BufferSeconds);
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, "Failed to load settings from {Path}, using defaults", settingsPath);
+        _globalSettings = new GlobalSettings();
+    }
+
+    return _globalSettings;
+}
+```
+
+Add save method:
+```csharp
+public void SaveSettings(string settingsPath, GlobalSettings settings)
+{
+    try
+    {
+        var yaml = _serializer.Serialize(settings);
+        var dir = Path.GetDirectoryName(settingsPath);
+        if (dir != null && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+        File.WriteAllText(settingsPath, yaml);
+        _globalSettings = settings;
+        _logger.LogInformation("Saved global settings to {Path}: BufferSeconds={BufferSeconds}",
+            settingsPath, settings.BufferSeconds);
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, "Failed to save settings to {Path}", settingsPath);
+        throw;
+    }
+}
+```
+
+**Step 3: Load settings on startup**
+
+In `Program.cs` or wherever `ConfigurationService` is initialized, after `EnsureDirectoriesExist()`, add:
+
+```csharp
+config.LoadSettings(environment.SettingsConfigPath);
+```
+
+Then apply the loaded value to EnvironmentService (so persisted config overrides env var):
+
+```csharp
+if (config.GlobalSettings.BufferSeconds != environment.BufferSeconds)
+{
+    environment.BufferSeconds = config.GlobalSettings.BufferSeconds;
+}
+```
+
+**Step 4: Build and verify**
+
+Run:
+```bash
+cd /c/CodeProjects/Multi-SendSpin-Player-Container-feat-adjustable-buffer && dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj
+```
+Expected: Build succeeded
+
+**Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add GlobalSettings model and settings.yaml persistence
+
+LoadSettings/SaveSettings on ConfigurationService, loaded on startup."
+```
+
+---
+
+### Task 4: Settings API Endpoint
+
+**Files:**
+- Create: `src/MultiRoomAudio/Controllers/SettingsEndpoint.cs`
+
+**Step 1: Create the endpoint file**
+
+```csharp
+using MultiRoomAudio.Services;
+
+namespace MultiRoomAudio.Controllers;
+
+public static class SettingsEndpoint
+{
+    public static void MapSettingsEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/settings");
+
+        group.MapGet("/buffer", (EnvironmentService env, PlayerManagerService players) =>
+        {
+            var bufferSeconds = env.BufferSeconds;
+            var playerCount = players.GetAllPlayers().Count();
+
+            return Results.Ok(new
+            {
+                bufferSeconds,
+                playerCount,
+                memoryEstimates = new[]
+                {
+                    new { sampleRate = 48000, label = "48 kHz", perPlayerMb = CalcMb(bufferSeconds, 48000), totalMb = CalcMb(bufferSeconds, 48000) * playerCount },
+                    new { sampleRate = 96000, label = "96 kHz", perPlayerMb = CalcMb(bufferSeconds, 96000), totalMb = CalcMb(bufferSeconds, 96000) * playerCount },
+                    new { sampleRate = 192000, label = "192 kHz", perPlayerMb = CalcMb(bufferSeconds, 192000), totalMb = CalcMb(bufferSeconds, 192000) * playerCount }
+                }
+            });
+        });
+
+        group.MapPut("/buffer", (BufferUpdateRequest request,
+            EnvironmentService env,
+            ConfigurationService config,
+            PlayerManagerService players) =>
+        {
+            if (request.BufferSeconds < 5 || request.BufferSeconds > 30 || request.BufferSeconds % 5 != 0)
+            {
+                return Results.BadRequest(new { success = false, message = "Buffer size must be 5, 10, 15, 20, 25, or 30 seconds." });
+            }
+
+            env.BufferSeconds = request.BufferSeconds;
+            config.SaveSettings(env.SettingsConfigPath, new GlobalSettings { BufferSeconds = request.BufferSeconds });
+
+            var playerCount = players.GetAllPlayers().Count();
+
+            return Results.Ok(new
+            {
+                success = true,
+                message = "Buffer size updated. Restart players to apply the new buffer size.",
+                bufferSeconds = env.BufferSeconds,
+                playerCount,
+                memoryEstimates = new[]
+                {
+                    new { sampleRate = 48000, label = "48 kHz", perPlayerMb = CalcMb(env.BufferSeconds, 48000), totalMb = CalcMb(env.BufferSeconds, 48000) * playerCount },
+                    new { sampleRate = 96000, label = "96 kHz", perPlayerMb = CalcMb(env.BufferSeconds, 96000), totalMb = CalcMb(env.BufferSeconds, 96000) * playerCount },
+                    new { sampleRate = 192000, label = "192 kHz", perPlayerMb = CalcMb(env.BufferSeconds, 192000), totalMb = CalcMb(env.BufferSeconds, 192000) * playerCount }
+                }
+            });
+        });
+    }
+
+    private static double CalcMb(int bufferSeconds, int sampleRate)
+    {
+        // buffer_seconds * sample_rate * 2 channels * 4 bytes (float32) / 1,048,576
+        return Math.Round((double)bufferSeconds * sampleRate * 2 * 4 / 1_048_576, 1);
+    }
+}
+
+public record BufferUpdateRequest(int BufferSeconds);
+```
+
+**Step 2: Register the endpoint in Program.cs**
+
+Find where other endpoints are mapped (e.g., `app.MapPlayersEndpoints()`) and add:
+
+```csharp
+app.MapSettingsEndpoints();
+```
+
+**Step 3: Build and verify**
+
+Run:
+```bash
+cd /c/CodeProjects/Multi-SendSpin-Player-Container-feat-adjustable-buffer && dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj
+```
+Expected: Build succeeded
+
+**Step 4: Commit**
+
+```bash
+git add src/MultiRoomAudio/Controllers/SettingsEndpoint.cs src/MultiRoomAudio/Program.cs
+git commit -m "feat: add GET/PUT /api/settings/buffer endpoint
+
+Returns buffer size, player count, and memory estimates per sample rate."
+```
+
+---
+
+### Task 5: Settings UI - Menu Item and Modal
+
+**Files:**
+- Modify: `src/MultiRoomAudio/wwwroot/index.html`
+- Modify: `src/MultiRoomAudio/wwwroot/js/app.js`
+
+**Step 1: Add "System" menu item to settings dropdown in index.html**
+
+Find the settings dropdown items (around lines 50-72). Before the `<div class="dropdown-divider">` that precedes the wizard link, add:
+
+```html
+<a class="dropdown-item" href="#" onclick="openSystemSettingsModal(); return false;">
+    <i class="bi bi-gear"></i> System
+</a>
+```
+
+**Step 2: Add systemSettingsModal to index.html**
+
+Add a new modal before the closing `</body>` tag (or alongside other modals):
+
+```html
+<!-- System Settings Modal -->
+<div class="modal fade" id="systemSettingsModal" tabindex="-1" aria-labelledby="systemSettingsModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="systemSettingsModalLabel">System Settings</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <h6>Audio Buffer Size</h6>
+                <div class="mb-3">
+                    <label for="bufferSlider" class="form-label">
+                        Buffer: <span id="bufferSliderValue">30</span> seconds
+                    </label>
+                    <input type="range" class="form-range" id="bufferSlider"
+                           min="5" max="30" step="5" value="30"
+                           oninput="updateBufferMemoryTable()">
+                </div>
+                <div class="small text-muted mb-2">
+                    Audio is buffered as decoded PCM float32 regardless of the codec used
+                    (FLAC, Opus, PCM). Memory usage depends on sample rate, not codec.
+                </div>
+                <table class="table table-sm table-bordered" id="bufferMemoryTable">
+                    <thead>
+                        <tr>
+                            <th>Sample Rate</th>
+                            <th>Per Player</th>
+                            <th id="bufferMemoryTotalHeader">Total (0 players)</th>
+                        </tr>
+                    </thead>
+                    <tbody id="bufferMemoryTableBody">
+                    </tbody>
+                </table>
+                <div id="bufferSaveMessage" class="small text-warning" style="display:none;"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" onclick="saveBufferSettings()">Save</button>
+            </div>
+        </div>
+    </div>
+</div>
+```
+
+**Step 3: Add JavaScript functions in app.js**
+
+Add to app.js:
+
+```javascript
+// ── System Settings ──────────────────────────────────────────────
+
+let _bufferPlayerCount = 0;
+
+async function openSystemSettingsModal() {
+    try {
+        const resp = await fetch('/api/settings/buffer');
+        if (!resp.ok) throw new Error('Failed to load buffer settings');
+        const data = await resp.json();
+
+        _bufferPlayerCount = data.playerCount;
+        document.getElementById('bufferSlider').value = data.bufferSeconds;
+        updateBufferMemoryTable();
+
+        const modal = new bootstrap.Modal(document.getElementById('systemSettingsModal'));
+        modal.show();
+    } catch (err) {
+        console.error('Failed to open system settings:', err);
+    }
+}
+
+function updateBufferMemoryTable() {
+    const slider = document.getElementById('bufferSlider');
+    const seconds = parseInt(slider.value, 10);
+    document.getElementById('bufferSliderValue').textContent = seconds;
+
+    const rates = [
+        { rate: 48000, label: '48 kHz' },
+        { rate: 96000, label: '96 kHz' },
+        { rate: 192000, label: '192 kHz' }
+    ];
+
+    const tbody = document.getElementById('bufferMemoryTableBody');
+    // Clear existing rows
+    while (tbody.firstChild) {
+        tbody.removeChild(tbody.firstChild);
+    }
+
+    for (const { rate, label } of rates) {
+        const perPlayer = (seconds * rate * 2 * 4 / 1048576).toFixed(1);
+        const total = (perPlayer * _bufferPlayerCount).toFixed(1);
+
+        const tr = document.createElement('tr');
+
+        const tdRate = document.createElement('td');
+        tdRate.textContent = label;
+        tr.appendChild(tdRate);
+
+        const tdPer = document.createElement('td');
+        tdPer.textContent = perPlayer + ' MB';
+        tr.appendChild(tdPer);
+
+        const tdTotal = document.createElement('td');
+        tdTotal.textContent = total + ' MB';
+        tr.appendChild(tdTotal);
+
+        tbody.appendChild(tr);
+    }
+
+    const header = document.getElementById('bufferMemoryTotalHeader');
+    header.textContent = 'Total (' + _bufferPlayerCount + ' player' + (_bufferPlayerCount !== 1 ? 's' : '') + ')';
+
+    // Hide save message when slider changes
+    document.getElementById('bufferSaveMessage').style.display = 'none';
+}
+
+async function saveBufferSettings() {
+    const seconds = parseInt(document.getElementById('bufferSlider').value, 10);
+    const msgEl = document.getElementById('bufferSaveMessage');
+
+    try {
+        const resp = await fetch('/api/settings/buffer', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ bufferSeconds: seconds })
+        });
+        const data = await resp.json();
+
+        if (resp.ok && data.success) {
+            msgEl.className = 'small text-success';
+            msgEl.textContent = data.message;
+        } else {
+            msgEl.className = 'small text-danger';
+            msgEl.textContent = data.message || 'Failed to save.';
+        }
+    } catch (err) {
+        msgEl.className = 'small text-danger';
+        msgEl.textContent = 'Error saving settings: ' + err.message;
+    }
+
+    msgEl.style.display = 'block';
+}
+```
+
+**Step 4: Build and verify**
+
+Run:
+```bash
+cd /c/CodeProjects/Multi-SendSpin-Player-Container-feat-adjustable-buffer && dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj
+```
+Expected: Build succeeded
+
+**Step 5: Manual test**
+
+Run the app with `MOCK_HARDWARE=true` and open http://localhost:8096. Verify:
+- "System" appears in the settings dropdown
+- Clicking it opens the modal with slider and memory table
+- Moving the slider updates the table values
+- Saving shows the restart message
+
+**Step 6: Commit**
+
+```bash
+git add src/MultiRoomAudio/wwwroot/index.html src/MultiRoomAudio/wwwroot/js/app.js
+git commit -m "feat: add System Settings modal with buffer size slider and memory table
+
+Slider range 5-30s (step 5). Memory table shows per-player and total
+estimates at 48/96/192 kHz sample rates."
+```
+
+---
+
+### Task 6: Update CLAUDE.md Environment Variables
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Step 1: Add BUFFER_SECONDS to environment variables table**
+
+Find the Environment Variables table and add a new row:
+
+```markdown
+| `BUFFER_SECONDS` | `30` | Audio buffer size in seconds (5-30, step 5). Lower values reduce RAM on constrained hardware. |
+```
+
+**Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add BUFFER_SECONDS to environment variables table"
+```

--- a/src/MultiRoomAudio/Controllers/SettingsEndpoint.cs
+++ b/src/MultiRoomAudio/Controllers/SettingsEndpoint.cs
@@ -1,0 +1,71 @@
+using MultiRoomAudio.Services;
+
+namespace MultiRoomAudio.Controllers;
+
+public static class SettingsEndpoint
+{
+    public static void MapSettingsEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/settings");
+
+        group.MapGet("/buffer", (EnvironmentService env, PlayerManagerService players) =>
+        {
+            var bufferSeconds = env.BufferSeconds;
+            var playerCount = players.GetAllPlayers().Players.Count;
+
+            return Results.Ok(new
+            {
+                bufferSeconds,
+                playerCount,
+                memoryEstimates = new[]
+                {
+                    new { sampleRate = 48000, label = "48 kHz", perPlayerMb = CalcMb(bufferSeconds, 48000), totalMb = CalcMb(bufferSeconds, 48000) * playerCount },
+                    new { sampleRate = 96000, label = "96 kHz", perPlayerMb = CalcMb(bufferSeconds, 96000), totalMb = CalcMb(bufferSeconds, 96000) * playerCount },
+                    new { sampleRate = 192000, label = "192 kHz", perPlayerMb = CalcMb(bufferSeconds, 192000), totalMb = CalcMb(bufferSeconds, 192000) * playerCount }
+                }
+            });
+        })
+        .WithTags("Settings")
+        .WithName("GetBufferSettings");
+
+        group.MapPut("/buffer", (BufferUpdateRequest request,
+            EnvironmentService env,
+            ConfigurationService config,
+            PlayerManagerService players) =>
+        {
+            if (request.BufferSeconds < 5 || request.BufferSeconds > 30 || request.BufferSeconds % 5 != 0)
+            {
+                return Results.BadRequest(new { success = false, message = "Buffer size must be 5, 10, 15, 20, 25, or 30 seconds." });
+            }
+
+            env.BufferSeconds = request.BufferSeconds;
+            config.SaveSettings(env.SettingsConfigPath, new GlobalSettings { BufferSeconds = request.BufferSeconds });
+
+            var playerCount = players.GetAllPlayers().Players.Count;
+
+            return Results.Ok(new
+            {
+                success = true,
+                message = "Buffer size updated. Restart players to apply the new buffer size.",
+                bufferSeconds = env.BufferSeconds,
+                playerCount,
+                memoryEstimates = new[]
+                {
+                    new { sampleRate = 48000, label = "48 kHz", perPlayerMb = CalcMb(env.BufferSeconds, 48000), totalMb = CalcMb(env.BufferSeconds, 48000) * playerCount },
+                    new { sampleRate = 96000, label = "96 kHz", perPlayerMb = CalcMb(env.BufferSeconds, 96000), totalMb = CalcMb(env.BufferSeconds, 96000) * playerCount },
+                    new { sampleRate = 192000, label = "192 kHz", perPlayerMb = CalcMb(env.BufferSeconds, 192000), totalMb = CalcMb(env.BufferSeconds, 192000) * playerCount }
+                }
+            });
+        })
+        .WithTags("Settings")
+        .WithName("UpdateBufferSettings");
+    }
+
+    private static double CalcMb(int bufferSeconds, int sampleRate)
+    {
+        // buffer_seconds * sample_rate * 2 channels * 4 bytes (float32) / 1,048,576
+        return Math.Round((double)bufferSeconds * sampleRate * 2 * 4 / 1_048_576, 1);
+    }
+}
+
+public record BufferUpdateRequest(int BufferSeconds);

--- a/src/MultiRoomAudio/MultiRoomAudio.csproj
+++ b/src/MultiRoomAudio/MultiRoomAudio.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <!-- Core SDK for Sendspin protocol -->
-    <PackageReference Include="SendSpin.SDK" Version="6.3.5" />
+    <PackageReference Include="SendSpin.SDK" Version="7.2.1" />
     <PackageReference Include="System.IO.Ports" Version="10.0.2" />
 
     <!-- USB HID support for HID relay boards -->

--- a/src/MultiRoomAudio/MultiRoomAudio.csproj
+++ b/src/MultiRoomAudio/MultiRoomAudio.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <!-- Core SDK for Sendspin protocol -->
-    <PackageReference Include="SendSpin.SDK" Version="7.2.1" />
+    <PackageReference Include="SendSpin.SDK" Version="7.3.0" />
     <PackageReference Include="System.IO.Ports" Version="10.0.2" />
 
     <!-- USB HID support for HID relay boards -->

--- a/src/MultiRoomAudio/MultiRoomAudio.csproj
+++ b/src/MultiRoomAudio/MultiRoomAudio.csproj
@@ -35,9 +35,6 @@
 
     <!-- Health checks -->
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
-
-    <!-- USB HID support for HID relay boards -->
-    <PackageReference Include="HidSharp" Version="2.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/MultiRoomAudio/Program.cs
+++ b/src/MultiRoomAudio/Program.cs
@@ -291,6 +291,7 @@ app.MapCardsEndpoints();
 app.MapLogsEndpoints();
 app.MapTriggersEndpoints();
 app.MapDiagnosticsEndpoints();
+app.MapSettingsEndpoints();
 
 // Startup progress endpoint (for web UI to show initialization status)
 app.MapGet("/api/startup", (StartupProgressService startup) => Results.Ok(startup.GetProgress()))

--- a/src/MultiRoomAudio/Program.cs
+++ b/src/MultiRoomAudio/Program.cs
@@ -324,6 +324,14 @@ app.MapGet("/api", () => Results.Ok(new
 var logger = app.Services.GetRequiredService<ILogger<Program>>();
 var environmentService = app.Services.GetRequiredService<EnvironmentService>();
 
+// Load global settings and apply to environment
+var configService = app.Services.GetRequiredService<ConfigurationService>();
+var loadedSettings = configService.LoadSettings(environmentService.SettingsConfigPath);
+if (loadedSettings.BufferSeconds != environmentService.BufferSeconds)
+{
+    environmentService.BufferSeconds = loadedSettings.BufferSeconds;
+}
+
 // Set up custom logging provider for web-visible logs
 var loggingService = app.Services.GetRequiredService<LoggingService>();
 var loggerFactory = app.Services.GetRequiredService<ILoggerFactory>();

--- a/src/MultiRoomAudio/Services/ConfigurationService.cs
+++ b/src/MultiRoomAudio/Services/ConfigurationService.cs
@@ -143,6 +143,14 @@ public class PlayerConfiguration
 }
 
 /// <summary>
+/// Global application settings persisted in settings.yaml.
+/// </summary>
+public class GlobalSettings
+{
+    public int BufferSeconds { get; set; } = 30;
+}
+
+/// <summary>
 /// Manages player configuration persistence with YAML storage.
 /// Provides a clean interface for configuration operations.
 /// </summary>
@@ -158,6 +166,7 @@ public class ConfigurationService
 
     private Dictionary<string, PlayerConfiguration> _players = new();
     private Dictionary<string, DeviceConfiguration> _devices = new();
+    private GlobalSettings _globalSettings = new();
 
     public ConfigurationService(
         ILogger<ConfigurationService> logger,
@@ -195,6 +204,11 @@ public class ConfigurationService
     /// All configured devices (with aliases and stable identifiers).
     /// </summary>
     public IReadOnlyDictionary<string, DeviceConfiguration> Devices => _devices;
+
+    /// <summary>
+    /// Global application settings.
+    /// </summary>
+    public GlobalSettings GlobalSettings => _globalSettings;
 
     /// <summary>
     /// Check if any players are configured.
@@ -651,6 +665,62 @@ public class ConfigurationService
         if (needsSave)
         {
             SaveDevices();
+        }
+    }
+
+    /// <summary>
+    /// Load global settings from YAML file.
+    /// </summary>
+    public GlobalSettings LoadSettings(string settingsPath)
+    {
+        if (!File.Exists(settingsPath))
+        {
+            _logger.LogDebug("No settings.yaml found at {Path}, using defaults", settingsPath);
+            _globalSettings = new GlobalSettings();
+            return _globalSettings;
+        }
+
+        try
+        {
+            var yaml = File.ReadAllText(settingsPath);
+            if (string.IsNullOrWhiteSpace(yaml))
+            {
+                _globalSettings = new GlobalSettings();
+                return _globalSettings;
+            }
+            _globalSettings = _deserializer.Deserialize<GlobalSettings>(yaml) ?? new GlobalSettings();
+            _logger.LogInformation("Loaded global settings from {Path}: BufferSeconds={BufferSeconds}",
+                settingsPath, _globalSettings.BufferSeconds);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load settings from {Path}, using defaults", settingsPath);
+            _globalSettings = new GlobalSettings();
+        }
+
+        return _globalSettings;
+    }
+
+    /// <summary>
+    /// Save global settings to YAML file.
+    /// </summary>
+    public void SaveSettings(string settingsPath, GlobalSettings settings)
+    {
+        try
+        {
+            var yaml = _serializer.Serialize(settings);
+            var dir = Path.GetDirectoryName(settingsPath);
+            if (dir != null && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+            File.WriteAllText(settingsPath, yaml);
+            _globalSettings = settings;
+            _logger.LogInformation("Saved global settings to {Path}: BufferSeconds={BufferSeconds}",
+                settingsPath, settings.BufferSeconds);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save settings to {Path}", settingsPath);
+            throw;
         }
     }
 

--- a/src/MultiRoomAudio/Services/EnvironmentService.cs
+++ b/src/MultiRoomAudio/Services/EnvironmentService.cs
@@ -20,6 +20,7 @@ public class EnvironmentService
     private readonly string _configPath;
     private readonly string _logPath;
     private readonly Dictionary<string, JsonElement>? _haosOptions;
+    private int _bufferSeconds;
 
     public const string EnvStandalone = "standalone";
     public const string EnvHaos = "haos";
@@ -28,6 +29,10 @@ public class EnvironmentService
     private const string HaosSupervisorTokenEnv = "SUPERVISOR_TOKEN";
     private const string MockHardwareEnv = "MOCK_HARDWARE";
     private const string AdvancedFormatsEnv = "ENABLE_ADVANCED_FORMATS";
+    private const string BufferSecondsEnv = "BUFFER_SECONDS";
+    private const int DefaultBufferSeconds = 30;
+    private const int MinBufferSeconds = 5;
+    private const int MaxBufferSeconds = 30;
 
     public EnvironmentService(ILogger<EnvironmentService> logger)
     {
@@ -99,6 +104,10 @@ public class EnvironmentService
         {
             _logger.LogInformation("ENABLE_ADVANCED_FORMATS mode enabled - per-player format selection available");
         }
+
+        // Detect buffer seconds setting
+        _bufferSeconds = DetectBufferSeconds();
+        _logger.LogInformation("Audio buffer size: {BufferSeconds} seconds", _bufferSeconds);
     }
 
     /// <summary>
@@ -117,6 +126,16 @@ public class EnvironmentService
     /// When true, the application exposes per-player format selection UI and API endpoints.
     /// </summary>
     public bool EnableAdvancedFormats => _enableAdvancedFormats;
+
+    /// <summary>
+    /// Audio buffer size in seconds (5-30, step 5). Applies to all players.
+    /// Changing this requires a player restart.
+    /// </summary>
+    public int BufferSeconds
+    {
+        get => _bufferSeconds;
+        set => _bufferSeconds = Math.Clamp(value, MinBufferSeconds, MaxBufferSeconds);
+    }
 
     /// <summary>
     /// Current environment name ("haos" or "standalone").
@@ -148,6 +167,11 @@ public class EnvironmentService
     /// Only used when IsMockHardware is true.
     /// </summary>
     public string MockHardwareConfigPath => Path.Combine(_configPath, "mock_hardware.yaml");
+
+    /// <summary>
+    /// Full path to settings.yaml configuration file (global settings).
+    /// </summary>
+    public string SettingsConfigPath => Path.Combine(_configPath, "settings.yaml");
 
     /// <summary>
     /// Path to log directory.
@@ -419,5 +443,52 @@ public class EnvironmentService
 
         // Default: disabled
         return false;
+    }
+
+    private int DetectBufferSeconds()
+    {
+        // Check environment variable first
+        var bufferSecondsValue = Environment.GetEnvironmentVariable(BufferSecondsEnv);
+        if (!string.IsNullOrEmpty(bufferSecondsValue))
+        {
+            if (int.TryParse(bufferSecondsValue, out var parsed))
+            {
+                var clamped = Math.Clamp(parsed, MinBufferSeconds, MaxBufferSeconds);
+                _logger.LogDebug("{EnvVar} detected: {Value} (clamped to {Clamped})",
+                    BufferSecondsEnv, bufferSecondsValue, clamped);
+                return clamped;
+            }
+            else
+            {
+                _logger.LogWarning("{EnvVar} value '{Value}' is not a valid integer, using default {Default}",
+                    BufferSecondsEnv, bufferSecondsValue, DefaultBufferSeconds);
+            }
+        }
+        else
+        {
+            _logger.LogDebug("{EnvVar} environment variable not set", BufferSecondsEnv);
+        }
+
+        // Check HAOS options
+        if (_isHaos && _haosOptions != null)
+        {
+            if (_haosOptions.TryGetValue("buffer_seconds", out var element))
+            {
+                try
+                {
+                    var haosValue = element.GetInt32();
+                    var clamped = Math.Clamp(haosValue, MinBufferSeconds, MaxBufferSeconds);
+                    _logger.LogDebug("Buffer seconds from HAOS options: {Value} (clamped to {Clamped})",
+                        haosValue, clamped);
+                    return clamped;
+                }
+                catch (InvalidOperationException)
+                {
+                    _logger.LogWarning("HAOS option 'buffer_seconds' is not an integer value");
+                }
+            }
+        }
+
+        return DefaultBufferSeconds;
     }
 }

--- a/src/MultiRoomAudio/Services/PlayerManagerService.cs
+++ b/src/MultiRoomAudio/Services/PlayerManagerService.cs
@@ -1401,7 +1401,7 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
                     // Command MA to update its displayed volume
                     await context.Client.SetVolumeAsync(volume);
                     // SDK 5.4.0 auto-acknowledges, but we still echo state for full sync
-                    await context.Client.SendPlayerStateAsync(volume, context.Player.IsMuted);
+                    await context.Client.SendPlayerStateAsync(volume, context.Player.IsMuted, context.ClockSync.StaticDelayMs);
                     _logger.LogInformation("VOLUME [Sync] Player '{Name}': sent {Volume}% to MA",
                         name, volume);
                 }
@@ -1457,7 +1457,7 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
             {
                 // Prevent feedback loop with PlayerStateChanged handler
                 context.IsUpdatingFromServer = true;
-                await context.Client.SendPlayerStateAsync(context.Config.Volume, muted);
+                await context.Client.SendPlayerStateAsync(context.Config.Volume, muted, context.ClockSync.StaticDelayMs);
                 context.LastConfirmedMuted = muted;
                 _logger.LogInformation("MUTE [StateEcho] Player '{Name}': synced {State} to server",
                     name, muted ? "muted" : "unmuted");
@@ -1506,7 +1506,7 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
                 {
                     context.IsUpdatingFromServer = true;
                     await context.Client.SetVolumeAsync(volume);
-                    await context.Client.SendPlayerStateAsync(volume, context.Player.IsMuted);
+                    await context.Client.SendPlayerStateAsync(volume, context.Player.IsMuted, context.ClockSync.StaticDelayMs);
                     _logger.LogInformation("VOLUME [Hardware->MA] Player '{Name}': synced {Volume}% to MA",
                         name, volume);
                 }
@@ -1555,7 +1555,7 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
             try
             {
                 context.IsUpdatingFromServer = true;
-                await context.Client.SendPlayerStateAsync(context.Config.Volume, muted);
+                await context.Client.SendPlayerStateAsync(context.Config.Volume, muted, context.ClockSync.StaticDelayMs);
                 context.LastConfirmedMuted = muted;
                 _logger.LogInformation("MUTE [Hardware->MA] Player '{Name}': synced {State} to server",
                     name, muted ? "muted" : "unmuted");

--- a/src/MultiRoomAudio/Services/PlayerManagerService.cs
+++ b/src/MultiRoomAudio/Services/PlayerManagerService.cs
@@ -402,6 +402,8 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
         public EventHandler<GroupState>? GroupStateHandler { get; set; }
         // SDK 5.4.0: Handler for individual player volume/mute commands
         public EventHandler<SdkPlayerState>? PlayerStateHandler { get; set; }
+        // SDK 7.2.1: Handler for server-pushed sync offset calibration
+        public EventHandler<SyncOffsetEventArgs>? SyncOffsetHandler { get; set; }
         // Flag to prevent feedback loops when updating server
         public bool IsUpdatingFromServer { get; set; }
     }
@@ -2129,6 +2131,8 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
         context.GroupStateHandler = CreateGroupStateHandler(name, context);
         // SDK 5.4.0: PlayerStateChanged for individual player volume/mute commands
         context.PlayerStateHandler = CreatePlayerStateHandler(name, context);
+        // SDK 7.2.1: SyncOffsetApplied for server-pushed static delay calibration
+        context.SyncOffsetHandler = CreateSyncOffsetHandler(name, context);
 
         // Subscribe to events
         context.Client.ConnectionStateChanged += context.ConnectionStateHandler;
@@ -2138,6 +2142,8 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
         context.Client.GroupStateChanged += context.GroupStateHandler;
         // SDK 5.4.0: Subscribe to PlayerStateChanged
         context.Client.PlayerStateChanged += context.PlayerStateHandler;
+        // SDK 7.2.1: Subscribe to SyncOffsetApplied
+        context.Client.SyncOffsetApplied += context.SyncOffsetHandler;
     }
 
     /// <summary>
@@ -2988,13 +2994,45 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
     }
 
     /// <summary>
+    /// Creates handler for server-pushed sync offset calibration (GroupSync).
+    /// The SDK already applies the offset to ClockSync.StaticDelayMs internally;
+    /// we just persist it and broadcast to UI.
+    /// </summary>
+    /// <remarks>
+    /// SDK 7.2.1 change: SyncOffsetApplied fires when server sends sync offset calibration.
+    /// </remarks>
+    private EventHandler<SyncOffsetEventArgs> CreateSyncOffsetHandler(
+        string name, PlayerContext context)
+    {
+        return (_, args) =>
+        {
+            _logger.LogInformation(
+                "SYNC_OFFSET Player '{Name}': server set static delay to {Offset:+0.0;-0.0}ms (source: {Source})",
+                name, args.OffsetMs, args.Source);
+
+            // Persist the offset so it survives restarts
+            _config.UpdatePlayerField(name, cfg => cfg.DelayMs = (int)Math.Round(args.OffsetMs), save: true);
+
+            // Broadcast to UI so delay offset display updates
+            _ = BroadcastStatusAsync();
+        };
+    }
+
+    /// <summary>
     /// Unsubscribes all event handlers from a player context.
     /// Must be called before disposal to prevent memory leaks and access to disposed objects.
     /// </summary>
     private void UnwireEvents(PlayerContext context)
     {
         // Unsubscribe in reverse order of subscription
-        // SDK 5.4.0: Unsubscribe PlayerStateChanged first (subscribed last)
+        // SDK 7.2.1: Unsubscribe SyncOffsetApplied first (subscribed last)
+        if (context.SyncOffsetHandler != null)
+        {
+            context.Client.SyncOffsetApplied -= context.SyncOffsetHandler;
+            context.SyncOffsetHandler = null;
+        }
+
+        // SDK 5.4.0: Unsubscribe PlayerStateChanged
         if (context.PlayerStateHandler != null)
         {
             context.Client.PlayerStateChanged -= context.PlayerStateHandler;

--- a/src/MultiRoomAudio/Services/PlayerManagerService.cs
+++ b/src/MultiRoomAudio/Services/PlayerManagerService.cs
@@ -404,6 +404,8 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
         public EventHandler<SdkPlayerState>? PlayerStateHandler { get; set; }
         // SDK 7.2.1: Handler for server-pushed sync offset calibration
         public EventHandler<SyncOffsetEventArgs>? SyncOffsetHandler { get; set; }
+        // SDK 7.2.1: Handler for server-cleared artwork
+        public EventHandler? ArtworkClearedHandler { get; set; }
         // Flag to prevent feedback loops when updating server
         public bool IsUpdatingFromServer { get; set; }
     }
@@ -2133,6 +2135,8 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
         context.PlayerStateHandler = CreatePlayerStateHandler(name, context);
         // SDK 7.2.1: SyncOffsetApplied for server-pushed static delay calibration
         context.SyncOffsetHandler = CreateSyncOffsetHandler(name, context);
+        // SDK 7.2.1: ArtworkCleared for clearing stale album art
+        context.ArtworkClearedHandler = CreateArtworkClearedHandler(name, context);
 
         // Subscribe to events
         context.Client.ConnectionStateChanged += context.ConnectionStateHandler;
@@ -2144,6 +2148,8 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
         context.Client.PlayerStateChanged += context.PlayerStateHandler;
         // SDK 7.2.1: Subscribe to SyncOffsetApplied
         context.Client.SyncOffsetApplied += context.SyncOffsetHandler;
+        // SDK 7.2.1: Subscribe to ArtworkCleared
+        context.Client.ArtworkCleared += context.ArtworkClearedHandler;
     }
 
     /// <summary>
@@ -3019,13 +3025,42 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
     }
 
     /// <summary>
+    /// Creates handler for server-cleared artwork.
+    /// The SDK already sets artwork URL to null internally;
+    /// we just broadcast to UI so stale album art is cleared.
+    /// </summary>
+    /// <remarks>
+    /// SDK 7.2.1 change: ArtworkCleared fires when server sends empty artwork.
+    /// </remarks>
+    private EventHandler CreateArtworkClearedHandler(
+        string name, PlayerContext context)
+    {
+        return (_, _) =>
+        {
+            _logger.LogDebug(
+                "Player '{Name}': artwork cleared by server",
+                name);
+
+            // Broadcast to UI so album art display clears
+            _ = BroadcastStatusAsync();
+        };
+    }
+
+    /// <summary>
     /// Unsubscribes all event handlers from a player context.
     /// Must be called before disposal to prevent memory leaks and access to disposed objects.
     /// </summary>
     private void UnwireEvents(PlayerContext context)
     {
         // Unsubscribe in reverse order of subscription
-        // SDK 7.2.1: Unsubscribe SyncOffsetApplied first (subscribed last)
+        // SDK 7.2.1: Unsubscribe ArtworkCleared first (subscribed last)
+        if (context.ArtworkClearedHandler != null)
+        {
+            context.Client.ArtworkCleared -= context.ArtworkClearedHandler;
+            context.ArtworkClearedHandler = null;
+        }
+
+        // SDK 7.2.1: Unsubscribe SyncOffsetApplied
         if (context.SyncOffsetHandler != null)
         {
             context.Client.SyncOffsetApplied -= context.SyncOffsetHandler;

--- a/src/MultiRoomAudio/Services/PlayerManagerService.cs
+++ b/src/MultiRoomAudio/Services/PlayerManagerService.cs
@@ -138,14 +138,14 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
     /// Local circular buffer capacity for decompressed PCM audio (in milliseconds).
     ///
     /// This is the TimedAudioBuffer size - how much decoded audio we can hold locally.
-    /// Aligned with SDK v7.2.0 default of 30 seconds. Provides ~30s of uninterrupted
-    /// playback during network hiccups and lightweight reconnects. At 48kHz stereo
-    /// float32 this is approximately 11MB per player.
+    /// Initialized from EnvironmentService.BufferSeconds (default 30 seconds). Provides
+    /// uninterrupted playback during network hiccups and lightweight reconnects. At 48kHz
+    /// stereo float32, 30s is approximately 11MB per player.
     ///
     /// Note: This is DIFFERENT from ServerAnnouncedBufferCapacityBytes which controls
     /// how far ahead the server sends compressed audio.
     /// </summary>
-    private const int LocalBufferCapacityMs = 30_000;
+    private readonly int _localBufferCapacityMs;
 
     /// <summary>
     /// Target buffer level for playback readiness (in milliseconds).
@@ -154,7 +154,7 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
     /// Lower values = faster playback start but more sensitive to jitter.
     ///
     /// This is NOT a buffer capacity - it's a threshold for when to START playing.
-    /// The actual buffer can hold much more (see LocalBufferCapacityMs).
+    /// The actual buffer can hold much more (see _localBufferCapacityMs).
     ///
     /// With SDK's HasMinimalSync (2 clock measurements), typical startup is 300-500ms.
     /// </summary>
@@ -467,6 +467,9 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
         _serviceProvider = serviceProvider;
         _versionService = versionService;
         _subscriptionService = subscriptionService;
+        _localBufferCapacityMs = environment.BufferSeconds * 1000;
+        _logger.LogInformation("Audio buffer capacity: {BufferMs}ms ({BufferSeconds}s)",
+            _localBufferCapacityMs, environment.BufferSeconds);
         _serverDiscovery = new MdnsServerDiscovery(
             loggerFactory.CreateLogger<MdnsServerDiscovery>());
 
@@ -966,7 +969,7 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
                 var buffer = new TimedAudioBuffer(
                     format,
                     sync,
-                    bufferCapacityMs: LocalBufferCapacityMs,
+                    bufferCapacityMs: _localBufferCapacityMs,
                     syncOptions: PulseAudioSyncOptions);
                 buffer.TargetBufferMilliseconds = PlaybackStartThresholdMs;
                 return buffer;

--- a/src/MultiRoomAudio/Services/PlayerManagerService.cs
+++ b/src/MultiRoomAudio/Services/PlayerManagerService.cs
@@ -138,12 +138,14 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
     /// Local circular buffer capacity for decompressed PCM audio (in milliseconds).
     ///
     /// This is the TimedAudioBuffer size - how much decoded audio we can hold locally.
-    /// Must be large enough to handle network jitter and decode timing variations.
+    /// Aligned with SDK v7.2.0 default of 30 seconds. Provides ~30s of uninterrupted
+    /// playback during network hiccups and lightweight reconnects. At 48kHz stereo
+    /// float32 this is approximately 11MB per player.
     ///
     /// Note: This is DIFFERENT from ServerAnnouncedBufferCapacityBytes which controls
     /// how far ahead the server sends compressed audio.
     /// </summary>
-    private const int LocalBufferCapacityMs = 8000;
+    private const int LocalBufferCapacityMs = 30_000;
 
     /// <summary>
     /// Target buffer level for playback readiness (in milliseconds).

--- a/src/MultiRoomAudio/Services/PlayerManagerService.cs
+++ b/src/MultiRoomAudio/Services/PlayerManagerService.cs
@@ -231,6 +231,13 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
     private const int MaxReconnectAttempts = 0; // Unlimited - keep trying forever
 
     /// <summary>
+    /// Maximum time to attempt lightweight reconnect before falling back to full teardown.
+    /// During lightweight reconnect, the pipeline/buffer/player stay alive so audio
+    /// continues playing from the 30s buffer while the WebSocket reconnects.
+    /// </summary>
+    private static readonly TimeSpan LightweightReconnectTimeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>
     /// Grace period after connection during which volume updates from MA are ignored.
     /// This allows the startup volume to "win" the initial sync battle with Music Assistant.
     /// </summary>
@@ -385,6 +392,7 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
         public AudioDevice? CachedDevice { get; set; }
         public string? ErrorMessage { get; set; }
         public DateTime? ConnectedAt { get; set; }
+        public DateTime? DisconnectedAt { get; set; }  // For lightweight reconnect window tracking
         public int InitialVolume { get; init; } // Store initial volume to detect resets
         public long SamplesPlayed { get; set; }
         public bool? LastConfirmedMuted { get; set; } // Track last mute state echoed to server

--- a/src/MultiRoomAudio/Services/PlayerManagerService.cs
+++ b/src/MultiRoomAudio/Services/PlayerManagerService.cs
@@ -2189,20 +2189,19 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
             if (args.NewState == ConnectionState.Connected)
             {
                 context.ConnectedAt = DateTime.UtcNow;
+                context.DisconnectedAt = null;  // Clear lightweight reconnect state
                 _logger.LogInformation("VOLUME [GracePeriod] Player '{Name}': grace period started for {Duration}s",
                     name, VolumeGracePeriod.TotalSeconds);
                 _ = PushVolumeToServerAsync(name, context);
             }
 
-            // Handle disconnection - queue for reconnection if appropriate
+            // Handle disconnection - attempt lightweight reconnect first, fall back to full teardown
             if (args.NewState == ConnectionState.Disconnected &&
                 previousState != Models.PlayerState.Stopped &&  // Not user-stopped
                 previousState != Models.PlayerState.Error &&    // Not already errored
                 !_pendingReconnections.ContainsKey(name) &&     // Not already pending server reconnection
                 !_devicePendingPlayers.ContainsKey(name))       // Not waiting for device reconnection
             {
-                _logger.LogWarning("Player '{Name}' disconnected unexpectedly, queuing for reconnection", name);
-
                 // Get the persisted configuration for reconnection
                 var persistedConfig = _config.Players.TryGetValue(name, out var cfg) ? cfg : null;
                 if (persistedConfig == null)
@@ -2211,16 +2210,28 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
                     return;
                 }
 
-                // Fire and forget the reconnection setup (can't await in event handler)
-                FireAndForget(async () =>
+                // First disconnect in this window? Start lightweight reconnect
+                if (context.DisconnectedAt == null)
                 {
-                    // Small delay to let disposal complete
-                    await Task.Delay(100);
+                    context.DisconnectedAt = DateTime.UtcNow;
+                    context.State = Models.PlayerState.Reconnecting;
+                    context.ErrorMessage = "Reconnecting...";
 
-                    // Remove the disconnected player and queue for reconnection
-                    await RemoveAndDisposePlayerAsync(name);
-                    QueueForReconnection(persistedConfig);
-                }, $"Reconnection setup for '{name}'", _logger);
+                    _logger.LogInformation(
+                        "Player '{Name}' disconnected, attempting lightweight reconnect (60s window, audio continues from buffer)",
+                        name);
+
+                    FireAndForget(async () =>
+                    {
+                        await AttemptLightweightReconnectAsync(name, context, persistedConfig);
+                    }, $"Lightweight reconnect for '{name}'", _logger);
+                }
+                else
+                {
+                    // This fires if the lightweight reconnect itself disconnected again
+                    // (e.g., handshake timeout). AttemptLightweightReconnectAsync's retry loop handles this.
+                    _logger.LogDebug("Player '{Name}' disconnected during lightweight reconnect window, retry loop will handle", name);
+                }
             }
 
             // Broadcast status update on connection state change
@@ -3397,6 +3408,124 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
     }
 
     #region Reconnection Methods
+
+    /// <summary>
+    /// Attempts lightweight reconnect by reusing existing SDK components.
+    /// Audio continues playing from the 30s buffer while the WebSocket reconnects.
+    /// Falls back to full teardown if the 60s window expires.
+    /// </summary>
+    private async Task AttemptLightweightReconnectAsync(
+        string name, PlayerContext context, PlayerConfiguration config)
+    {
+        var attempt = 0;
+
+        while (context.DisconnectedAt != null &&
+               DateTime.UtcNow - context.DisconnectedAt.Value <= LightweightReconnectTimeout &&
+               !context.Cts.Token.IsCancellationRequested)
+        {
+            attempt++;
+
+            try
+            {
+                // Resolve server URI
+                Uri? serverUri = null;
+                if (!string.IsNullOrEmpty(config.Server))
+                {
+                    serverUri = new Uri(config.Server);
+                }
+                else
+                {
+                    try
+                    {
+                        serverUri = await GetOrDiscoverServerAsync(context.Cts.Token);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogDebug(ex, "Player '{Name}': mDNS discovery failed during lightweight reconnect", name);
+                    }
+                }
+
+                if (serverUri == null)
+                {
+                    _logger.LogDebug("Player '{Name}': no server URI found, will retry", name);
+                }
+                else
+                {
+                    _logger.LogInformation(
+                        "Player '{Name}': lightweight reconnect attempt {Attempt} to {Uri}",
+                        name, attempt, serverUri);
+
+                    // Reuse existing client — ConnectAsync creates new WebSocket, re-handshakes,
+                    // SDK resets clock sync and calls Pipeline.NotifyReconnect() automatically
+                    await context.Client.ConnectAsync(serverUri, context.Cts.Token);
+
+                    // Success — clear disconnect timestamp
+                    context.DisconnectedAt = null;
+                    context.ConnectedAt = DateTime.UtcNow;
+                    context.ConnectedAddress = $"{serverUri.Host}:{serverUri.Port}";
+                    context.ServerName = context.Client.ServerName;
+                    context.ErrorMessage = null;
+
+                    _logger.LogInformation(
+                        "Player '{Name}': lightweight reconnect succeeded after {Attempt} attempt(s), pipeline preserved",
+                        name, attempt);
+
+                    _ = BroadcastStatusAsync();
+                    return;
+                }
+            }
+            catch (OperationCanceledException) when (context.Cts.Token.IsCancellationRequested)
+            {
+                _logger.LogDebug("Player '{Name}': lightweight reconnect cancelled", name);
+                return;
+            }
+            catch (Exception ex)
+            {
+                var elapsed = DateTime.UtcNow - context.DisconnectedAt!.Value;
+                var remaining = LightweightReconnectTimeout - elapsed;
+
+                _logger.LogWarning(
+                    "Player '{Name}': lightweight reconnect attempt {Attempt} failed ({Remaining:F0}s remaining): {Message}",
+                    name, attempt, remaining.TotalSeconds, ex.Message);
+
+                if (remaining <= TimeSpan.Zero)
+                    break;
+            }
+
+            // Exponential backoff: 1s, 2s, 4s, 8s... capped at 15s
+            var delay = TimeSpan.FromSeconds(Math.Min(Math.Pow(2, attempt - 1), 15));
+            var timeRemaining = LightweightReconnectTimeout - (DateTime.UtcNow - context.DisconnectedAt!.Value);
+            if (delay > timeRemaining)
+                delay = timeRemaining > TimeSpan.Zero ? timeRemaining : TimeSpan.Zero;
+
+            if (delay > TimeSpan.Zero)
+            {
+                try
+                {
+                    await Task.Delay(delay, context.Cts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+            }
+        }
+
+        // Lightweight window expired — fall back to full teardown
+        if (context.DisconnectedAt != null)
+        {
+            _logger.LogWarning(
+                "Player '{Name}': lightweight reconnect window expired after {Attempt} attempts, falling back to full teardown",
+                name, attempt);
+
+            context.DisconnectedAt = null;
+
+            // Small delay to let any pending operations complete
+            await Task.Delay(100);
+            await RemoveAndDisposePlayerAsync(name);
+            QueueForReconnection(config);
+        }
+    }
 
     /// <summary>
     /// Queues a player for automatic reconnection.

--- a/src/MultiRoomAudio/wwwroot/index.html
+++ b/src/MultiRoomAudio/wwwroot/index.html
@@ -61,6 +61,9 @@
                             <li><a class="dropdown-item" href="#" onclick="openTriggersModal(); return false;">
                                 <i class="fas fa-bolt me-2"></i>12V Triggers
                             </a></li>
+                            <li><a class="dropdown-item" href="#" onclick="openSystemSettingsModal(); return false;">
+                                <i class="fas fa-sliders-h me-2"></i>System
+                            </a></li>
                             <li><hr class="dropdown-divider"></li>
                             <li><a class="dropdown-item" href="#" onclick="runSetupWizard(); return false;">
                                 <i class="fas fa-magic me-2"></i>Run Setup Wizard
@@ -769,6 +772,49 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                     <button type="button" class="btn btn-primary" id="editBoardSaveBtn">Save</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- System Settings Modal -->
+    <div class="modal fade" id="systemSettingsModal" tabindex="-1" aria-labelledby="systemSettingsModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="systemSettingsModalLabel">System Settings</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <h6>Audio Buffer Size</h6>
+                    <div class="mb-3">
+                        <label for="bufferSlider" class="form-label">
+                            Buffer: <span id="bufferSliderValue">30</span> seconds
+                        </label>
+                        <input type="range" class="form-range" id="bufferSlider"
+                               min="5" max="30" step="5" value="30"
+                               oninput="updateBufferMemoryTable()">
+                    </div>
+                    <div class="small text-muted mb-2">
+                        Audio is buffered as decoded PCM float32 regardless of the codec used
+                        (FLAC, Opus, PCM). Memory usage depends on sample rate, not codec.
+                    </div>
+                    <table class="table table-sm table-bordered" id="bufferMemoryTable">
+                        <thead>
+                            <tr>
+                                <th>Sample Rate</th>
+                                <th>Per Player</th>
+                                <th id="bufferMemoryTotalHeader">Total (0 players)</th>
+                            </tr>
+                        </thead>
+                        <tbody id="bufferMemoryTableBody">
+                        </tbody>
+                    </table>
+                    <div id="bufferSaveMessage" class="small" style="display:none;"></div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" onclick="saveBufferSettings()">Save</button>
                 </div>
             </div>
         </div>

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -5649,7 +5649,7 @@ let _bufferPlayerCount = 0;
 
 async function openSystemSettingsModal() {
     try {
-        const resp = await fetch('/api/settings/buffer');
+        const resp = await fetch('./api/settings/buffer');
         if (!resp.ok) throw new Error('Failed to load buffer settings');
         const data = await resp.json();
 
@@ -5712,7 +5712,7 @@ async function saveBufferSettings() {
     const msgEl = document.getElementById('bufferSaveMessage');
 
     try {
-        const resp = await fetch('/api/settings/buffer', {
+        const resp = await fetch('./api/settings/buffer', {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ bufferSeconds: seconds })

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -5642,3 +5642,94 @@ async function reconnectTriggerBoard() {
         showAlert(`Failed to reconnect: ${error.message}`, 'danger');
     }
 }
+
+// ── System Settings ──────────────────────────────────────────────
+
+let _bufferPlayerCount = 0;
+
+async function openSystemSettingsModal() {
+    try {
+        const resp = await fetch('/api/settings/buffer');
+        if (!resp.ok) throw new Error('Failed to load buffer settings');
+        const data = await resp.json();
+
+        _bufferPlayerCount = data.playerCount;
+        document.getElementById('bufferSlider').value = data.bufferSeconds;
+        updateBufferMemoryTable();
+
+        const modal = new bootstrap.Modal(document.getElementById('systemSettingsModal'));
+        modal.show();
+    } catch (err) {
+        console.error('Failed to open system settings:', err);
+    }
+}
+
+function updateBufferMemoryTable() {
+    const slider = document.getElementById('bufferSlider');
+    const seconds = parseInt(slider.value, 10);
+    document.getElementById('bufferSliderValue').textContent = seconds;
+
+    const rates = [
+        { rate: 48000, label: '48 kHz' },
+        { rate: 96000, label: '96 kHz' },
+        { rate: 192000, label: '192 kHz' }
+    ];
+
+    const tbody = document.getElementById('bufferMemoryTableBody');
+    while (tbody.firstChild) {
+        tbody.removeChild(tbody.firstChild);
+    }
+
+    for (const { rate, label } of rates) {
+        const perPlayer = (seconds * rate * 2 * 4 / 1048576).toFixed(1);
+        const total = (perPlayer * _bufferPlayerCount).toFixed(1);
+
+        const tr = document.createElement('tr');
+
+        const tdRate = document.createElement('td');
+        tdRate.textContent = label;
+        tr.appendChild(tdRate);
+
+        const tdPer = document.createElement('td');
+        tdPer.textContent = perPlayer + ' MB';
+        tr.appendChild(tdPer);
+
+        const tdTotal = document.createElement('td');
+        tdTotal.textContent = total + ' MB';
+        tr.appendChild(tdTotal);
+
+        tbody.appendChild(tr);
+    }
+
+    const header = document.getElementById('bufferMemoryTotalHeader');
+    header.textContent = 'Total (' + _bufferPlayerCount + ' player' + (_bufferPlayerCount !== 1 ? 's' : '') + ')';
+
+    document.getElementById('bufferSaveMessage').style.display = 'none';
+}
+
+async function saveBufferSettings() {
+    const seconds = parseInt(document.getElementById('bufferSlider').value, 10);
+    const msgEl = document.getElementById('bufferSaveMessage');
+
+    try {
+        const resp = await fetch('/api/settings/buffer', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ bufferSeconds: seconds })
+        });
+        const data = await resp.json();
+
+        if (resp.ok && data.success) {
+            msgEl.className = 'small text-success';
+            msgEl.textContent = data.message;
+        } else {
+            msgEl.className = 'small text-danger';
+            msgEl.textContent = data.message || 'Failed to save.';
+        }
+    } catch (err) {
+        msgEl.className = 'small text-danger';
+        msgEl.textContent = 'Error saving settings: ' + err.message;
+    }
+
+    msgEl.style.display = 'block';
+}

--- a/src/MultiRoomAudio/wwwroot/js/wizard.js
+++ b/src/MultiRoomAudio/wwwroot/js/wizard.js
@@ -768,34 +768,16 @@ const Wizard = {
                                     </div>
                                     <div class="col-md-6">
                                         <div class="mb-3">
-                                            <label class="form-label">Left Channel</label>
-                                            <div class="d-flex align-items-center">
-                                                <select class="form-select" id="wizardRemapLeft">
-                                                    <option value="front-left">Front Left</option>
-                                                    <option value="front-right">Front Right</option>
-                                                </select>
-                                                <button class="btn btn-outline-primary btn-sm ms-2"
-                                                        id="wizardRemapLeftTestBtn"
-                                                        onclick="Wizard.playRemapChannelTestTone('left')"
-                                                        title="Play test tone">
-                                                    <i class="fas fa-volume-up"></i>
-                                                </button>
+                                            <label class="form-label">Output Mode</label>
+                                            <div class="btn-group w-100 mb-3" role="group">
+                                                <input type="radio" class="btn-check" name="wizardOutputMode" id="wizardOutputModeMono" value="mono" onchange="Wizard.updateRemapChannels()">
+                                                <label class="btn btn-outline-primary" for="wizardOutputModeMono">Mono</label>
+                                                <input type="radio" class="btn-check" name="wizardOutputMode" id="wizardOutputModeStereo" value="stereo" checked onchange="Wizard.updateRemapChannels()">
+                                                <label class="btn btn-outline-primary" for="wizardOutputModeStereo">Stereo</label>
                                             </div>
                                         </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Right Channel</label>
-                                            <div class="d-flex align-items-center">
-                                                <select class="form-select" id="wizardRemapRight">
-                                                    <option value="front-left">Front Left</option>
-                                                    <option value="front-right" selected>Front Right</option>
-                                                </select>
-                                                <button class="btn btn-outline-primary btn-sm ms-2"
-                                                        id="wizardRemapRightTestBtn"
-                                                        onclick="Wizard.playRemapChannelTestTone('right')"
-                                                        title="Play test tone">
-                                                    <i class="fas fa-volume-up"></i>
-                                                </button>
-                                            </div>
+                                        <div id="wizardChannelPicker">
+                                            <!-- Populated dynamically by updateRemapChannels() -->
                                         </div>
                                     </div>
                                 </div>
@@ -820,14 +802,14 @@ const Wizard = {
         `;
     },
 
-    // Update channel options based on selected master device
+    // Update channel options based on selected master device and output mode
     updateRemapChannels() {
         const masterSelect = document.getElementById('wizardRemapMaster');
-        const leftSelect = document.getElementById('wizardRemapLeft');
-        const rightSelect = document.getElementById('wizardRemapRight');
+        const channelPicker = document.getElementById('wizardChannelPicker');
 
-        if (!masterSelect || !leftSelect || !rightSelect) return;
+        if (!masterSelect || !channelPicker) return;
 
+        const isMono = document.getElementById('wizardOutputModeMono')?.checked;
         const selectedOption = masterSelect.selectedOptions[0];
         const channelCount = parseInt(selectedOption?.dataset?.channels || '2');
 
@@ -865,12 +847,58 @@ const Wizard = {
             `<option value="${ch.value}">${ch.label}</option>`
         ).join('');
 
-        leftSelect.innerHTML = optionsHtml;
-        rightSelect.innerHTML = optionsHtml;
-
-        // Set sensible defaults
-        leftSelect.value = 'front-left';
-        rightSelect.value = 'front-right';
+        if (isMono) {
+            channelPicker.innerHTML = `
+                <div class="mb-3">
+                    <label class="form-label">Source Channel</label>
+                    <div class="d-flex align-items-center">
+                        <select class="form-select" id="wizardRemapMono">
+                            ${optionsHtml}
+                        </select>
+                        <button class="btn btn-outline-primary btn-sm ms-2"
+                                id="wizardRemapMonoTestBtn"
+                                onclick="Wizard.playRemapChannelTestTone('mono')"
+                                title="Play test tone">
+                            <i class="fas fa-volume-up"></i>
+                        </button>
+                    </div>
+                </div>
+            `;
+            document.getElementById('wizardRemapMono').value = 'front-left';
+        } else {
+            channelPicker.innerHTML = `
+                <div class="mb-3">
+                    <label class="form-label">Left Channel</label>
+                    <div class="d-flex align-items-center">
+                        <select class="form-select" id="wizardRemapLeft">
+                            ${optionsHtml}
+                        </select>
+                        <button class="btn btn-outline-primary btn-sm ms-2"
+                                id="wizardRemapLeftTestBtn"
+                                onclick="Wizard.playRemapChannelTestTone('left')"
+                                title="Play test tone">
+                            <i class="fas fa-volume-up"></i>
+                        </button>
+                    </div>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Right Channel</label>
+                    <div class="d-flex align-items-center">
+                        <select class="form-select" id="wizardRemapRight">
+                            ${optionsHtml}
+                        </select>
+                        <button class="btn btn-outline-primary btn-sm ms-2"
+                                id="wizardRemapRightTestBtn"
+                                onclick="Wizard.playRemapChannelTestTone('right')"
+                                title="Play test tone">
+                            <i class="fas fa-volume-up"></i>
+                        </button>
+                    </div>
+                </div>
+            `;
+            document.getElementById('wizardRemapLeft').value = 'front-left';
+            document.getElementById('wizardRemapRight').value = 'front-right';
+        }
     },
 
     // Create a combine sink
@@ -958,8 +986,6 @@ const Wizard = {
         const nameInput = document.getElementById('wizardRemapName');
         const descInput = document.getElementById('wizardRemapDesc');
         const masterSelect = document.getElementById('wizardRemapMaster');
-        const leftSelect = document.getElementById('wizardRemapLeft');
-        const rightSelect = document.getElementById('wizardRemapRight');
         const errorDiv = document.getElementById('wizardRemapError');
         const successDiv = document.getElementById('wizardRemapSuccess');
 
@@ -970,8 +996,7 @@ const Wizard = {
         const name = nameInput.value.trim();
         const description = descInput.value.trim();
         const masterSink = masterSelect.value;
-        const leftChannel = leftSelect.value;
-        const rightChannel = rightSelect.value;
+        const isMono = document.getElementById('wizardOutputModeMono')?.checked;
 
         // Validation
         if (!name) {
@@ -994,6 +1019,23 @@ const Wizard = {
             return;
         }
 
+        let channels, channelMappings;
+        if (isMono) {
+            const monoChannel = document.getElementById('wizardRemapMono').value;
+            channels = 1;
+            channelMappings = [
+                { outputChannel: 'mono', masterChannel: monoChannel }
+            ];
+        } else {
+            const leftChannel = document.getElementById('wizardRemapLeft').value;
+            const rightChannel = document.getElementById('wizardRemapRight').value;
+            channels = 2;
+            channelMappings = [
+                { outputChannel: 'front-left', masterChannel: leftChannel },
+                { outputChannel: 'front-right', masterChannel: rightChannel }
+            ];
+        }
+
         try {
             const response = await fetch('./api/sinks/remap', {
                 method: 'POST',
@@ -1002,11 +1044,9 @@ const Wizard = {
                     name,
                     description: description || null,
                     masterSink,
-                    channels: 2,
-                    channelMappings: [
-                        { outputChannel: 'front-left', masterChannel: leftChannel },
-                        { outputChannel: 'front-right', masterChannel: rightChannel }
-                    ]
+                    channels,
+                    channelMappings,
+                    remix: isMono
                 })
             });
 
@@ -1024,7 +1064,7 @@ const Wizard = {
                 description: description,
                 slaves: [],
                 masterSink: masterSink,
-                maxChannels: 2,
+                maxChannels: isMono ? 1 : 2,
                 defaultSampleRate: 48000
             });
 
@@ -1325,8 +1365,14 @@ const Wizard = {
     // Play test tone for a specific channel in wizard remap sink
     async playRemapChannelTestTone(channel) {
         const masterSelect = document.getElementById('wizardRemapMaster');
-        const channelSelect = document.getElementById(channel === 'left' ? 'wizardRemapLeft' : 'wizardRemapRight');
-        const btn = document.getElementById(channel === 'left' ? 'wizardRemapLeftTestBtn' : 'wizardRemapRightTestBtn');
+        let channelSelect, btn;
+        if (channel === 'mono') {
+            channelSelect = document.getElementById('wizardRemapMono');
+            btn = document.getElementById('wizardRemapMonoTestBtn');
+        } else {
+            channelSelect = document.getElementById(channel === 'left' ? 'wizardRemapLeft' : 'wizardRemapRight');
+            btn = document.getElementById(channel === 'left' ? 'wizardRemapLeftTestBtn' : 'wizardRemapRightTestBtn');
+        }
 
         if (!masterSelect.value) {
             showAlert('Please select a master device first', 'warning');


### PR DESCRIPTION
## v5.1.0 Release

### SendSpin SDK Upgrade (6.3.5 → 7.3.0)
- NativeAOT support (v7.0.0)
- Static delay reporting for improved multi-room sync (v7.1.0)
- Reconnect resilience + FLAC 32-bit fix (v7.2.0)
- Buffer overrun sync fix (v7.2.1)
- Simplified sync deadband, mDNS input sanitization, PlaybackRate diagnostics (v7.3.0)

### Configurable Audio Buffer Size
- New `BUFFER_SECONDS` env var / HAOS option (5-30s, step 5, default 30s)
- `GET/PUT /api/settings/buffer` endpoint with memory estimates per sample rate
- System Settings modal with slider and per-player memory table
- Settings persisted to `settings.yaml` via ConfigurationService
- Increased default buffer from 8s to 30s to match SDK v7.2.0 default (~11MB/player at 48kHz)

### Hybrid Reconnection
- Lightweight reconnect for disconnections <=60s - reuses existing SDK pipeline/buffer/player so audio continues playing from buffer while WebSocket reconnects
- Exponential backoff (1s, 2s, 4s... capped at 15s)
- Falls back to full teardown after 60s window expires

### New SDK Event Handlers
- **SyncOffsetApplied**: Persists server-pushed static delay calibration to config, broadcasts to UI
- **ArtworkCleared**: Clears stale album art when server signals no artwork available
- **StaticDelayMs**: All SendPlayerStateAsync calls now include per-player delay offsets for GroupSync

### Wizard Mono Output Mode
- Remap sink creation now supports Mono/Stereo toggle (contributed by @scyto)
- Dynamic channel picker rendering and proper remix flag for mono sinks

### Bug Fixes
- Fix buffer settings fetch paths for HA ingress (relative ./api/ paths)
- Fix PulseAudio config files using CRLF line endings (added .gitattributes rules for .conf/.pa)
- Remove duplicate HidSharp package reference