### PR TITLE
feat: per-sink volume control for custom sinks (#220)

### DIFF
--- a/src/MultiRoomAudio/Controllers/SinksEndpoint.cs
+++ b/src/MultiRoomAudio/Controllers/SinksEndpoint.cs
@@ -128,6 +128,41 @@ public static class SinksEndpoint
         .WithName("CreateRemapSink")
         .WithDescription("Create a remap-sink to extract channels from a multi-channel device");
 
+        // PUT /api/sinks/{name}/volume - Set volume of a custom sink
+        group.MapPut("/{name}/volume", async (
+            string name,
+            SinkVolumeRequest request,
+            CustomSinksService service,
+            ILoggerFactory loggerFactory,
+            CancellationToken ct) =>
+        {
+            var logger = loggerFactory.CreateLogger("SinksEndpoint");
+            logger.LogDebug("API: PUT /api/sinks/{SinkName}/volume - {Volume}%", name, request.Volume);
+            return await ApiExceptionHandler.ExecuteAsync(async () =>
+            {
+                var sink = service.GetSink(name);
+                if (sink == null)
+                    return SinkNotFoundResult(name, logger, "set-volume");
+
+                if (sink.State != CustomSinkState.Loaded)
+                {
+                    return Results.BadRequest(new ErrorResponse(false,
+                        $"Sink '{name}' is not loaded (state: {sink.State}). Volume can only be set on loaded sinks."));
+                }
+
+                var success = await service.SetSinkVolumeAsync(name, request.Volume, ct);
+                if (!success)
+                {
+                    return Results.Problem($"Failed to set volume for sink '{name}'");
+                }
+
+                logger.LogInformation("API: Sink '{SinkName}' volume set to {Volume}%", name, request.Volume);
+                return Results.Ok(new { success = true, name, volume = request.Volume });
+            }, logger, "set-volume", name);
+        })
+        .WithName("SetSinkVolume")
+        .WithDescription("Set the volume (0-100) of a loaded custom sink");
+
         // DELETE /api/sinks/{name} - Delete sink
         group.MapDelete("/{name}", async (
             string name,

--- a/src/MultiRoomAudio/Models/SinkModels.cs
+++ b/src/MultiRoomAudio/Models/SinkModels.cs
@@ -247,6 +247,22 @@ public class CustomSinkConfiguration
     /// Whether to remix (for remap-sink).
     /// </summary>
     public bool Remix { get; set; } = false;
+
+    /// <summary>
+    /// Persisted volume level (0-100). Null means use PulseAudio default (100%).
+    /// Applied automatically after the sink is loaded.
+    /// </summary>
+    public int? Volume { get; set; }
+}
+
+/// <summary>
+/// Request to set volume on a custom sink.
+/// </summary>
+public class SinkVolumeRequest
+{
+    /// <summary>Volume level 0-100.</summary>
+    [Range(0, 100, ErrorMessage = "Volume must be between 0 and 100.")]
+    public int Volume { get; set; }
 }
 
 /// <summary>
@@ -266,7 +282,9 @@ public record CustomSinkResponse(
     // Remap-sink specific
     string? MasterSink = null,
     int? Channels = null,
-    List<ChannelMapping>? ChannelMappings = null
+    List<ChannelMapping>? ChannelMappings = null,
+    // Volume
+    int? Volume = null
 );
 
 /// <summary>

--- a/src/MultiRoomAudio/Services/CustomSinksService.cs
+++ b/src/MultiRoomAudio/Services/CustomSinksService.cs
@@ -19,6 +19,7 @@ public class CustomSinksService : IAsyncDisposable
     private readonly IPaModuleRunner _moduleRunner;
     private readonly EnvironmentService _environment;
     private readonly IServiceProvider _services;
+    private readonly VolumeCommandRunner _volumeRunner;
     private readonly ConcurrentDictionary<string, CustomSinkContext> _sinks = new();
     private readonly string _configPath;
     private readonly IDeserializer _deserializer;
@@ -43,11 +44,13 @@ public class CustomSinksService : IAsyncDisposable
         ILogger<CustomSinksService> logger,
         IPaModuleRunner moduleRunner,
         EnvironmentService environment,
+        VolumeCommandRunner volumeRunner,
         IServiceProvider services)
     {
         _logger = logger;
         _moduleRunner = moduleRunner;
         _environment = environment;
+        _volumeRunner = volumeRunner;
         _services = services;
         _configPath = Path.Combine(environment.ConfigPath, "custom-sinks.yaml");
 
@@ -575,6 +578,13 @@ public class CustomSinksService : IAsyncDisposable
                 context.State = CustomSinkState.Loaded;
                 _logger.LogInformation("Loaded {Type}-sink '{Name}' with module index {Index}",
                     config.Type, config.Name, moduleIndex.Value);
+
+                // Apply persisted volume if set
+                if (config.Volume.HasValue)
+                {
+                    await _volumeRunner.SetVolumeAsync(config.Name, config.Volume.Value, cancellationToken);
+                    _logger.LogInformation("Restored volume of sink '{Name}' to {Volume}%", config.Name, config.Volume.Value);
+                }
             }
             else
             {
@@ -1528,6 +1538,38 @@ public class CustomSinksService : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Set the volume of a loaded custom sink and persist the value.
+    /// </summary>
+    public async Task<bool> SetSinkVolumeAsync(string name, int volume, CancellationToken cancellationToken = default)
+    {
+        if (!_sinks.TryGetValue(name, out var context))
+            return false;
+
+        volume = Math.Clamp(volume, 0, 100);
+
+        var success = await _volumeRunner.SetVolumeAsync(name, volume, cancellationToken);
+        if (success)
+        {
+            context.Config.Volume = volume;
+            SaveConfiguration(context.Config);
+            _logger.LogInformation("Set volume of sink '{Name}' to {Volume}%", name, volume);
+        }
+
+        return success;
+    }
+
+    /// <summary>
+    /// Get the current volume of a custom sink from PulseAudio.
+    /// </summary>
+    public async Task<int?> GetSinkVolumeAsync(string name, CancellationToken cancellationToken = default)
+    {
+        if (!_sinks.TryGetValue(name, out _))
+            return null;
+
+        return await _volumeRunner.GetVolumeAsync(name, cancellationToken);
+    }
+
     private static CustomSinkResponse ToResponse(string name, CustomSinkContext context)
     {
         var config = context.Config;
@@ -1543,7 +1585,8 @@ public class CustomSinksService : IAsyncDisposable
             Slaves: config.Slaves,
             MasterSink: config.MasterSink,
             Channels: config.Type == CustomSinkType.Remap ? config.Channels : null,
-            ChannelMappings: config.ChannelMappings
+            ChannelMappings: config.ChannelMappings,
+            Volume: config.Volume
         );
     }
 

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -2691,6 +2691,22 @@ function renderSinks() {
                             </div>
                         ` : ''}
 
+                        ${isLoaded ? `
+                            <div class="mt-3 sink-volume-row">
+                                <div class="d-flex align-items-center gap-2">
+                                    <i class="fas fa-volume-down text-muted" style="width:14px;"></i>
+                                    <input type="range" class="form-range flex-grow-1" min="0" max="100" step="1"
+                                           id="sink-vol-${escapeHtml(name)}"
+                                           value="${sink.volume != null ? sink.volume : 100}"
+                                           oninput="onSinkVolumeInput(this, '${escapeJsString(name)}')"
+                                           onchange="setSinkVolume('${escapeJsString(name)}', this.value)"
+                                           title="Lautstärke">
+                                    <i class="fas fa-volume-up text-muted" style="width:14px;"></i>
+                                    <span class="text-muted small sink-vol-label" id="sink-vol-label-${escapeHtml(name)}" style="min-width:38px;text-align:right;">${sink.volume != null ? sink.volume : 100}%</span>
+                                </div>
+                            </div>
+                        ` : ''}
+
                         ${sink.errorMessage ? `
                             <div class="mt-2">
                                 <small class="text-danger player-error-message" title="${escapeHtml(sink.errorMessage)}">
@@ -2703,6 +2719,36 @@ function renderSinks() {
             </div>
         `;
     }).join('') + '</div>';
+}
+
+function onSinkVolumeInput(slider, name) {
+    const label = document.getElementById(`sink-vol-label-${name}`);
+    if (label) label.textContent = `${slider.value}%`;
+}
+
+const _sinkVolumeTimers = {};
+
+async function setSinkVolume(name, value) {
+    clearTimeout(_sinkVolumeTimers[name]);
+    _sinkVolumeTimers[name] = setTimeout(async () => {
+        const volume = parseInt(value, 10);
+        try {
+            const resp = await fetch(`./api/sinks/${encodeURIComponent(name)}/volume`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ volume })
+            });
+            if (!resp.ok) {
+                const err = await resp.json().catch(() => ({}));
+                console.error('Failed to set sink volume:', err);
+            } else {
+                // Update local state so re-render keeps value
+                if (customSinks[name]) customSinks[name].volume = volume;
+            }
+        } catch (e) {
+            console.error('Error setting sink volume:', e);
+        }
+    }, 300);
 }
 
 function getSinkStateBadgeClass(state) {


### PR DESCRIPTION
## Summary

Implements **#220** — a per-sink volume slider for custom sinks, so each zone can be balanced independently.

This is a cleaned-up version of **#222** by @heidle78 (authorship preserved on the commit): re-targeted to `dev`, with the accidentally-committed `volume.patch` artifact removed. No functional changes to the contributor's implementation.

## What it does

- `PUT /api/sinks/{name}/volume` — sets volume (0–100) on a *loaded* custom sink.
- Volume is persisted in `custom-sinks.yaml` (`CustomSinkConfiguration.Volume`) and re-applied automatically when the sink loads.
- UI: a debounced volume slider with a live % label on each loaded sink card.

## Review notes

- ✅ **DI verified** — `CustomSinksService` gains a `VolumeCommandRunner` dependency; it's registered as a singleton (Program.cs:105) and `CustomSinksService` is also a singleton, so resolution is clean (no startup failure).
- ✅ Follows existing endpoint conventions (`ApiExceptionHandler`, `ErrorResponse`), validates sink existence + `Loaded` state, clamps 0–100.
- ✅ UI uses `escapeHtml`/`escapeJsString` (XSS-safe per project guidelines).
- ⚠️ Minor: the slider `title` is hardcoded German (`Lautstärke`); rest of the UI is English — worth anglicizing.
- ⚠️ Minor: `GetSinkVolumeAsync` is added but not referenced by any endpoint (latent/dead). Harmless; could be wired to a status read or removed.

## Verification

- ✅ Builds clean (0 errors) against current `dev`.
- ⚠️ Needs a runtime test on real audio hardware (set a custom sink's volume, confirm it applies and survives a reload/restart).

Closes #222 (superseded by this re-targeted branch).