### PR TITLE
fix: multiple identical USB DACs break the app (#223)

### DIFF
--- a/src/MultiRoomAudio/Audio/PulseAudio/PulseAudioDeviceEnumerator.cs
+++ b/src/MultiRoomAudio/Audio/PulseAudio/PulseAudioDeviceEnumerator.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using MultiRoomAudio.Models;
+using MultiRoomAudio.Services;
 
 namespace MultiRoomAudio.Audio.PulseAudio;
 
@@ -60,6 +61,12 @@ public static partial class PulseAudioDeviceEnumerator
             }
 
             _logger?.LogDebug("Found {Count} PulseAudio sinks", devices.Count);
+
+            // #223: identical USB devices that expose no bus path or serial collapse to the
+            // same stable device key (usb_VID_PID). That conflates their saved config and
+            // breaks playback when more than one is connected. Give colliding devices a
+            // synthetic identifier from their (unique) sink name so each gets a distinct key.
+            DisambiguateCollidingDeviceKeys(devices);
         }
         catch (Exception ex)
         {
@@ -67,6 +74,41 @@ public static partial class PulseAudioDeviceEnumerator
         }
 
         return devices;
+    }
+
+    /// <summary>
+    /// Ensures every enumerated device has a distinct stable key. Identical USB devices that
+    /// expose no bus path or serial otherwise collapse to the same usb_VID_PID key (#223),
+    /// conflating their saved configuration and breaking playback when more than one is
+    /// connected. The first device with a given key keeps it (preserving existing config);
+    /// each subsequent collision is given a synthetic bus path derived from its unique
+    /// PulseAudio sink name. For truly indistinguishable devices the synthetic key is stable
+    /// only while the sink name is, but this prevents the hard breakage of conflated devices.
+    /// </summary>
+    private static void DisambiguateCollidingDeviceKeys(List<AudioDevice> devices)
+    {
+        var seenKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < devices.Count; i++)
+        {
+            var key = ConfigurationService.GenerateDeviceKey(devices[i]);
+            if (seenKeys.Add(key))
+            {
+                continue;
+            }
+
+            // Collision with an earlier device. Synthesize a unique identifier from the sink
+            // name (PulseAudio guarantees sink names are unique) so this device gets its own key.
+            var device = devices[i];
+            var ids = device.Identifiers ?? new DeviceIdentifiers(null, null, null, null, null, null, null);
+            devices[i] = device with { Identifiers = ids with { BusPath = $"sink:{device.Id}" } };
+
+            var newKey = ConfigurationService.GenerateDeviceKey(devices[i]);
+            seenKeys.Add(newKey);
+            _logger?.LogWarning(
+                "Device '{Name}' (sink '{Sink}') collided on device key '{Key}' with another device " +
+                "and exposes no bus path/serial; assigned synthetic key '{NewKey}' to avoid conflated config (#223).",
+                device.Name, device.Id, key, newKey);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes #223 — connecting two or more identical USB DACs breaks playback entirely; it works again only with a single DAC connected.

## Root cause

Device configuration is keyed by `ConfigurationService.GenerateDeviceKey`, which prioritizes `BusPath > Serial > VendorId+ProductId > SinkName`. Two identical DAC models that expose **no `device.bus_path` and no serial** (common for generic USB DACs) both fall through to `usb_{VendorId}_{ProductId}` — **the same key for both physical devices**.

That single shared key conflates the two devices: their saved config (alias, max volume, hidden, HID buttons) collides, and — critically — `DeviceMatchingService` can no longer tell the two sinks apart, so players get matched to the wrong/same sink and audio breaks. The attached diagnostics show the downstream symptom (buffer overflow / resync churn on the affected sink).

## Fix

Disambiguate at the enumeration source (`PulseAudioDeviceEnumerator.GetOutputDevices`), so **both** the matching path (`DeviceMatchingService` calls the backend directly) and the UI path see distinct devices:

- After enumerating sinks, detect any two devices that produce the same `GenerateDeviceKey`.
- The **first** device with a given key keeps it → existing single-device configs are untouched.
- Each **subsequent** colliding device gets a synthetic `BusPath` (`sink:<sinkname>`) derived from its PulseAudio sink name (which PulseAudio guarantees unique), yielding a distinct `path_…` key.
- A warning is logged per collision so it's visible in diagnostics.

## Trade-off (documented)

For *truly* indistinguishable devices (no bus path, no serial, identical model), the synthetic key is only as stable as the sink name. Across reboots the two configs could swap. This is unavoidable without a hardware-unique identifier — but it's vastly better than the current hard breakage, and single-device setups are completely unaffected.

## Verification

- ✅ Builds clean (0 errors).
- ⚠️ **Needs testing on your 2-DAC hardware.** Please connect both DACs and confirm: both appear as distinct devices, each can be assigned to a player, and playback works on both simultaneously. The new `...collided on device key... assigned synthetic key...` warning in the logs confirms the disambiguation fired (and reveals exactly what your DACs expose).