### PR TITLE
fix: correct stale squeezelite-docker repo URLs (#225)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing to this project!
 ## Quick Start for Contributors
 
 1. **Fork the repository** on GitHub
-2. **Clone your fork**: `git clone https://github.com/yourusername/squeezelite-docker.git`
+2. **Clone your fork**: `git clone https://github.com/yourusername/Multi-SendSpin-Player-Container.git`
 3. **Create a feature branch**: `git checkout -b feature/amazing-feature`
 4. **Make your changes** and test thoroughly
 5. **Build and verify**: `dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj`

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Navigate to `http://your-host-ip:8096`
 
 For Home Assistant OS users, install as an add-on:
 
-1. Add repository: `https://github.com/chrisuthe/squeezelite-docker`
+1. Add repository: `https://github.com/chrisuthe/Multi-SendSpin-Player-Container`
 2. Install "Multi-Room Audio Controller"
 3. Start and access via sidebar
 
@@ -298,9 +298,9 @@ For detailed license information, see [LICENSES.md](LICENSES.md).
 
 ## Support and Community
 
-- **Issues**: Report bugs and request features via [GitHub Issues](https://github.com/chrisuthe/squeezelite-docker/issues)
+- **Issues**: Report bugs and request features via [GitHub Issues](https://github.com/chrisuthe/Multi-SendSpin-Player-Container/issues)
 - **Docker Hub**: Pre-built images at `https://hub.docker.com/r/chrisuthe/squeezelitemultiroom`
-- **Documentation**: [Wiki](https://github.com/chrisuthe/squeezelite-docker/wiki)
+- **Documentation**: [Wiki](https://github.com/chrisuthe/Multi-SendSpin-Player-Container/wiki)
 
 ## About This Project
 
@@ -316,7 +316,7 @@ This project was developed with the assistance of AI (Claude by Anthropic) via [
 *Built with .NET 8.0 for the open-source community*
 
 [![Docker Hub](https://img.shields.io/badge/Docker%20Hub-chrisuthe%2Fsqueezelitemultiroom-blue?style=flat-square&logo=docker)](https://hub.docker.com/r/chrisuthe/squeezelitemultiroom)
-[![GitHub](https://img.shields.io/badge/GitHub-Source%20Code-black?style=flat-square&logo=github)](https://github.com/chrisuthe/squeezelite-docker)
+[![GitHub](https://img.shields.io/badge/GitHub-Source%20Code-black?style=flat-square&logo=github)](https://github.com/chrisuthe/Multi-SendSpin-Player-Container)
 
 </div>
 <!-- markdownlint-enable MD036 -->

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -152,7 +152,7 @@ After restarting the container, your custom ALSA devices will appear in the devi
 1. Go to **Settings** > **Add-ons** > **Add-on Store**
 2. Click the three-dot menu (top right)
 3. Select **Repositories**
-4. Add: `https://github.com/chrisuthe/squeezelite-docker`
+4. Add: `https://github.com/chrisuthe/Multi-SendSpin-Player-Container`
 5. Click **Add**, then **Close**
 
 ### Step 2: Install the Add-on

--- a/docs/HAOS_ADDON_GUIDE.md
+++ b/docs/HAOS_ADDON_GUIDE.md
@@ -64,7 +64,7 @@ This add-on works differently than the standalone Docker container. Understand t
 1. Navigate to **Settings** > **Add-ons** > **Add-on Store**
 2. Click the **three-dot menu** (top right corner)
 3. Select **Repositories**
-4. Enter: `https://github.com/chrisuthe/squeezelite-docker`
+4. Enter: `https://github.com/chrisuthe/Multi-SendSpin-Player-Container`
 5. Click **Add**
 6. Click **Close**
 
@@ -421,4 +421,4 @@ If you are stuck:
    - Relevant logs
    - Steps to reproduce
 
-**GitHub Issues**: https://github.com/chrisuthe/squeezelite-docker/issues
+**GitHub Issues**: https://github.com/chrisuthe/Multi-SendSpin-Player-Container/issues

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -85,7 +85,7 @@ Then open `http://YOUR-SERVER-IP:8096` - the setup wizard will guide you through
 
 ### Home Assistant OS
 
-1. Add repository: `https://github.com/chrisuthe/squeezelite-docker`
+1. Add repository: `https://github.com/chrisuthe/Multi-SendSpin-Player-Container`
 2. Install "Multi-Room Audio Controller" add-on
 3. Start and open from sidebar
 4. Follow the setup wizard
@@ -132,5 +132,5 @@ volumes:
 
 ## Links
 
-- [GitHub Repository](https://github.com/chrisuthe/squeezelite-docker)
-- [Report an Issue](https://github.com/chrisuthe/squeezelite-docker/issues)
+- [GitHub Repository](https://github.com/chrisuthe/Multi-SendSpin-Player-Container)
+- [Report an Issue](https://github.com/chrisuthe/Multi-SendSpin-Player-Container/issues)

--- a/docs/WHATS_NEW_4.0.md
+++ b/docs/WHATS_NEW_4.0.md
@@ -155,7 +155,7 @@ For the technically curious:
 
 This release represents months of work based on community feedback. Special thanks to everyone who reported issues, requested features, and tested pre-releases.
 
-Found a bug? Have a suggestion? [Open an issue](https://github.com/chrisuthe/squeezelite-docker/issues).
+Found a bug? Have a suggestion? [Open an issue](https://github.com/chrisuthe/Multi-SendSpin-Player-Container/issues).
 
 ---
 

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -20,5 +20,5 @@
 * [Code Structure](CODE_STRUCTURE)
 
 **Links**
-* [GitHub Repository](https://github.com/chrisuthe/squeezelite-docker)
-* [Report Issue](https://github.com/chrisuthe/squeezelite-docker/issues)
+* [GitHub Repository](https://github.com/chrisuthe/Multi-SendSpin-Player-Container)
+* [Report Issue](https://github.com/chrisuthe/Multi-SendSpin-Player-Container/issues)

--- a/docs/plans/2026-03-05-sdk-7.2.1-upgrade-design.md
+++ b/docs/plans/2026-03-05-sdk-7.2.1-upgrade-design.md
@@ -1,0 +1,117 @@
+# Sendspin SDK 7.2.1 Upgrade Design
+
+**Date**: 2026-03-05
+**Current SDK**: 6.3.5
+**Target SDK**: 7.2.1
+**Breaking changes affecting us**: None (we don't use `SendspinListener`)
+
+---
+
+## 1. Hybrid Reconnection Strategy
+
+Replace the current destroy-and-recreate reconnection with a two-tier approach.
+
+### Lightweight Reconnect (disconnect <= 60s)
+
+When the WebSocket disconnects, keep all SDK components alive and reconnect only the transport layer:
+
+1. Record `DisconnectedAt` timestamp on the `PlayerContext`
+2. Keep `KalmanClockSynchronizer` alive (state is naturally preserved — no Reset())
+3. Attempt WebSocket reconnect (existing backoff logic)
+4. On successful reconnect within 60s:
+   - Call `Pipeline.NotifyReconnect()` (cascades to buffer, player, sync correction)
+   - SDK's built-in 2s stabilization period suppresses sync corrections automatically
+   - Audio continues playing from the 30s buffer throughout
+   - Clear `DisconnectedAt` timestamp
+
+> **Note**: SDK v7.2.0 release notes document `Freeze()/Thaw()/IsFrozen` on `IClockSynchronizer`,
+> but these are **not yet implemented** in the code. This is fine — by keeping the clock sync
+> alive (not destroying it), the Kalman filter state is naturally preserved. The filter will
+> re-converge quickly as new measurements arrive after reconnect.
+
+### Full Teardown (disconnect > 60s)
+
+If 60 seconds elapse without a successful reconnect:
+
+1. Tear down the existing `PlayerContext` (current behavior)
+2. Recreate all SDK components from scratch
+3. Proceed with normal connection flow
+
+### PlayerContext Changes
+
+Add a `DisconnectedAt` nullable `DateTime` field to track when the connection was lost. Clear it on successful reconnect.
+
+---
+
+## 2. Buffer Capacity Increase
+
+Change `LocalBufferCapacityMs` from `8000` to `30000`.
+
+- Matches SDK v7.2.0 default
+- ~11MB per player at 48kHz stereo float32 (acceptable)
+- Provides ~30s of uninterrupted playback during lightweight reconnects
+- More resilient to network hiccups in general
+
+---
+
+## 3. Bidirectional Static Delay Sync
+
+### Reporting to Server
+
+Pass `staticDelayMs` as the third parameter in all `SendPlayerStateAsync()` calls. Currently four call sites in `PlayerManagerService.cs` call `SendPlayerStateAsync(volume, muted)` -- add the delay offset from `ClockSync.StaticDelayMs`.
+
+### Accepting from Server
+
+Handle server-pushed `staticDelayMs` updates in the `PlayerStateChanged` event handler:
+
+1. Read the incoming static delay value
+2. Apply to `ClockSync.StaticDelayMs`
+3. Update persisted config so it survives restarts
+4. Broadcast change to UI via SignalR
+
+---
+
+## 4. Artwork Cleared Event
+
+Wire up `ISendspinClient.ArtworkCleared` in the `WireEvents` method:
+
+1. Subscribe to `Client.ArtworkCleared` per player
+2. Handler broadcasts an artwork-clear message to the UI via SignalR
+3. UI (`app.js`) clears the album art display on receiving the event
+4. Unsubscribe in `UnwireEvents` for proper cleanup
+
+---
+
+## 5. Free Fixes (SDK Internal, No Code Changes)
+
+These improvements come automatically with the version bump:
+
+| Fix | Version | Effect |
+|-----|---------|--------|
+| FLAC 32-bit silence | v7.2.0 | Reads true bit depth from STREAMINFO |
+| Buffer overrun safety | v7.2.1 | Discards audio when buffer fills before playback starts |
+| Skip stale audio | v7.2.1 | Buffer skips to correct position when scheduled start is in past |
+| Reanchor cooldown | v7.2.0 | 5s cooldown prevents re-anchor loops |
+| Reconnect stabilization | v7.2.0 | 2s suppression of sync corrections after reconnect |
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `MultiRoomAudio.csproj` | `SendSpin.SDK` 6.3.5 -> 7.2.1 |
+| `PlayerManagerService.cs` | Hybrid reconnect logic, `LocalBufferCapacityMs` 8000 -> 30000, `staticDelayMs` in `SendPlayerStateAsync` calls, accept server-pushed delay, `ArtworkCleared` event wiring |
+| `PlayerContext` (in PlayerManagerService.cs) | Add `DisconnectedAt` field |
+| `BufferedAudioSampleSource.cs` | Add `NotifyReconnect()` pass-through if needed |
+| `PlayerStatsMapper.cs` | Minor updates if staticDelayMs mapping changes |
+| `wwwroot/js/app.js` | Handle artwork-cleared SignalR event |
+
+---
+
+## Out of Scope
+
+- `SendspinListener` / server-initiated connections (not used)
+- NativeAOT / trimming (explicitly disabled per CLAUDE.md)
+- `Freeze()/Thaw()/IsFrozen` — documented but not implemented in SDK 7.2.1 source
+- New SyncCorrectionOptions fields (`ReconnectStabilizationMicroseconds`, `ReanchorCooldownMicroseconds`) -- SDK defaults are appropriate

--- a/docs/plans/2026-03-05-sdk-7.2.1-upgrade-plan.md
+++ b/docs/plans/2026-03-05-sdk-7.2.1-upgrade-plan.md
@@ -1,0 +1,743 @@
+# SDK 7.2.1 Upgrade Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Upgrade Sendspin SDK from 6.3.5 to 7.2.1 with hybrid reconnection, larger buffer, bidirectional static delay sync, and artwork cleared event.
+
+**Architecture:** The upgrade touches `PlayerManagerService.cs` primarily, adding a lightweight reconnect path that reuses existing SDK components (pipeline, buffer, player, clock sync, client) for disconnections under 60 seconds, falling back to full teardown for longer ones. The SDK internally resets clock sync and calls `NotifyReconnect()` on the pipeline during re-handshake, so our code just needs to keep the components alive and reconnect.
+
+**Tech Stack:** C# / .NET 8.0, Sendspin.SDK 7.2.1, ASP.NET Core SignalR
+
+**Design doc:** `docs/plans/2026-03-05-sdk-7.2.1-upgrade-design.md`
+
+---
+
+### Task 1: Package Version Bump + Build Verification
+
+**Files:**
+- Modify: `src/MultiRoomAudio/MultiRoomAudio.csproj`
+
+**Step 1: Update SDK version**
+
+In `MultiRoomAudio.csproj`, change:
+```xml
+<PackageReference Include="SendSpin.SDK" Version="6.3.5" />
+```
+to:
+```xml
+<PackageReference Include="SendSpin.SDK" Version="7.2.1" />
+```
+
+**Step 2: Restore and build**
+
+Run: `dotnet restore src/MultiRoomAudio/MultiRoomAudio.csproj && dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj --no-restore`
+Expected: Build succeeds with no errors (no breaking changes affect our code)
+
+**Step 3: Commit**
+
+```bash
+git add src/MultiRoomAudio/MultiRoomAudio.csproj
+git commit -m "$(cat <<'EOF'
+chore: upgrade Sendspin SDK 6.3.5 -> 7.2.1
+
+Includes: NativeAOT support (v7.0.0), static delay reporting (v7.1.0),
+reconnect resilience + FLAC 32-bit fix (v7.2.0), buffer overrun sync fix (v7.2.1).
+No breaking changes affect our codebase (we don't use SendspinListener).
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Buffer Capacity Increase
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Services/PlayerManagerService.cs:146`
+
+**Step 1: Change buffer capacity constant**
+
+At line 146 in `PlayerManagerService.cs`, change:
+```csharp
+private const int LocalBufferCapacityMs = 8000;
+```
+to:
+```csharp
+private const int LocalBufferCapacityMs = 30_000;
+```
+
+Update the XML doc comment above it (lines 137-145) to mention the SDK v7.2.0 default alignment:
+```csharp
+/// <summary>
+/// Local circular buffer capacity for decompressed PCM audio (in milliseconds).
+///
+/// This is the TimedAudioBuffer size - how much decoded audio we can hold locally.
+/// Must be large enough to handle network jitter and decode timing variations.
+/// Set to 30s to match SDK v7.2.0 default and support lightweight reconnection
+/// (audio continues playing from buffer while WebSocket reconnects).
+///
+/// Note: This is DIFFERENT from ServerAnnouncedBufferCapacityBytes which controls
+/// how far ahead the server sends compressed audio.
+/// </summary>
+private const int LocalBufferCapacityMs = 30_000;
+```
+
+**Step 2: Build to verify**
+
+Run: `dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj`
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add src/MultiRoomAudio/Services/PlayerManagerService.cs
+git commit -m "$(cat <<'EOF'
+feat: increase local audio buffer from 8s to 30s
+
+Matches SDK v7.2.0 default. Provides ~30s of uninterrupted playback
+during network hiccups and lightweight reconnects. ~11MB per player
+at 48kHz stereo float32.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Add staticDelayMs to SendPlayerStateAsync Calls
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Services/PlayerManagerService.cs`
+
+There are 4 call sites to update. Each currently calls `SendPlayerStateAsync(volume, muted)` and needs the third parameter `context.ClockSync.StaticDelayMs`.
+
+**Step 1: Update call site 1 — SetVolume sync (line ~1402)**
+
+Change:
+```csharp
+await context.Client.SendPlayerStateAsync(volume, context.Player.IsMuted);
+```
+to:
+```csharp
+await context.Client.SendPlayerStateAsync(volume, context.Player.IsMuted, context.ClockSync.StaticDelayMs);
+```
+
+**Step 2: Update call site 2 — SetMuted sync (line ~1458)**
+
+Change:
+```csharp
+await context.Client.SendPlayerStateAsync(context.Config.Volume, muted);
+```
+to:
+```csharp
+await context.Client.SendPlayerStateAsync(context.Config.Volume, muted, context.ClockSync.StaticDelayMs);
+```
+
+**Step 3: Update call site 3 — HID volume sync (line ~1507)**
+
+Change:
+```csharp
+await context.Client.SendPlayerStateAsync(volume, context.Player.IsMuted);
+```
+to:
+```csharp
+await context.Client.SendPlayerStateAsync(volume, context.Player.IsMuted, context.ClockSync.StaticDelayMs);
+```
+
+**Step 4: Update call site 4 — HID mute sync (line ~1556)**
+
+Change:
+```csharp
+await context.Client.SendPlayerStateAsync(context.Config.Volume, muted);
+```
+to:
+```csharp
+await context.Client.SendPlayerStateAsync(context.Config.Volume, muted, context.ClockSync.StaticDelayMs);
+```
+
+**Step 5: Build to verify**
+
+Run: `dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj`
+Expected: Build succeeds
+
+**Step 6: Commit**
+
+```bash
+git add src/MultiRoomAudio/Services/PlayerManagerService.cs
+git commit -m "$(cat <<'EOF'
+feat: report staticDelayMs in all SendPlayerStateAsync calls
+
+Server can now factor per-player delay offsets into GroupSync
+calculations for improved multi-room sync accuracy.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Accept Server-Pushed Static Delay (SyncOffsetApplied Event)
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Services/PlayerManagerService.cs` (PlayerContext, WireEvents, UnwireEvents, new handler)
+
+The SDK already applies sync offset to `ClockSync.StaticDelayMs` internally via `HandleSyncOffset()` in `SendSpinClient.cs:897`. We need to:
+1. Subscribe to `SyncOffsetApplied` event to persist the value and update UI
+2. Store the handler reference on `PlayerContext` for cleanup
+
+**Step 1: Add event handler field to PlayerContext (after line ~402)**
+
+Add to the `PlayerContext` record body:
+```csharp
+// SDK 7.1.0: Handler for sync offset calibration updates from server
+public EventHandler<SyncOffsetEventArgs>? SyncOffsetHandler { get; set; }
+```
+
+Add the `using` directive if not already present at the top of the file:
+```csharp
+using Sendspin.SDK.Client;
+```
+
+**Step 2: Create handler method**
+
+Add a new method near the other `Create*Handler` methods (after `CreatePlayerStateHandler`, around line ~2986):
+
+```csharp
+/// <summary>
+/// Creates handler for server-pushed sync offset updates (GroupSync calibration).
+/// The SDK already applies the offset to ClockSync.StaticDelayMs internally;
+/// this handler persists it to config and broadcasts to UI.
+/// </summary>
+private EventHandler<SyncOffsetEventArgs> CreateSyncOffsetHandler(
+    string name, PlayerContext context)
+{
+    return (_, args) =>
+    {
+        _logger.LogInformation(
+            "SYNC_OFFSET Player '{Name}': server set static delay to {Offset:+0.0;-0.0}ms (source: {Source})",
+            name, args.OffsetMs, args.Source ?? "unknown");
+
+        // Persist to config so it survives restarts
+        _config.UpdatePlayerField(name, cfg => cfg.DelayOffset = (int)Math.Round(args.OffsetMs), save: true);
+
+        // Broadcast to UI
+        _ = BroadcastStatusAsync();
+    };
+}
+```
+
+**Step 3: Wire the event in WireEvents (line ~2139)**
+
+Add after the PlayerStateChanged subscription:
+```csharp
+// SDK 7.1.0: SyncOffsetApplied for server-pushed delay calibration
+context.SyncOffsetHandler = CreateSyncOffsetHandler(name, context);
+context.Client.SyncOffsetApplied += context.SyncOffsetHandler;
+```
+
+**Step 4: Unwire the event in UnwireEvents (line ~2992, add before existing code)**
+
+Add as the FIRST unsubscription (reverse order):
+```csharp
+// SDK 7.1.0: Unsubscribe SyncOffsetApplied first (subscribed last)
+if (context.SyncOffsetHandler != null)
+{
+    context.Client.SyncOffsetApplied -= context.SyncOffsetHandler;
+    context.SyncOffsetHandler = null;
+}
+```
+
+**Step 5: Build to verify**
+
+Run: `dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj`
+Expected: Build succeeds
+
+**Step 6: Commit**
+
+```bash
+git add src/MultiRoomAudio/Services/PlayerManagerService.cs
+git commit -m "$(cat <<'EOF'
+feat: accept server-pushed static delay via SyncOffsetApplied event
+
+When server sends sync offset calibration (GroupSync), persist the
+value to config and broadcast to UI. SDK already applies the offset
+to ClockSync.StaticDelayMs internally.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Wire ArtworkCleared Event
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Services/PlayerManagerService.cs` (PlayerContext, WireEvents, UnwireEvents, new handler)
+- Modify: `src/MultiRoomAudio/wwwroot/js/app.js` (handle SignalR event)
+
+**Step 1: Add event handler field to PlayerContext**
+
+Add to the `PlayerContext` record body (near the other handler fields):
+```csharp
+// SDK 7.1.0: Handler for artwork cleared signal
+public EventHandler? ArtworkClearedHandler { get; set; }
+```
+
+**Step 2: Create handler method**
+
+Add near the other `Create*Handler` methods:
+
+```csharp
+/// <summary>
+/// Creates handler for artwork cleared events.
+/// Broadcasts to UI to clear stale album art display.
+/// </summary>
+private EventHandler CreateArtworkClearedHandler(string name, PlayerContext context)
+{
+    return (_, _) =>
+    {
+        _logger.LogDebug("Player '{Name}': artwork cleared by server", name);
+        _ = BroadcastStatusAsync();
+    };
+}
+```
+
+Note: Since artwork URL comes from `GroupState.Metadata.ArtworkUrl` (which the SDK sets to null when artwork is cleared), the existing `BroadcastStatusAsync` already sends the updated state with null artwork. The UI just needs to handle `artworkUrl: null` properly.
+
+**Step 3: Wire the event in WireEvents**
+
+Add after the SyncOffsetApplied subscription:
+```csharp
+// SDK 7.1.0: ArtworkCleared for clearing stale album art
+context.ArtworkClearedHandler = CreateArtworkClearedHandler(name, context);
+context.Client.ArtworkCleared += context.ArtworkClearedHandler;
+```
+
+**Step 4: Unwire the event in UnwireEvents**
+
+Add as the FIRST unsubscription (reverse order — subscribed last, unsubscribed first):
+```csharp
+// SDK 7.1.0: Unsubscribe ArtworkCleared first (subscribed last)
+if (context.ArtworkClearedHandler != null)
+{
+    context.Client.ArtworkCleared -= context.ArtworkClearedHandler;
+    context.ArtworkClearedHandler = null;
+}
+```
+
+**Step 5: Verify UI handles null artwork**
+
+Check that `app.js` line ~1648 already handles missing artwork:
+```javascript
+${player.currentTrack.artworkUrl ? `<img src="..." ...>` : ''}
+```
+This ternary already handles null/undefined artwork — no UI change needed. The `BroadcastStatusAsync` will send `artworkUrl: null` and the UI will render without the image.
+
+**Step 6: Build to verify**
+
+Run: `dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj`
+Expected: Build succeeds
+
+**Step 7: Commit**
+
+```bash
+git add src/MultiRoomAudio/Services/PlayerManagerService.cs
+git commit -m "$(cat <<'EOF'
+feat: wire ArtworkCleared event to clear stale album art
+
+When server signals no artwork available, broadcast status update
+so UI clears the previous track's album art immediately.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Hybrid Reconnection — PlayerContext + Constants
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Services/PlayerManagerService.cs`
+
+**Step 1: Add DisconnectedAt to PlayerContext (line ~385)**
+
+Add to the `PlayerContext` record body:
+```csharp
+/// <summary>
+/// When the connection was lost. Used to decide lightweight vs full reconnect.
+/// Null when connected or never disconnected.
+/// </summary>
+public DateTime? DisconnectedAt { get; set; }
+```
+
+**Step 2: Add lightweight reconnect timeout constant**
+
+Add near the other constants (after `MaxReconnectAttempts` around line ~229):
+```csharp
+/// <summary>
+/// Maximum time to attempt lightweight reconnect before falling back to full teardown.
+/// During lightweight reconnect, the pipeline/buffer/player stay alive so audio
+/// continues playing from the 30s buffer while the WebSocket reconnects.
+/// </summary>
+private static readonly TimeSpan LightweightReconnectTimeout = TimeSpan.FromSeconds(60);
+```
+
+**Step 3: Build to verify**
+
+Run: `dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj`
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add src/MultiRoomAudio/Services/PlayerManagerService.cs
+git commit -m "$(cat <<'EOF'
+feat: add DisconnectedAt and lightweight reconnect timeout
+
+Foundation for hybrid reconnection: track when connection was lost
+to decide between lightweight (<=60s) and full teardown reconnect.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Hybrid Reconnection — Lightweight Reconnect Path
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Services/PlayerManagerService.cs`
+
+This is the core change. The current `CreateConnectionStateHandler` (line ~2145) tears down the player on disconnect. We need to:
+1. On disconnect: record timestamp, attempt lightweight reconnect
+2. On successful reconnect within 60s: clear timestamp, push volume
+3. On timeout (>60s): fall back to full teardown
+
+**Step 1: Modify CreateConnectionStateHandler disconnect logic**
+
+Replace the disconnection handling block (lines ~2175-2202) with lightweight reconnect logic:
+
+```csharp
+// Handle disconnection - attempt lightweight reconnect first
+if (args.NewState == ConnectionState.Disconnected &&
+    previousState != Models.PlayerState.Stopped &&  // Not user-stopped
+    previousState != Models.PlayerState.Error &&    // Not already errored
+    !_pendingReconnections.ContainsKey(name) &&     // Not already pending server reconnection
+    !_devicePendingPlayers.ContainsKey(name))       // Not waiting for device reconnection
+{
+    // Get the persisted configuration for reconnection
+    var persistedConfig = _config.Players.TryGetValue(name, out var cfg) ? cfg : null;
+    if (persistedConfig == null)
+    {
+        _logger.LogWarning("Player '{Name}' has no persisted configuration, cannot auto-reconnect", name);
+        return;
+    }
+
+    // Check if we should attempt lightweight reconnect (reuse existing SDK components)
+    if (context.DisconnectedAt == null)
+    {
+        // First disconnect — start lightweight reconnect window
+        context.DisconnectedAt = DateTime.UtcNow;
+        context.State = Models.PlayerState.Reconnecting;
+        context.ErrorMessage = "Reconnecting...";
+
+        _logger.LogInformation(
+            "Player '{Name}' disconnected, starting lightweight reconnect (60s window, audio continues from buffer)",
+            name);
+
+        FireAndForget(async () =>
+        {
+            await AttemptLightweightReconnectAsync(name, context, persistedConfig);
+        }, $"Lightweight reconnect for '{name}'", _logger);
+    }
+    else if (DateTime.UtcNow - context.DisconnectedAt.Value > LightweightReconnectTimeout)
+    {
+        // Lightweight reconnect window expired — fall back to full teardown
+        _logger.LogWarning(
+            "Player '{Name}' lightweight reconnect timeout ({Timeout}s), falling back to full teardown",
+            name, LightweightReconnectTimeout.TotalSeconds);
+
+        context.DisconnectedAt = null;
+
+        FireAndForget(async () =>
+        {
+            await Task.Delay(100);
+            await RemoveAndDisposePlayerAsync(name);
+            QueueForReconnection(persistedConfig);
+        }, $"Full reconnection setup for '{name}'", _logger);
+    }
+    // else: already in lightweight reconnect window, retry handled by AttemptLightweightReconnectAsync
+}
+```
+
+**Step 2: Add AttemptLightweightReconnectAsync method**
+
+Add this method near the reconnection region:
+
+```csharp
+/// <summary>
+/// Attempts to reconnect by reusing existing SDK components (client, pipeline, buffer, player).
+/// Audio continues playing from the 30s buffer while the WebSocket reconnects.
+/// Falls back to full teardown if the lightweight reconnect window (60s) expires.
+/// </summary>
+private async Task AttemptLightweightReconnectAsync(
+    string name, PlayerContext context, PlayerConfiguration config)
+{
+    var serverUri = GetServerUri(config);
+    if (serverUri == null)
+    {
+        // Try mDNS discovery
+        serverUri = _lastDiscoveredServerUri;
+        if (serverUri == null)
+        {
+            _logger.LogWarning("Player '{Name}': no server URI for lightweight reconnect, trying mDNS", name);
+            try
+            {
+                var discovered = await DiscoverServerAsync(TimeSpan.FromSeconds(5), context.Cts.Token);
+                serverUri = discovered;
+            }
+            catch
+            {
+                // Fall through to retry logic
+            }
+        }
+    }
+
+    if (serverUri == null)
+    {
+        _logger.LogWarning("Player '{Name}': no server found, falling back to full teardown", name);
+        context.DisconnectedAt = null;
+        await RemoveAndDisposePlayerAsync(name);
+        QueueForReconnection(config);
+        return;
+    }
+
+    // Retry with exponential backoff within the 60s window
+    var attempt = 0;
+    while (context.DisconnectedAt != null &&
+           DateTime.UtcNow - context.DisconnectedAt.Value <= LightweightReconnectTimeout &&
+           !context.Cts.Token.IsCancellationRequested)
+    {
+        attempt++;
+        try
+        {
+            _logger.LogInformation(
+                "Player '{Name}': lightweight reconnect attempt {Attempt} to {Uri}",
+                name, attempt, serverUri);
+
+            await context.Client.ConnectAsync(serverUri, context.Cts.Token);
+
+            // Success — clear disconnect timestamp, push volume
+            context.DisconnectedAt = null;
+            context.ConnectedAt = DateTime.UtcNow;
+            context.State = Models.PlayerState.Connected;
+            context.ErrorMessage = null;
+
+            _logger.LogInformation(
+                "Player '{Name}': lightweight reconnect succeeded after {Attempt} attempt(s)",
+                name, attempt);
+
+            _ = PushVolumeToServerAsync(name, context);
+            _ = BroadcastStatusAsync();
+            return;
+        }
+        catch (OperationCanceledException) when (context.Cts.Token.IsCancellationRequested)
+        {
+            _logger.LogDebug("Player '{Name}': lightweight reconnect cancelled", name);
+            return;
+        }
+        catch (Exception ex)
+        {
+            var elapsed = DateTime.UtcNow - context.DisconnectedAt!.Value;
+            var remaining = LightweightReconnectTimeout - elapsed;
+
+            _logger.LogWarning(
+                "Player '{Name}': lightweight reconnect attempt {Attempt} failed ({Remaining:F0}s remaining): {Message}",
+                name, attempt, remaining.TotalSeconds, ex.Message);
+
+            if (remaining <= TimeSpan.Zero)
+                break;
+
+            // Exponential backoff: 1s, 2s, 4s, 8s... capped at 15s
+            var delay = TimeSpan.FromSeconds(Math.Min(Math.Pow(2, attempt - 1), 15));
+            if (delay > remaining)
+                delay = remaining;
+
+            try
+            {
+                await Task.Delay(delay, context.Cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+
+    // Window expired — fall back to full teardown
+    if (context.DisconnectedAt != null)
+    {
+        _logger.LogWarning(
+            "Player '{Name}': lightweight reconnect window expired after {Attempt} attempts, full teardown",
+            name, attempt);
+
+        context.DisconnectedAt = null;
+        await RemoveAndDisposePlayerAsync(name);
+        QueueForReconnection(config);
+    }
+}
+```
+
+**Step 3: Clear DisconnectedAt on successful connection**
+
+In `CreateConnectionStateHandler`, update the `Connected` block (line ~2167-2173) to also clear `DisconnectedAt`:
+
+```csharp
+if (args.NewState == ConnectionState.Connected)
+{
+    context.ConnectedAt = DateTime.UtcNow;
+    context.DisconnectedAt = null;  // Clear lightweight reconnect state
+    _logger.LogInformation("VOLUME [GracePeriod] Player '{Name}': grace period started for {Duration}s",
+        name, VolumeGracePeriod.TotalSeconds);
+    _ = PushVolumeToServerAsync(name, context);
+}
+```
+
+**Step 4: Add helper method for server URI resolution**
+
+Add this helper if it doesn't already exist (check first):
+
+```csharp
+/// <summary>
+/// Gets the server URI for a player configuration.
+/// Returns null if no server is configured (mDNS discovery needed).
+/// </summary>
+private static Uri? GetServerUri(PlayerConfiguration config)
+{
+    if (string.IsNullOrEmpty(config.Server))
+        return null;
+
+    try
+    {
+        return new Uri(config.Server);
+    }
+    catch
+    {
+        return null;
+    }
+}
+```
+
+**Step 5: Build to verify**
+
+Run: `dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj`
+Expected: Build succeeds. Address any compilation issues (e.g., `DiscoverServerAsync` or `_lastDiscoveredServerUri` may need to match the actual field/method names in the codebase — check and adjust).
+
+**Step 6: Commit**
+
+```bash
+git add src/MultiRoomAudio/Services/PlayerManagerService.cs
+git commit -m "$(cat <<'EOF'
+feat: hybrid reconnection - lightweight for <=60s, full teardown after
+
+On disconnect, attempt lightweight reconnect by reusing existing SDK
+components (pipeline, buffer, player, clock sync). Audio continues
+playing from the 30s buffer while WebSocket reconnects with exponential
+backoff. If 60s elapses without success, fall back to full teardown
+and recreate all components from scratch.
+
+SDK internally resets clock sync and calls Pipeline.NotifyReconnect()
+on re-handshake, suppressing sync corrections for 2s stabilization.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Step 1: Update SDK version reference**
+
+Find and update the NuGet package reference in CLAUDE.md:
+```xml
+<PackageReference Include="SendSpin.SDK" Version="7.2.1" />
+```
+
+Also update the description:
+```
+- SendSpin.SDK v7.2.1 - Sendspin protocol handling
+```
+
+**Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs: update CLAUDE.md SDK version to 7.2.1
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: Manual Testing Verification
+
+**Step 1: Start the app in mock mode**
+
+```bash
+cd src/MultiRoomAudio
+MOCK_HARDWARE=true dotnet run
+```
+
+**Step 2: Verify startup**
+
+- Navigate to `http://localhost:8096`
+- Confirm UI loads without errors
+- Check browser console for JavaScript errors
+
+**Step 3: Verify build completes clean**
+
+```bash
+dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj -c Release
+```
+Expected: No warnings related to SDK changes
+
+**Step 4: Kill the app**
+
+```bash
+pkill -f "MultiRoomAudio"
+```
+
+---
+
+## Implementation Notes
+
+### Key SDK behaviors to understand:
+
+1. **`SendspinClient.ConnectAsync(uri)`** can be called again after disconnect — creates new WebSocket internally, performs handshake
+2. **`HandleServerHello`** (SDK internal) always calls `_clockSynchronizer.Reset()` + `_audioPipeline?.NotifyReconnect()` on every handshake
+3. **`Pipeline.NotifyReconnect()`** cascades to buffer and player, enabling 2s stabilization window
+4. **`SyncOffsetApplied`** fires when server pushes `client/sync_offset` — SDK already applies to `ClockSync.StaticDelayMs`
+5. **`ArtworkCleared`** fires when server sends empty artwork binary payload
+6. **Buffer overrun safety** and **SkipStaleAudio** work automatically with SDK 7.2.1
+
+### Files modified summary:
+
+| File | Tasks |
+|------|-------|
+| `MultiRoomAudio.csproj` | Task 1 |
+| `PlayerManagerService.cs` | Tasks 2, 3, 4, 5, 6, 7 |
+| `CLAUDE.md` | Task 8 |

--- a/multiroom-audio-dev/config.yaml
+++ b/multiroom-audio-dev/config.yaml
@@ -4,7 +4,7 @@ slug: multiroom-audio-dev
 description: >-
   Development builds - may be unstable. Sendspin-powered multi-room audio
   controller for testing new features.
-url: https://github.com/chrisuthe/squeezelite-docker
+url: https://github.com/chrisuthe/Multi-SendSpin-Player-Container
 image: ghcr.io/chrisuthe/multiroom-audio-hassio-dev
 startup: services
 arch:

--- a/multiroom-audio/DOCS.md
+++ b/multiroom-audio/DOCS.md
@@ -244,8 +244,8 @@ own channel assignments. Boards are identified by:
 
 ## Support
 
-- [GitHub Issues](https://github.com/chrisuthe/squeezelite-docker/issues)
-- [Documentation](https://github.com/chrisuthe/squeezelite-docker)
+- [GitHub Issues](https://github.com/chrisuthe/Multi-SendSpin-Player-Container/issues)
+- [Documentation](https://github.com/chrisuthe/Multi-SendSpin-Player-Container)
 
 ## About
 


### PR DESCRIPTION
## Summary

Fixes #225 — the README (and several other docs) linked to the old `chrisuthe/squeezelite-docker` repository instead of the current `Multi-SendSpin-Player-Container`.

The project was renamed (`squeezelite-docker` → `multiroom-audio` → `Multi-SendSpin-Player-Container`) but stale repository URLs were left behind, sending users to the wrong/404 target — including the *Add repository* instructions for the HAOS add-on store.

## Changes

Replaced all `https://github.com/chrisuthe/squeezelite-docker` links (repo, `/issues`, `/wiki`) with the current repository URL across:

- `README.md` (4 links incl. the HAOS add-on install step and the GitHub badge)
- `docs/Home.md`, `docs/_Sidebar.md`, `docs/GETTING_STARTED.md`, `docs/HAOS_ADDON_GUIDE.md`, `docs/WHATS_NEW_4.0.md`
- `multiroom-audio/DOCS.md`
- `multiroom-audio-dev/config.yaml` — the dev add-on `url:` field (shown in the HA add-on store)
- `CONTRIBUTING.md` — the fork-clone example (kept the `yourusername` placeholder)

Docs-only; no code paths touched. The production `multiroom-audio/config.yaml` already had the correct URL.

## Not included (tracked separately)

The deeper naming inconsistency from #215 (the `squeezelite-docker.sln` filename, the `multiroom-audio` Docker image name, and directory-tree references) is **not** addressed here — it needs a decision on the canonical project name first.