### PR TITLE
ci: hold Swashbuckle major bumps until net9/net10 (re: #216)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      # Swashbuckle.AspNetCore 9+ pulls Microsoft.OpenApi 2.x, whose flattened
+      # namespace conflicts at runtime with Microsoft.AspNetCore.OpenApi 8.x
+      # (used via .WithOpenApi()), which references Microsoft.OpenApi 1.x types.
+      # The major bump compiles but throws TypeLoadException at startup. Hold it
+      # until the project targets net9/net10. See #216.
+      - dependency-name: "Swashbuckle.AspNetCore"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Tells dependabot to stop re-proposing the **Swashbuckle.AspNetCore 8 → 10** major bump (PR #216), which **cannot be merged while the project targets net8.0**.

## Why #216 can't be merged

Swashbuckle 9+ depends on **Microsoft.OpenApi 2.x**, which flattened its namespace (`Microsoft.OpenApi.Models.*` → `Microsoft.OpenApi.*`). But this app uses `.WithOpenApi()` (from **Microsoft.AspNetCore.OpenApi 8.x**) on 15+ endpoints, and that package is built against **Microsoft.OpenApi 1.x** — it references `Microsoft.OpenApi.Models.OpenApiOperation`.

The two can't coexist at runtime:

```
System.TypeLoadException: Could not load type 'Microsoft.OpenApi.Models.OpenApiOperation'
from assembly 'Microsoft.OpenApi, Version=2.4.1.0'
```

Critically, **this compiles and passes CI** — the conflict only surfaces at runtime when the unified Microsoft.OpenApi 2.4.1 assembly is loaded. There's no net8-compatible Microsoft.AspNetCore.OpenApi that uses OpenApi 2.x (the 2.x-aligned versions require net9+).

## Recommendation

- Merge this to silence the recurring failing PR.
- **Close #216** (it's infeasible on net8). It'll naturally become viable after a net9/net10 migration, at which point removing this ignore + the namespace updates makes the upgrade straightforward.

Verified locally: the bump + namespace fix builds clean but throws the TypeLoadException above at startup (caught by running the app, not by `dotnet build`).