### PR TITLE
fix: header title clipping with long translated titles (#212)

### DIFF
--- a/src/MultiRoomAudio/wwwroot/css/style.css
+++ b/src/MultiRoomAudio/wwwroot/css/style.css
@@ -73,6 +73,15 @@ h1, h2, h3, h4, h5, h6 {
     font-size: 1.5rem;
     font-weight: 600;
     color: var(--header-text);
+    /* Allow long auto-translated titles (e.g. RU "Многокомнатное аудио") to wrap
+       instead of forcing horizontal overflow that clips the header (#212). */
+    overflow-wrap: anywhere;
+}
+
+/* Let the title column shrink so the heading wraps rather than overflowing the
+   row when the action buttons sit alongside it on narrow / ingress-panel widths (#212). */
+.header-gradient .col {
+    min-width: 0;
 }
 
 .header-gradient p {


### PR DESCRIPTION
## Summary

Best-effort fix for **#212** — the header title (`Multi-Room Audio`) is clipped when browser/HA auto-translation swaps in a longer string like Russian `Многокомнатное аудио`.

## Analysis

The title is hardcoded English in `index.html`; the Russian text comes from **browser/HA auto-translation**, not an in-app i18n layer (there isn't one). app.js never touches the `<h1>`, so the reporter's "only during TTS" detail appears to be incidental — the real issue is layout. A long unbreakable translated word forces the Bootstrap flex row wider than the viewport (flex items default to `min-width: auto`), overflowing the `.container` and clipping the title — worst in narrow HA ingress panels.

## Fix (CSS only)

- `overflow-wrap: anywhere` on `.header-gradient h1` — long translated words may wrap.
- `min-width: 0` on `.header-gradient .col` — lets the title column shrink so the heading reflows instead of overflowing.

No layout change at normal widths / English text; the heading only wraps when it would otherwise clip.

## Verification

- ✅ CSS validated (braces balanced); no markup changes.
- ⚠️ **Needs your visual confirmation** — I can't reproduce browser auto-translate + ingress rendering here. Please check the Russian UI header (ideally in the HA ingress panel) shows the full title wrapped, not clipped. If the "during TTS" trigger persists after this, there may be a separate cause worth a fresh repro.

Marked `Re: #212` (not auto-closing) pending your visual confirmation.