### PR TITLE
feat: MQTT → Home Assistant bridge (Phase 2 — amp zones, override, virtual relay)

### DIFF
--- a/docs/superpowers/plans/2026-06-25-mqtt-home-assistant-bridge-phase2.md
+++ b/docs/superpowers/plans/2026-06-25-mqtt-home-assistant-bridge-phase2.md
@@ -1,0 +1,1439 @@
+# MQTT → Home Assistant Bridge — Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose the 12V amp/relay zones to Home Assistant (status + sticky manual-override switch), add a software `VirtualRelayBoard` whose power state HA can mirror onto a smart outlet, and let HAOS users enable MQTT from the add-on configuration.
+
+**Architecture:** All override/event logic lives in `TriggerService` (above the board layer) so it works for every board type uniformly. A new `TriggersChanged` event drives MQTT amp publishing the same way Phase 1's `PlayersChanged` drives player publishing. The virtual board is a software `IRelayBoard` (like `MockRelayBoard`) with no MQTT dependency — its power state reaches HA through the normal amp-state publish. Pure builders (topics/discovery/state/command) are extended and unit-tested; the `MqttService` glue subscribes to the new event and dispatches the new override command.
+
+**Tech Stack:** .NET 8, ASP.NET Core minimal APIs, MQTTnet v5, YamlDotNet, xUnit.
+
+**Builds on:** Phase 1 (merged to `dev` via PR #235). This branch `feat/mqtt-ha-bridge-phase2` is based off `dev`.
+
+## Global Constraints
+
+- **Target framework:** .NET 8.0, `Nullable` enabled, `ImplicitUsings` enabled. Microsoft C# conventions. XML doc comments on public APIs.
+- **Non-blocking startup (hard rule):** No MQTT/trigger failure may block the UI. The existing `mqtt` `StartupOrchestrator` phase runs after `triggers`; do not add a new phase. The `TriggersChanged` publish handler and all MQTT async handlers must never throw into their callers.
+- **Sticky override semantics:** override ON = force relay on + suspend auto-logic for that channel (no auto-off); override OFF (release) = re-evaluate auto — stay on if `ActivePlayerCount > 0`, else start the channel's normal off-delay.
+- **Virtual board:** software-only `IRelayBoard`, always `IsConnected`, no MQTT calls in the relay layer. `BoardId` is `VIRTUAL:<id>`, generated once and persisted. Created by BOTH factories.
+- **Config precedence:** env var → HAOS option → yaml → default. Docker uses `MQTT_*` env vars (unchanged). HAOS uses snake_case option keys (`mqtt_enabled`, `mqtt_host`, `mqtt_port`, `mqtt_username`, `mqtt_password`, `mqtt_tls`).
+- **Dropped from scope:** the per-player `sync_error_ms` sensor.
+- **Do not** change the default web port (8096) or enable trimming. Vanilla JS only for UI.
+- **Tests:** xUnit, in `tests/MultiRoomAudio.Tests/`. Internals already visible via `InternalsVisibleTo`.
+- **Commits:** Conventional Commits. Author as the repo owner — no AI/Claude self-reference, no `Co-Authored-By`.
+
+## File Structure
+
+**Modify:**
+- `src/MultiRoomAudio/Models/TriggerModels.cs` — add `RelayBoardType.Virtual`; add `bool IsOverridden` to `TriggerResponse`.
+- `src/MultiRoomAudio/Services/TriggerService.cs` — `IsOverridden` channel state, `SetOverride`, auto-logic guards, `TriggersChanged` event, populate `IsOverridden` in `GetBoardStatus`, `VIRTUAL:` type inference + connect branch.
+- `src/MultiRoomAudio/Relay/RealRelayBoardFactory.cs`, `MockRelayBoardFactory.cs` — create `VirtualRelayBoard` for `RelayBoardType.Virtual`.
+- `src/MultiRoomAudio/Mqtt/MqttTopics.cs` — amp topics.
+- `src/MultiRoomAudio/Mqtt/MqttStatePayloads.cs` — `Amp(...)`.
+- `src/MultiRoomAudio/Mqtt/HaDiscovery.cs` — `ForAmp(...)`.
+- `src/MultiRoomAudio/Mqtt/MqttCommand.cs` — amp override parsing.
+- `src/MultiRoomAudio/Services/MqttService.cs` — `TriggerService` dep, `TriggersChanged` subscription, amp publish + command dispatch.
+- `src/MultiRoomAudio/Services/MqttConfigService.cs` — snake_case HAOS keys.
+- `src/MultiRoomAudio/Controllers/TriggersEndpoint.cs` — override endpoint + virtual board add.
+- `src/MultiRoomAudio/wwwroot/js/app.js` (and any trigger UI partial) — virtual board + override controls.
+- `multiroom-audio/config.yaml` — MQTT options/schema.
+
+**Create:**
+- `src/MultiRoomAudio/Relay/VirtualRelayBoard.cs`
+- Tests: `tests/MultiRoomAudio.Tests/Mqtt/AmpTopicsTests.cs`, `AmpStatePayloadsTests.cs`, `AmpDiscoveryTests.cs`, `AmpCommandTests.cs`; `tests/MultiRoomAudio.Tests/Relay/VirtualRelayBoardTests.cs`; `tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs`; add HAOS-key case to the existing `MqttConfigServiceTests.cs`.
+
+---
+
+### Task 1: Models — `RelayBoardType.Virtual` + `TriggerResponse.IsOverridden`
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Models/TriggerModels.cs`
+- Test: `tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs` (created here, asserts the record default)
+
+**Interfaces:**
+- Produces: `RelayBoardType.Virtual` enum member; `TriggerResponse` gains a trailing `bool IsOverridden = false` parameter.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs`:
+
+```csharp
+using MultiRoomAudio.Models;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Services;
+
+public class TriggerModelsTests
+{
+    [Fact]
+    public void TriggerResponse_IsOverridden_DefaultsFalse()
+    {
+        var r = new TriggerResponse(
+            Channel: 1, CustomSinkName: null, CustomSinkDisplayName: null,
+            OffDelaySeconds: 60, ZoneName: null, RelayState: RelayState.Off,
+            IsActive: false, LastActivated: null, ScheduledOffTime: null);
+        Assert.False(r.IsOverridden);
+    }
+
+    [Fact]
+    public void RelayBoardType_HasVirtual()
+        => Assert.True(System.Enum.IsDefined(typeof(RelayBoardType), RelayBoardType.Virtual));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter TriggerModelsTests`
+Expected: FAIL — `RelayBoardType.Virtual` doesn't exist and `TriggerResponse` has no `IsOverridden`.
+
+- [ ] **Step 3: Add the enum member**
+
+In `src/MultiRoomAudio/Models/TriggerModels.cs`, in the `RelayBoardType` enum, add after `Lcus`:
+
+```csharp
+    /// <summary>Software-only virtual board; power state is published over MQTT for HA to mirror onto a smart outlet.</summary>
+    Virtual,
+```
+
+(Keep `Mock` last or add `Virtual` before `Mock` — order doesn't matter, but do not renumber existing members by inserting in the middle if any persisted config relies on integer values; YAML persists enum names, so appending is safe.)
+
+- [ ] **Step 4: Add `IsOverridden` to `TriggerResponse`**
+
+In the `TriggerResponse` record, add a trailing parameter (after `ScheduledOffTime`):
+
+```csharp
+public record TriggerResponse(
+    int Channel,
+    string? CustomSinkName,
+    string? CustomSinkDisplayName,
+    int OffDelaySeconds,
+    string? ZoneName,
+    RelayState RelayState,
+    bool IsActive,
+    DateTime? LastActivated,
+    DateTime? ScheduledOffTime,
+    bool IsOverridden = false
+);
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter TriggerModelsTests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/MultiRoomAudio/Models/TriggerModels.cs tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs
+git commit -m "feat: add Virtual relay board type and TriggerResponse.IsOverridden"
+```
+
+---
+
+### Task 2: TriggerService — sticky override, auto-logic guard, `TriggersChanged` event
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Services/TriggerService.cs`
+- Test: `tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs` (add cases)
+
+**Interfaces:**
+- Consumes: `RelayBoardType.Virtual`, `TriggerResponse.IsOverridden` (Task 1).
+- Produces:
+  - `public event Action? TriggersChanged;`
+  - `public bool SetOverride(string boardId, int channel, bool on)`
+  - `TriggerChannelState` (private) gains `public bool IsOverridden { get; set; }`
+  - `GetBoardStatus` populates `TriggerResponse.IsOverridden` from channel state.
+
+**Context for the implementer:** The auto-logic methods are `ActivateTrigger` (line ~1068), `DeactivateTrigger` (~1104), and `OnOffTimerElapsed` (~1170). `CancelOffTimer` (~1160) and `StartOffTimer` (~1146) manage the off-delay `System.Timers.Timer`. `_channelStates` is a `ConcurrentDictionary<(string BoardId, int Channel), TriggerChannelState>`. `_stateLock` guards state mutations. The channel's configured off-delay is `boardConfig.Triggers.FirstOrDefault(t => t.Channel == channel)?.OffDelaySeconds ?? 60`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs`:
+
+```csharp
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using MultiRoomAudio.Relay;
+using MultiRoomAudio.Services;
+
+public class TriggerOverrideBehaviorTests
+{
+    // Builds a TriggerService in mock mode with one virtual board + one configured channel.
+    private static async Task<(TriggerService svc, string boardId)> SetupAsync()
+    {
+        var svc = TriggerTestHarness.CreateMockService();
+        svc.SetEnabled(true);
+        var boardId = "VIRTUAL:test01";
+        svc.AddBoard(boardId, "Test Zone", channelCount: 2, boardType: RelayBoardType.Virtual);
+        svc.ConfigureTrigger(boardId, channel: 1, customSinkName: "sink1", offDelaySeconds: 30, zoneName: "Zone 1");
+        await Task.CompletedTask;
+        return (svc, boardId);
+    }
+
+    [Fact]
+    public async Task Override_On_ForcesRelayOn_AndReportsOverridden()
+    {
+        var (svc, boardId) = await SetupAsync();
+        Assert.True(svc.SetOverride(boardId, 1, true));
+
+        var ch = svc.GetBoardStatus(boardId)!.Triggers.Single(t => t.Channel == 1);
+        Assert.Equal(RelayState.On, ch.RelayState);
+        Assert.True(ch.IsOverridden);
+    }
+
+    [Fact]
+    public async Task Override_Suspends_AutoOff_WhilePlaybackStops()
+    {
+        var (svc, boardId) = await SetupAsync();
+        svc.OnPlayerStarted("p1", "sink1");     // auto-on
+        svc.SetOverride(boardId, 1, true);      // grab manual control
+        svc.OnPlayerStopped("p1", "sink1");     // would normally schedule off
+
+        var ch = svc.GetBoardStatus(boardId)!.Triggers.Single(t => t.Channel == 1);
+        Assert.Equal(RelayState.On, ch.RelayState);   // still on — auto-off suppressed
+        Assert.True(ch.IsOverridden);
+        Assert.Null(ch.ScheduledOffTime);             // no off-timer scheduled
+    }
+
+    [Fact]
+    public async Task Release_WhileIdle_SchedulesOff()
+    {
+        var (svc, boardId) = await SetupAsync();
+        svc.SetOverride(boardId, 1, true);   // on, no players
+        svc.SetOverride(boardId, 1, false);  // release while idle
+
+        var ch = svc.GetBoardStatus(boardId)!.Triggers.Single(t => t.Channel == 1);
+        Assert.False(ch.IsOverridden);
+        Assert.NotNull(ch.ScheduledOffTime);  // off-delay started
+    }
+
+    [Fact]
+    public async Task Release_WhilePlaying_StaysOn_NoOffTimer()
+    {
+        var (svc, boardId) = await SetupAsync();
+        svc.OnPlayerStarted("p1", "sink1");
+        svc.SetOverride(boardId, 1, true);
+        svc.SetOverride(boardId, 1, false);  // release with a player still active
+
+        var ch = svc.GetBoardStatus(boardId)!.Triggers.Single(t => t.Channel == 1);
+        Assert.Equal(RelayState.On, ch.RelayState);
+        Assert.Null(ch.ScheduledOffTime);
+    }
+
+    [Fact]
+    public async Task TriggersChanged_FiresOnOverride()
+    {
+        var (svc, boardId) = await SetupAsync();
+        int fires = 0;
+        svc.TriggersChanged += () => fires++;
+        svc.SetOverride(boardId, 1, true);
+        Assert.True(fires >= 1);
+    }
+}
+```
+
+- [ ] **Step 2: Add the test harness helper**
+
+Create `tests/MultiRoomAudio.Tests/Services/TriggerTestHarness.cs`:
+
+```csharp
+using Microsoft.Extensions.Logging.Abstractions;
+using MultiRoomAudio.Relay;
+using MultiRoomAudio.Services;
+
+namespace MultiRoomAudio.Tests.Services;
+
+/// <summary>Builds a TriggerService wired entirely to mock/in-memory dependencies for unit tests.</summary>
+internal static class TriggerTestHarness
+{
+    public static TriggerService CreateMockService()
+    {
+        var loggerFactory = NullLoggerFactory.Instance;
+        var env = new EnvironmentService(NullLogger<EnvironmentService>.Instance);
+        var sinks = new CustomSinksService(/* see note */ );
+        var enumerator = new MockRelayDeviceEnumerator(loggerFactory.CreateLogger<MockRelayDeviceEnumerator>());
+        var factory = new MockRelayBoardFactory(loggerFactory);
+        return new TriggerService(
+            loggerFactory.CreateLogger<TriggerService>(),
+            loggerFactory, sinks, env, enumerator, factory, hubContext: null);
+    }
+}
+```
+
+**Implementer note:** `CustomSinksService`'s constructor may require arguments — read `src/MultiRoomAudio/Services/CustomSinksService.cs` and construct it with the minimal mock/null dependencies it needs (the override tests do not exercise real sinks; `ConfigureTrigger` only stores the sink *name*). If `CustomSinksService` is hard to construct in isolation, instead have the harness use a temporary `EnvironmentService` config dir (env var `CONFIG_PATH` pointed at a temp folder) so `TriggerService` writes its `triggers.yaml` there. Keep the harness minimal and document what you wired.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter TriggerOverrideBehaviorTests`
+Expected: FAIL — `SetOverride` and `TriggersChanged` don't exist.
+
+- [ ] **Step 4: Add `IsOverridden` to `TriggerChannelState`**
+
+In `TriggerService.cs`, in the private `TriggerChannelState` class (line ~46), add:
+
+```csharp
+        public bool IsOverridden { get; set; }
+```
+
+- [ ] **Step 5: Add the `TriggersChanged` event and a raise helper**
+
+Near the other fields/events at the top of `TriggerService`, add:
+
+```csharp
+    /// <summary>
+    /// Raised whenever a relay/channel or board state changes (auto on/off, off-timer,
+    /// manual control, override, connect/disconnect). The MQTT bridge subscribes to
+    /// publish amp state without polling.
+    /// </summary>
+    public event Action? TriggersChanged;
+
+    private void RaiseTriggersChanged() => TriggersChanged?.Invoke();
+```
+
+- [ ] **Step 6: Guard the auto-logic against overridden channels, and raise the event**
+
+In `ActivateTrigger`, inside the `lock (_stateLock)`, after `CancelOffTimer(...)` and the count increment, wrap the relay-on so an overridden channel is left to manual control (it's already on). Replace the `if (!state.IsActive) { ... }` block's body so it still sets `IsActive` but skips a redundant `SetRelay` when overridden is harmless — the key guards are in the OFF paths. At the END of the method (after the lock), add `RaiseTriggersChanged();`.
+
+In `DeactivateTrigger`, guard the off path. Change:
+
+```csharp
+            if (state.ActivePlayerCount == 0 && state.IsActive)
+            {
+```
+to:
+```csharp
+            if (state.IsOverridden)
+            {
+                // Manual override holds the relay on; auto-off is suspended until released.
+            }
+            else if (state.ActivePlayerCount == 0 && state.IsActive)
+            {
+```
+At the end of the method (after the lock), add `RaiseTriggersChanged();`.
+
+In `OnOffTimerElapsed`, add the override guard at the top of the `lock`:
+
+```csharp
+        lock (_stateLock)
+        {
+            if (state.IsOverridden)
+                return;   // override holds the relay on
+            if (state.ActivePlayerCount == 0 && state.IsActive)
+            { ... existing ... }
+```
+After the lock, add `RaiseTriggersChanged();`.
+
+- [ ] **Step 7: Add `SetOverride`**
+
+Add this public method (near `ManualControl`):
+
+```csharp
+    /// <summary>
+    /// Sticky manual override for a channel. ON forces the relay on and suspends the
+    /// playback auto-logic for that channel; OFF releases back to auto (stays on if a
+    /// player is active, otherwise starts the configured off-delay).
+    /// </summary>
+    public bool SetOverride(string boardId, int channel, bool on)
+    {
+        var boardConfig = _config.Boards.FirstOrDefault(b => b.BoardId == boardId);
+        if (boardConfig == null)
+            throw new ArgumentException($"Board '{boardId}' not found", nameof(boardId));
+        if (channel < 1 || channel > boardConfig.ChannelCount)
+            throw new ArgumentOutOfRangeException(nameof(channel), $"Channel must be between 1 and {boardConfig.ChannelCount}");
+
+        if (!_channelStates.TryGetValue((boardId, channel), out var state))
+            return false;
+
+        var offDelay = boardConfig.Triggers.FirstOrDefault(t => t.Channel == channel)?.OffDelaySeconds ?? 60;
+
+        lock (_stateLock)
+        {
+            if (on)
+            {
+                CancelOffTimer(boardId, channel);
+                state.IsOverridden = true;
+                state.IsActive = true;
+                var board = TryGetOrReconnectBoard(boardId);
+                board?.SetRelay(channel, true);
+                _logger.LogInformation("Override ON: Board '{BoardId}' channel {Channel} (auto-logic suspended)", boardId, channel);
+            }
+            else
+            {
+                state.IsOverridden = false;
+                if (state.ActivePlayerCount > 0)
+                {
+                    // A player is still active — keep it on, ensure relay reflects that.
+                    state.IsActive = true;
+                    TryGetOrReconnectBoard(boardId)?.SetRelay(channel, true);
+                    _logger.LogInformation("Override released: Board '{BoardId}' channel {Channel} → stays ON (active playback)", boardId, channel);
+                }
+                else if (state.IsActive)
+                {
+                    if (offDelay <= 0)
+                    {
+                        state.IsActive = false;
+                        TryGetOrReconnectBoard(boardId)?.SetRelay(channel, false);
+                    }
+                    else
+                    {
+                        StartOffTimer(boardId, channel, offDelay);
+                    }
+                    _logger.LogInformation("Override released: Board '{BoardId}' channel {Channel} → returning to auto (off in {Delay}s)", boardId, channel, offDelay);
+                }
+            }
+        }
+
+        RaiseTriggersChanged();
+        return true;
+    }
+```
+
+- [ ] **Step 8: Populate `IsOverridden` in `GetBoardStatus`**
+
+In `GetBoardStatus`, in the `new TriggerResponse(...)` construction (line ~231), add the trailing argument:
+
+```csharp
+                ScheduledOffTime: channelState.OffDelayTimer?.Enabled == true
+                    ? channelState.LastActivated?.AddSeconds(config.OffDelaySeconds)
+                    : null,
+                IsOverridden: channelState.IsOverridden
+```
+
+- [ ] **Step 9: Run tests to verify they pass**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter "TriggerOverrideBehaviorTests|TriggerModelsTests"`
+Expected: PASS (all). If the harness needs adjustment for `CustomSinksService`, fix per the Step 2 note until green.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/MultiRoomAudio/Services/TriggerService.cs tests/MultiRoomAudio.Tests/Services/
+git commit -m "feat: add sticky relay override and TriggersChanged event to TriggerService"
+```
+
+---
+
+### Task 3: `VirtualRelayBoard` + factory/connect wiring
+
+**Files:**
+- Create: `src/MultiRoomAudio/Relay/VirtualRelayBoard.cs`
+- Modify: `src/MultiRoomAudio/Relay/RealRelayBoardFactory.cs`, `src/MultiRoomAudio/Relay/MockRelayBoardFactory.cs`, `src/MultiRoomAudio/Services/TriggerService.cs` (type inference + connect branch)
+- Test: `tests/MultiRoomAudio.Tests/Relay/VirtualRelayBoardTests.cs`
+
+**Interfaces:**
+- Consumes: `IRelayBoard`, `RelayBoardType.Virtual` (Task 1).
+- Produces: `VirtualRelayBoard : IRelayBoard` (always `IsConnected` after `Open()`), created by both factories for `RelayBoardType.Virtual`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/MultiRoomAudio.Tests/Relay/VirtualRelayBoardTests.cs`:
+
+```csharp
+using MultiRoomAudio.Models;
+using MultiRoomAudio.Relay;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Relay;
+
+public class VirtualRelayBoardTests
+{
+    [Fact]
+    public void SetAndGet_RoundTrips()
+    {
+        var b = new VirtualRelayBoard(serialNumber: "VIRTUAL:x", channelCount: 4);
+        Assert.True(b.Open());
+        Assert.True(b.IsConnected);
+        Assert.True(b.SetRelay(2, true));
+        Assert.Equal(RelayState.On, b.GetRelay(2));
+        Assert.Equal(RelayState.Off, b.GetRelay(1));
+        Assert.Equal(0b10, b.CurrentState);
+    }
+
+    [Fact]
+    public void AllOff_ClearsState()
+    {
+        var b = new VirtualRelayBoard(serialNumber: "VIRTUAL:x", channelCount: 4);
+        b.Open();
+        b.SetRelay(1, true);
+        Assert.True(b.AllOff());
+        Assert.Equal(0, b.CurrentState);
+    }
+
+    [Fact]
+    public void RealFactory_CreatesVirtualBoard()
+    {
+        var f = new RealRelayBoardFactory(Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance);
+        Assert.True(f.CanCreate("VIRTUAL:x", RelayBoardType.Virtual));
+        var board = f.CreateBoard("VIRTUAL:x", RelayBoardType.Virtual);
+        Assert.IsType<VirtualRelayBoard>(board);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter VirtualRelayBoardTests`
+Expected: FAIL — `VirtualRelayBoard` doesn't exist.
+
+- [ ] **Step 3: Implement `VirtualRelayBoard`**
+
+Create `src/MultiRoomAudio/Relay/VirtualRelayBoard.cs`:
+
+```csharp
+using MultiRoomAudio.Models;
+
+namespace MultiRoomAudio.Relay;
+
+/// <summary>
+/// Software-only relay board. Records channel state in memory and is always ready once opened.
+/// Its power state reaches Home Assistant through the normal amp-state publish (driven by
+/// TriggerService.TriggersChanged) — there is no MQTT dependency in the relay layer itself.
+/// </summary>
+public sealed class VirtualRelayBoard : IRelayBoard
+{
+    private readonly ILogger<VirtualRelayBoard>? _logger;
+    private readonly string _serialNumber;
+    private readonly int _channelCount;
+    private readonly bool[] _states = new bool[16];
+    private bool _isConnected;
+    private bool _disposed;
+
+    public VirtualRelayBoard(ILogger<VirtualRelayBoard>? logger = null, string? serialNumber = null, int channelCount = 8)
+    {
+        _logger = logger;
+        _serialNumber = serialNumber ?? "VIRTUAL";
+        _channelCount = Math.Clamp(channelCount, 1, 16);
+    }
+
+    public bool IsConnected => _isConnected;
+    public string? SerialNumber => _serialNumber;
+    public int ChannelCount => _channelCount;
+
+    public int CurrentState
+    {
+        get
+        {
+            int s = 0;
+            for (int i = 0; i < _channelCount; i++)
+                if (_states[i]) s |= (1 << i);
+            return s;
+        }
+    }
+
+    public bool Open()
+    {
+        if (_disposed) return false;
+        _isConnected = true;
+        return true;
+    }
+
+    public bool OpenBySerial(string serialNumber) => Open();
+
+    public void Close() => _isConnected = false;
+
+    public bool SetRelay(int channel, bool on)
+    {
+        if (!_isConnected || channel < 1 || channel > _channelCount) return false;
+        _states[channel - 1] = on;
+        _logger?.LogDebug("Virtual relay '{Serial}' channel {Channel} → {State}", _serialNumber, channel, on ? "ON" : "OFF");
+        return true;
+    }
+
+    public RelayState GetRelay(int channel)
+    {
+        if (!_isConnected || channel < 1 || channel > _channelCount) return RelayState.Unknown;
+        return _states[channel - 1] ? RelayState.On : RelayState.Off;
+    }
+
+    public bool AllOff()
+    {
+        if (!_isConnected) return false;
+        Array.Clear(_states);
+        return true;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _isConnected = false;
+    }
+}
+```
+
+- [ ] **Step 4: Wire both factories**
+
+In `RealRelayBoardFactory.CreateBoard`, add a switch arm before the default:
+
+```csharp
+            RelayBoardType.Virtual => new VirtualRelayBoard(_loggerFactory.CreateLogger<VirtualRelayBoard>(), boardId),
+```
+In `RealRelayBoardFactory.CanCreate`, add:
+```csharp
+            RelayBoardType.Virtual => true, // software board, always available
+```
+
+In `MockRelayBoardFactory.CreateBoard`, before the `return new MockRelayBoard(...)`, add:
+
+```csharp
+        if (boardType == RelayBoardType.Virtual)
+            return new VirtualRelayBoard(_loggerFactory.CreateLogger<VirtualRelayBoard>(), boardId, channelCount);
+```
+(`CanCreate` already returns true for any type in the mock factory.)
+
+- [ ] **Step 5: Teach `TriggerService` about `VIRTUAL:` IDs**
+
+In `AddBoard` (type inference block ~322) and in the `ConnectBoard` inference block (~742), add a `VIRTUAL:` branch so an unspecified type resolves correctly:
+
+```csharp
+            else if (boardId.StartsWith("VIRTUAL:", StringComparison.OrdinalIgnoreCase))
+                boardType = RelayBoardType.Virtual;
+```
+(Place it alongside the existing `HID:`/`MODBUS:` checks, before the `else { boardType = Ftdi; }`.)
+
+In the `ConnectBoard` connect-branch chain (the `if (boardId.StartsWith("HID:"...))` ladder ~769), add a branch:
+
+```csharp
+            else if (boardId.StartsWith("VIRTUAL:", StringComparison.OrdinalIgnoreCase))
+            {
+                connected = board.Open();
+            }
+```
+(Place it before the final `else` FTDI-serial branch.)
+
+- [ ] **Step 6: Run tests + build**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter VirtualRelayBoardTests`
+Expected: PASS.
+Run: `dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj -c Debug`
+Expected: 0 errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/MultiRoomAudio/Relay/ src/MultiRoomAudio/Services/TriggerService.cs tests/MultiRoomAudio.Tests/Relay/
+git commit -m "feat: add VirtualRelayBoard and factory/connect wiring"
+```
+
+---
+
+### Task 4: Triggers API — override endpoint + virtual board add
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Controllers/TriggersEndpoint.cs`
+
+**Interfaces:**
+- Consumes: `TriggerService.SetOverride`, `AddBoard` (Task 2/existing).
+- Produces: `PUT /api/triggers/boards/{boardId}/{channel}/override` and virtual-board support in the add-board endpoint.
+
+**Context:** Read `src/MultiRoomAudio/Controllers/TriggersEndpoint.cs` first to match its exact minimal-API idiom (route group, parameter binding, response shape, how `{boardId}` is bound/decoded). The existing add-board endpoint maps to `TriggerService.AddBoard(boardId, displayName, channelCount, boardType)`. The existing test relay route `POST .../{channel}/test` calls `ManualControl` — mirror its structure for the override route.
+
+- [ ] **Step 1: Add the override endpoint**
+
+In the trigger route group, add (matching the file's existing style for body binding and responses):
+
+```csharp
+        group.MapPut("/boards/{boardId}/{channel:int}/override", (string boardId, int channel, RelayManualControlRequest request, TriggerService triggers) =>
+        {
+            try
+            {
+                var ok = triggers.SetOverride(Uri.UnescapeDataString(boardId), channel, request.On);
+                return ok
+                    ? Results.Ok(new { success = true, message = $"Override {(request.On ? "engaged" : "released")}.", boardId, channel, on = request.On })
+                    : Results.BadRequest(new ErrorResponse(false, "Board not connected or channel unavailable."));
+            }
+            catch (ArgumentException ex) { return Results.BadRequest(new ErrorResponse(false, ex.Message)); }
+        })
+        .WithTags("Triggers").WithName("SetTriggerOverride");
+```
+(Reuse the existing `RelayManualControlRequest` — it already carries a `bool On`. If the file binds `boardId` without URL-decoding elsewhere, match that; the snippet decodes defensively.)
+
+- [ ] **Step 2: Allow virtual boards in the add-board endpoint**
+
+Locate the existing `POST /api/triggers/boards` handler. It binds an `AddBoardRequest` (fields `BoardId`, `DisplayName`, `BoardType`, `ChannelCount`). For a virtual board the client sends `BoardType = Virtual` and may leave `BoardId` empty; generate a stable id server-side when missing/virtual. Add, at the top of the handler body:
+
+```csharp
+            var boardId = request.BoardId;
+            if (request.BoardType == RelayBoardType.Virtual && string.IsNullOrWhiteSpace(boardId))
+                boardId = $"VIRTUAL:{Guid.NewGuid():N}".Substring(0, 16);
+```
+Then call `AddBoard(boardId, request.DisplayName, request.ChannelCount, request.BoardType)` using this `boardId`. Keep the rest of the handler (validation, response) as-is. If the handler currently rejects empty `BoardId` before this point, move the generation above that check.
+
+- [ ] **Step 3: Build + smoke**
+
+Run: `dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj -c Debug`
+Expected: 0 errors.
+Optional runtime smoke (`MOCK_HARDWARE=true dotnet run ...`): `POST /api/triggers/boards` with `{"boardType":"Virtual","displayName":"Test","channelCount":2}` returns success and a `VIRTUAL:` board appears in `GET /api/triggers`; `PUT /api/triggers/boards/{id}/1/override` with `{"on":true}` returns success. Kill the app after. If runtime isn't feasible, verify by build + code inspection and note it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/MultiRoomAudio/Controllers/TriggersEndpoint.cs
+git commit -m "feat: add trigger override endpoint and virtual board creation"
+```
+
+---
+
+### Task 5: `MqttTopics` — amp topics
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Mqtt/MqttTopics.cs`
+- Test: `tests/MultiRoomAudio.Tests/Mqtt/AmpTopicsTests.cs`
+
+**Interfaces:**
+- Consumes: existing `MqttTopics` (ctor `(baseTopic, discoveryPrefix)`, `Sanitize`).
+- Produces: `AmpStateTopic(string boardId, int channel)`, `AmpCommandTopic(string boardId, int channel, string command)`, `string AmpCommandSubscription`. Zone key = `Sanitize(boardId)_<channel>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/MultiRoomAudio.Tests/Mqtt/AmpTopicsTests.cs`:
+
+```csharp
+using MultiRoomAudio.Mqtt;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Mqtt;
+
+public class AmpTopicsTests
+{
+    private readonly MqttTopics _t = new("multiroom-audio", "homeassistant");
+
+    [Fact]
+    public void AmpState_UsesSanitizedBoardAndChannel()
+        => Assert.Equal("multiroom-audio/amp/virtual_x_1/state", _t.AmpStateTopic("VIRTUAL:x", 1));
+
+    [Fact]
+    public void AmpCommand_AppendsSetSuffix()
+        => Assert.Equal("multiroom-audio/amp/virtual_x_1/override/set", _t.AmpCommandTopic("VIRTUAL:x", 1, "override"));
+
+    [Fact]
+    public void AmpCommandSubscription_IsWildcard()
+        => Assert.Equal("multiroom-audio/amp/+/+/set", _t.AmpCommandSubscription);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter AmpTopicsTests`
+Expected: FAIL — methods don't exist.
+
+- [ ] **Step 3: Implement**
+
+In `MqttTopics.cs` add:
+
+```csharp
+    private string AmpZone(string boardId, int channel) => $"{Sanitize(boardId)}_{channel}";
+
+    /// <summary>State topic for an amp/zone (one JSON document per zone).</summary>
+    public string AmpStateTopic(string boardId, int channel) => $"{_base}/amp/{AmpZone(boardId, channel)}/state";
+
+    /// <summary>Command topic for an amp/zone control (e.g. "override").</summary>
+    public string AmpCommandTopic(string boardId, int channel, string command) =>
+        $"{_base}/amp/{AmpZone(boardId, channel)}/{command}/set";
+
+    /// <summary>Single wildcard subscription covering all amp command topics.</summary>
+    public string AmpCommandSubscription => $"{_base}/amp/+/+/set";
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter AmpTopicsTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/MultiRoomAudio/Mqtt/MqttTopics.cs tests/MultiRoomAudio.Tests/Mqtt/AmpTopicsTests.cs
+git commit -m "feat: add MQTT amp topic helpers"
+```
+
+---
+
+### Task 6: `MqttStatePayloads.Amp`
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Mqtt/MqttStatePayloads.cs`
+- Test: `tests/MultiRoomAudio.Tests/Mqtt/AmpStatePayloadsTests.cs`
+
+**Interfaces:**
+- Consumes: `TriggerResponse` (with `IsOverridden`, `RelayState`, `ScheduledOffTime`).
+- Produces: `static string Amp(TriggerResponse t, bool boardConnected)` → JSON `{ power, scheduled_off, override, board_connected }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/MultiRoomAudio.Tests/Mqtt/AmpStatePayloadsTests.cs`:
+
+```csharp
+using System.Text.Json;
+using MultiRoomAudio.Models;
+using MultiRoomAudio.Mqtt;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Mqtt;
+
+public class AmpStatePayloadsTests
+{
+    private static TriggerResponse Zone(RelayState s, bool overridden) => new(
+        Channel: 1, CustomSinkName: "sink", CustomSinkDisplayName: "Sink",
+        OffDelaySeconds: 30, ZoneName: "Living Room", RelayState: s,
+        IsActive: s == RelayState.On, LastActivated: null, ScheduledOffTime: null,
+        IsOverridden: overridden);
+
+    [Fact]
+    public void Amp_SerializesPowerOverrideAndConnectivity()
+    {
+        using var doc = JsonDocument.Parse(MqttStatePayloads.Amp(Zone(RelayState.On, overridden: true), boardConnected: true));
+        var root = doc.RootElement;
+        Assert.Equal("ON", root.GetProperty("power").GetString());
+        Assert.Equal("ON", root.GetProperty("override").GetString());
+        Assert.Equal("ON", root.GetProperty("board_connected").GetString());
+    }
+
+    [Fact]
+    public void Amp_PowerOff_WhenRelayOff()
+    {
+        using var doc = JsonDocument.Parse(MqttStatePayloads.Amp(Zone(RelayState.Off, overridden: false), boardConnected: false));
+        var root = doc.RootElement;
+        Assert.Equal("OFF", root.GetProperty("power").GetString());
+        Assert.Equal("OFF", root.GetProperty("override").GetString());
+        Assert.Equal("OFF", root.GetProperty("board_connected").GetString());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter AmpStatePayloadsTests`
+Expected: FAIL — `Amp` doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+In `MqttStatePayloads.cs` add (the `OnOff` helper already exists in the class):
+
+```csharp
+    /// <summary>Per-amp/zone state document. RelayState.On → power ON; Unknown → OFF.</summary>
+    public static string Amp(MultiRoomAudio.Models.TriggerResponse t, bool boardConnected) => JsonSerializer.Serialize(new
+    {
+        power = OnOff(t.RelayState == MultiRoomAudio.Models.RelayState.On),
+        scheduled_off = t.ScheduledOffTime,
+        @override = OnOff(t.IsOverridden),
+        board_connected = OnOff(boardConnected),
+    });
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter AmpStatePayloadsTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/MultiRoomAudio/Mqtt/MqttStatePayloads.cs tests/MultiRoomAudio.Tests/Mqtt/AmpStatePayloadsTests.cs
+git commit -m "feat: add MQTT amp state payload builder"
+```
+
+---
+
+### Task 7: `HaDiscovery.ForAmp`
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Mqtt/HaDiscovery.cs`
+- Test: `tests/MultiRoomAudio.Tests/Mqtt/AmpDiscoveryTests.cs`
+
+**Interfaces:**
+- Consumes: `MqttTopics` (amp topics from Task 5), `TriggerResponse`.
+- Produces: `IReadOnlyList<DiscoveryMessage> ForAmp(string boardId, string? boardDisplayName, TriggerResponse t)` — four entities (power binary_sensor, scheduled-off sensor, override switch w/ command_topic, board-connected diagnostic binary_sensor) sharing device id `mra_amp_<sanitized boardId>_<channel>`.
+
+**Context:** Mirror the existing `ForPlayer`/`ForContainer` structure (the private `Build(...)` helper and `Device(...)` callback already exist and produce the device block + availability fields). Reuse them.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/MultiRoomAudio.Tests/Mqtt/AmpDiscoveryTests.cs`:
+
+```csharp
+using System.Linq;
+using System.Text.Json;
+using MultiRoomAudio.Models;
+using MultiRoomAudio.Mqtt;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Mqtt;
+
+public class AmpDiscoveryTests
+{
+    private readonly HaDiscovery _d = new(new MqttTopics("multiroom-audio", "homeassistant"), "1.2.3");
+
+    private static TriggerResponse Zone() => new(
+        Channel: 1, CustomSinkName: "sink", CustomSinkDisplayName: "Sink",
+        OffDelaySeconds: 30, ZoneName: "Living Room", RelayState: RelayState.On,
+        IsActive: true, LastActivated: null, ScheduledOffTime: null, IsOverridden: false);
+
+    [Fact]
+    public void Amp_EmitsOverrideSwitchWithCommandTopic()
+    {
+        var sw = _d.ForAmp("VIRTUAL:x", "Living Room Amp", Zone()).Single(m => m.Topic.Contains("/switch/"));
+        using var doc = JsonDocument.Parse(sw.Payload);
+        var root = doc.RootElement;
+        Assert.Equal("multiroom-audio/amp/virtual_x_1/override/set", root.GetProperty("command_topic").GetString());
+        Assert.Equal("multiroom-audio/amp/virtual_x_1/state", root.GetProperty("state_topic").GetString());
+    }
+
+    [Fact]
+    public void Amp_AllEntitiesShareDeviceIdentifier()
+    {
+        var ids = _d.ForAmp("VIRTUAL:x", "Living Room Amp", Zone()).Select(m =>
+        {
+            using var doc = JsonDocument.Parse(m.Payload);
+            return doc.RootElement.GetProperty("device").GetProperty("identifiers")[0].GetString();
+        }).Distinct().ToList();
+        Assert.Single(ids);
+        Assert.Equal("mra_amp_virtual_x_1", ids[0]);
+    }
+
+    [Fact]
+    public void Amp_EmitsPowerBinarySensor()
+        => Assert.Contains(_d.ForAmp("VIRTUAL:x", null, Zone()), m => m.Topic.Contains("/binary_sensor/") && m.Payload.Contains("value_json.power"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter AmpDiscoveryTests`
+Expected: FAIL — `ForAmp` doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+In `HaDiscovery.cs` add:
+
+```csharp
+    public IReadOnlyList<DiscoveryMessage> ForAmp(string boardId, string? boardDisplayName, MultiRoomAudio.Models.TriggerResponse t)
+    {
+        var zone = $"{MqttTopics.Sanitize(boardId)}_{t.Channel}";
+        var stateTopic = _topics.AmpStateTopic(boardId, t.Channel);
+        var deviceId = $"mra_amp_{zone}";
+        var label = !string.IsNullOrWhiteSpace(t.ZoneName) ? t.ZoneName
+                  : !string.IsNullOrWhiteSpace(boardDisplayName) ? $"{boardDisplayName} CH{t.Channel}"
+                  : $"{boardId} CH{t.Channel}";
+        var device = Device(deviceId, label!, "Amplifier Zone");
+
+        DiscoveryMessage Entity(string component, string key, string name, Action<Utf8JsonWriter> extra)
+            => Build(component, $"mra_amp_{zone}_{key}", name, deviceId, stateTopic, device, extra);
+
+        return new List<DiscoveryMessage>
+        {
+            Entity("binary_sensor", "power", $"{label} Power", w =>
+            {
+                w.WriteString("value_template", "{{ value_json.power }}");
+                w.WriteString("payload_on", "ON");
+                w.WriteString("payload_off", "OFF");
+                w.WriteString("device_class", "power");
+            }),
+            Entity("sensor", "scheduled_off", $"{label} Scheduled Off", w =>
+            {
+                w.WriteString("value_template", "{{ value_json.scheduled_off }}");
+                w.WriteString("device_class", "timestamp");
+                w.WriteString("entity_category", "diagnostic");
+            }),
+            Entity("switch", "override", $"{label} Override", w =>
+            {
+                w.WriteString("command_topic", _topics.AmpCommandTopic(boardId, t.Channel, "override"));
+                w.WriteString("value_template", "{{ value_json.override }}");
+                w.WriteString("state_on", "ON");
+                w.WriteString("state_off", "OFF");
+                w.WriteString("payload_on", "ON");
+                w.WriteString("payload_off", "OFF");
+            }),
+            Entity("binary_sensor", "board_connected", $"{label} Board Connected", w =>
+            {
+                w.WriteString("value_template", "{{ value_json.board_connected }}");
+                w.WriteString("payload_on", "ON");
+                w.WriteString("payload_off", "OFF");
+                w.WriteString("device_class", "connectivity");
+                w.WriteString("entity_category", "diagnostic");
+            }),
+        };
+    }
+```
+
+**Implementer note:** confirm the existing `Build` and `Device` helper signatures match this usage (they were created in Phase 1 Task 6). If `Build`'s parameter order differs, adapt the calls — do not change `Build`/`Device` themselves.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter AmpDiscoveryTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/MultiRoomAudio/Mqtt/HaDiscovery.cs tests/MultiRoomAudio.Tests/Mqtt/AmpDiscoveryTests.cs
+git commit -m "feat: add HA discovery builders for amp zones"
+```
+
+---
+
+### Task 8: `MqttCommand` — amp override parsing
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Mqtt/MqttCommand.cs`
+- Test: `tests/MultiRoomAudio.Tests/Mqtt/AmpCommandTests.cs`
+
+**Interfaces:**
+- Produces: `MqttCommandKind.AmpOverride`; `ParsedCommand` gains amp fields. To avoid breaking Phase 1's `ParsedCommand` shape used by `MqttService`, extend it with optional fields:
+  `record ParsedCommand(MqttCommandKind Kind, string PlayerClientId, int? IntValue, string? AmpZone = null, bool? BoolValue = null)`.
+  `Parse` now also recognizes `{base}/amp/{zone}/override/set` → `(AmpOverride, AmpZone=zone, BoolValue=payload=="ON")`.
+
+**Context:** `AmpZone` is the sanitized `boardId_channel` string from the topic; `MqttService` (Task 9) maps it back to a real `(boardId, channel)` by matching `Sanitize(boardId)_channel` over the live board list.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/MultiRoomAudio.Tests/Mqtt/AmpCommandTests.cs`:
+
+```csharp
+using MultiRoomAudio.Mqtt;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Mqtt;
+
+public class AmpCommandTests
+{
+    [Fact]
+    public void Parse_AmpOverrideOn()
+    {
+        var c = MqttCommand.Parse("multiroom-audio", "multiroom-audio/amp/virtual_x_1/override/set", "ON");
+        Assert.Equal(MqttCommandKind.AmpOverride, c.Kind);
+        Assert.Equal("virtual_x_1", c.AmpZone);
+        Assert.True(c.BoolValue);
+    }
+
+    [Fact]
+    public void Parse_AmpOverrideOff()
+    {
+        var c = MqttCommand.Parse("multiroom-audio", "multiroom-audio/amp/virtual_x_1/override/set", "OFF");
+        Assert.Equal(MqttCommandKind.AmpOverride, c.Kind);
+        Assert.False(c.BoolValue);
+    }
+
+    [Fact]
+    public void Parse_PlayerOffset_StillWorks()
+    {
+        var c = MqttCommand.Parse("multiroom-audio", "multiroom-audio/player/abc123/offset/set", "250");
+        Assert.Equal(MqttCommandKind.PlayerOffset, c.Kind);
+        Assert.Equal(250, c.IntValue);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter AmpCommandTests`
+Expected: FAIL — `AmpOverride`/`AmpZone`/`BoolValue` don't exist.
+
+- [ ] **Step 3: Implement**
+
+Replace `MqttCommand.cs` contents with:
+
+```csharp
+using System.Globalization;
+
+namespace MultiRoomAudio.Mqtt;
+
+public enum MqttCommandKind { Unknown, PlayerOffset, PlayerRestart, AmpOverride }
+
+public record ParsedCommand(
+    MqttCommandKind Kind,
+    string PlayerClientId,
+    int? IntValue,
+    string? AmpZone = null,
+    bool? BoolValue = null);
+
+/// <summary>
+/// Parses inbound MQTT command topics into typed commands. Pure — no dispatch.
+/// Player: {base}/player/{sanitizedClientId}/{command}/set
+/// Amp:    {base}/amp/{sanitizedBoardId_channel}/{command}/set
+/// </summary>
+public static class MqttCommand
+{
+    public static ParsedCommand Parse(string baseTopic, string topic, string payload)
+    {
+        var root = baseTopic.TrimEnd('/');
+
+        var playerPrefix = root + "/player/";
+        if (topic.StartsWith(playerPrefix, StringComparison.Ordinal))
+        {
+            var parts = topic[playerPrefix.Length..].Split('/');   // {id}/{command}/set
+            if (parts.Length != 3 || parts[2] != "set")
+                return Unknown();
+            var id = parts[0];
+            return parts[1] switch
+            {
+                "offset" => new ParsedCommand(MqttCommandKind.PlayerOffset, id,
+                    int.TryParse(payload, NumberStyles.Integer, CultureInfo.InvariantCulture, out var v) ? v : null),
+                "restart" => new ParsedCommand(MqttCommandKind.PlayerRestart, id, null),
+                _ => new ParsedCommand(MqttCommandKind.Unknown, id, null),
+            };
+        }
+
+        var ampPrefix = root + "/amp/";
+        if (topic.StartsWith(ampPrefix, StringComparison.Ordinal))
+        {
+            var parts = topic[ampPrefix.Length..].Split('/');      // {zone}/{command}/set
+            if (parts.Length != 3 || parts[2] != "set")
+                return Unknown();
+            var zone = parts[0];
+            return parts[1] switch
+            {
+                "override" => new ParsedCommand(MqttCommandKind.AmpOverride, "", null,
+                    AmpZone: zone, BoolValue: payload.Trim().Equals("ON", StringComparison.OrdinalIgnoreCase)),
+                _ => Unknown(),
+            };
+        }
+
+        return Unknown();
+    }
+
+    private static ParsedCommand Unknown() => new(MqttCommandKind.Unknown, "", null);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter "AmpCommandTests|MqttCommandTests"`
+Expected: PASS (the Phase 1 `MqttCommandTests` still pass — the player path is preserved).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/MultiRoomAudio/Mqtt/MqttCommand.cs tests/MultiRoomAudio.Tests/Mqtt/AmpCommandTests.cs
+git commit -m "feat: parse amp override commands in MqttCommand"
+```
+
+---
+
+### Task 9: `MqttService` — TriggerService dependency, amp publish, override dispatch
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Services/MqttService.cs`
+
+**Interfaces:**
+- Consumes: `TriggerService` (`GetStatus()`, `SetOverride(boardId, channel, on)`, `TriggersChanged`), amp builders (Tasks 5-8).
+- Produces: amp discovery + state published on connect and on `TriggersChanged`; amp override commands dispatched.
+
+**Context:** Read the current `MqttService.cs` first. Phase 1 established: `ConnectAndAnnounceAsync` (subscribes, publishes availability/discovery/state), `PublishDiscoveryAsync`, `PublishAllStateAsync`, `OnPlayersChanged` (fire-and-forget republish), `OnMessageReceivedAsync` (parses + dispatches), `PublishAsync`, the `_topics`/`_discovery` fields, and the constructor. `TriggerFeatureResponse` from `GetStatus()` has `.Boards` (each `TriggerBoardResponse` with `.BoardId`, `.DisplayName`, `.IsConnected`, `.Triggers` — each a `TriggerResponse`).
+
+- [ ] **Step 1: Add the `TriggerService` dependency**
+
+Add a field `private readonly TriggerService _triggers;` and add `TriggerService triggers` to the constructor parameter list, assigning `_triggers = triggers;`. (DI already has `TriggerService` as a singleton — no Program.cs change needed for the dependency, but verify the constructor still resolves.)
+
+- [ ] **Step 2: Publish amp discovery + state on connect**
+
+In `PublishDiscoveryAsync`, after the player + container discovery loops, add:
+
+```csharp
+        var trig = _triggers.GetStatus();
+        foreach (var board in trig.Boards)
+            foreach (var t in board.Triggers)
+                foreach (var m in _discovery!.ForAmp(board.BoardId, board.DisplayName, t))
+                    await PublishAsync(m.Topic, m.Payload, retain: true, ct);
+```
+
+In `PublishAllStateAsync`, after the player + container state, add:
+
+```csharp
+        var trigState = _triggers.GetStatus();
+        foreach (var board in trigState.Boards)
+            foreach (var t in board.Triggers)
+                await PublishAsync(_topics!.AmpStateTopic(board.BoardId, t.Channel),
+                    MqttStatePayloads.Amp(t, board.IsConnected), retain: true, ct);
+```
+
+**Note on the virtual "MQTT not connected" diagnostic:** for amp `board_connected`, pass `board.IsConnected` as above for all boards. (A virtual board reports `IsConnected = true` once opened; surfacing "MQTT not connected" specifically is handled by the bridge availability LWT — when MQTT drops, all entities including the amp go `unavailable` in HA, which is the clearest signal. No extra per-board logic needed here.)
+
+- [ ] **Step 3: Subscribe to the amp command topic**
+
+In `ConnectAndAnnounceAsync`, where it subscribes to `PlayerCommandSubscription`, add a second subscribe:
+
+```csharp
+        await _client.SubscribeAsync(_topics!.AmpCommandSubscription, MqttQualityOfServiceLevel.AtLeastOnce, ct);
+```
+
+- [ ] **Step 4: Subscribe to `TriggersChanged`**
+
+In `InitializeAsync`, right after `_players.PlayersChanged += OnPlayersChanged;`, add:
+
+```csharp
+        _triggers.TriggersChanged += OnTriggersChanged;
+```
+In `ShutdownAsync`, alongside the `PlayersChanged -= ...` unsubscribe, add:
+
+```csharp
+        _triggers.TriggersChanged -= OnTriggersChanged;
+```
+Add the handler (mirror `OnPlayersChanged` exactly — fire-and-forget, swallow exceptions):
+
+```csharp
+    private void OnTriggersChanged()
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                if (!IsConnected) return;
+                await PublishDiscoveryAsync(CancellationToken.None);
+                await PublishAllStateAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to publish MQTT state on trigger change");
+            }
+        });
+    }
+```
+
+- [ ] **Step 5: Dispatch the amp override command**
+
+In `OnMessageReceivedAsync`, after the existing player-command handling, add amp handling. After parsing `var cmd = MqttCommand.Parse(_baseTopic, topic, payload);` and the existing `Unknown` early-return, add an amp branch (before or after the player-player lookup, guarded by kind):
+
+```csharp
+            if (cmd.Kind == MqttCommandKind.AmpOverride && cmd.AmpZone is not null)
+            {
+                foreach (var board in _triggers.GetStatus().Boards)
+                {
+                    foreach (var t in board.Triggers)
+                    {
+                        if ($"{MqttTopics.Sanitize(board.BoardId)}_{t.Channel}" == cmd.AmpZone)
+                        {
+                            _triggers.SetOverride(board.BoardId, t.Channel, cmd.BoolValue ?? false);
+                            return;
+                        }
+                    }
+                }
+                _logger.LogWarning("MQTT amp override for unknown zone {Zone}", cmd.AmpZone);
+                return;
+            }
+```
+Ensure the existing player-dispatch path only runs for player kinds (it already maps by `PlayerClientId`; the amp branch returns before reaching it).
+
+- [ ] **Step 6: Build**
+
+Run: `dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj -c Debug`
+Expected: 0 errors. Run `dotnet test tests/MultiRoomAudio.Tests` → existing suite still green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/MultiRoomAudio/Services/MqttService.cs
+git commit -m "feat: publish amp state and dispatch override commands in MqttService"
+```
+
+---
+
+### Task 10: `MqttConfigService` — snake_case HAOS keys
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Services/MqttConfigService.cs`
+- Test: `tests/MultiRoomAudio.Tests/Mqtt/MqttConfigServiceTests.cs` (add a case)
+
+**Interfaces:**
+- Consumes: `EnvironmentService.GetHaosOption<T>` / `IsHaos` (existing).
+- Produces: HAOS option lookups keyed by snake_case (`mqtt_enabled`, `mqtt_host`, `mqtt_port`, `mqtt_username`, `mqtt_password`, `mqtt_tls`). Env-var keys (`MQTT_*`) unchanged. `ApplyOverrides` signature unchanged; precedence env → HAOS → yaml → default preserved.
+
+**Context:** In Phase 1, `Reload()` built lambdas like `key => _env.GetHaosOption<bool?>(key)` and `ApplyOverrides` called them with the **env-var key** (`"MQTT_ENABLED"`). Since `ApplyOverrides` takes the env dictionary AND the HAOS accessor funcs, the cleanest fix is: inside `ApplyOverrides`, look up HAOS using the snake_case key while reading env with the `MQTT_*` key. The HAOS funcs are passed the snake_case key.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/MultiRoomAudio.Tests/Mqtt/MqttConfigServiceTests.cs`:
+
+```csharp
+public class MqttConfigHaosKeyTests
+{
+    [Fact]
+    public void HaosSnakeCaseKeys_Resolve_AndOverrideYaml()
+    {
+        var result = MultiRoomAudio.Services.MqttConfigService.ApplyOverrides(
+            new MqttSettings { Host = "yaml-host", Enabled = false },
+            new Dictionary<string, string?>(),                 // no env
+            haosBool: key => key == "mqtt_enabled" ? true : (bool?)null,
+            haosString: key => key == "mqtt_host" ? "haos-host" : null,
+            haosInt: _ => null);
+
+        Assert.True(result.Enabled);              // from mqtt_enabled
+        Assert.Equal("haos-host", result.Host);   // from mqtt_host overriding yaml
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter MqttConfigHaosKeyTests`
+Expected: FAIL — HAOS lookups currently use `"MQTT_ENABLED"`/`"MQTT_HOST"`, so the snake_case funcs return null and yaml values win.
+
+- [ ] **Step 3: Update `ApplyOverrides` HAOS keys**
+
+In `ApplyOverrides`, change each HAOS accessor call to the snake_case key while keeping `EnvStr(...)` on the `MQTT_*` key:
+
+```csharp
+            Enabled = EnvStr("MQTT_ENABLED") is { } en ? IsTruthy(en)
+                      : haosBool("mqtt_enabled") ?? fromYaml.Enabled,
+            Host = EnvStr("MQTT_HOST") ?? haosString("mqtt_host") ?? fromYaml.Host,
+            Port = (EnvStr("MQTT_PORT") is { } p && int.TryParse(p, out var pv)) ? pv
+                   : haosInt("mqtt_port") ?? fromYaml.Port,
+            Username = EnvStr("MQTT_USERNAME") ?? haosString("mqtt_username") ?? fromYaml.Username,
+            Password = EnvStr("MQTT_PASSWORD") ?? haosString("mqtt_password") ?? fromYaml.Password,
+            UseTls = EnvStr("MQTT_TLS") is { } tls ? IsTruthy(tls)
+                     : haosBool("mqtt_tls") ?? fromYaml.UseTls,
+            DiscoveryPrefix = EnvStr("MQTT_DISCOVERY_PREFIX") ?? haosString("mqtt_discovery_prefix") ?? fromYaml.DiscoveryPrefix,
+            BaseTopic = EnvStr("MQTT_BASE_TOPIC") ?? haosString("mqtt_base_topic") ?? fromYaml.BaseTopic,
+```
+
+Also update `ResolveSource` in `Reload()`/the class: where it checks `_env.GetHaosOption<string?>("MQTT_HOST")`, change to `"mqtt_host"`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests --filter "MqttConfigHaosKeyTests|MqttConfigOverrideTests"`
+Expected: PASS (env-precedence tests from Phase 1 still pass — env keys unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/MultiRoomAudio/Services/MqttConfigService.cs tests/MultiRoomAudio.Tests/Mqtt/MqttConfigServiceTests.cs
+git commit -m "fix: resolve HAOS MQTT options by snake_case keys"
+```
+
+---
+
+### Task 11: HAOS add-on `config.yaml` MQTT options
+
+**Files:**
+- Modify: `multiroom-audio/config.yaml`
+
+**Interfaces:** none (declarative add-on schema). Keys must match Task 10's snake_case lookups.
+
+- [ ] **Step 1: Add options + schema**
+
+In `multiroom-audio/config.yaml`, replace the `options:` and `schema:` blocks with:
+
+```yaml
+# User-configurable options
+options:
+  log_level: info
+  mqtt_enabled: false
+
+schema:
+  log_level: list(debug|info|warning|error)
+  mqtt_enabled: bool
+  mqtt_host: str?
+  mqtt_port: port?
+  mqtt_username: str?
+  mqtt_password: password?
+  mqtt_tls: bool?
+```
+
+Do NOT touch the `version:` field (CI auto-updates it).
+
+- [ ] **Step 2: Validate YAML**
+
+Run: `python -c "import yaml,sys; yaml.safe_load(open('multiroom-audio/config.yaml')); print('ok')"` (or any YAML linter available).
+Expected: `ok` / no parse error.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add multiroom-audio/config.yaml
+git commit -m "feat: expose MQTT options in HAOS add-on config"
+```
+
+---
+
+### Task 12: Web UI — virtual board add + override toggle
+
+**Files:**
+- Modify: `src/MultiRoomAudio/wwwroot/js/app.js` (and any trigger-related markup/partial it renders into)
+
+**Interfaces:**
+- Consumes: `POST /api/triggers/boards` (with `boardType: "Virtual"`), `PUT /api/triggers/boards/{boardId}/{channel}/override` (`{ on: bool }`), `GET /api/triggers` (each trigger now has `isOverridden`).
+
+**Context:** This is integration with existing vanilla JS. Read the current triggers UI in `app.js` first (search for the triggers/relay rendering and the existing "test relay" control, which already calls `POST .../{channel}/test`). Match its DOM-building and fetch patterns (the project uses `textContent`, not `innerHTML`, for user data). Do not introduce frameworks.
+
+- [ ] **Step 1: Read the existing triggers UI**
+
+Run: `grep -n "triggers\|relay\|board" src/MultiRoomAudio/wwwroot/js/app.js | head -40`
+Identify: the function that renders boards/channels, the "add board" flow, and the "test relay" handler. These are your templates.
+
+- [ ] **Step 2: Add "Add virtual board" control**
+
+In the add-board UI, add an option/button that POSTs to `/api/triggers/boards` with body `{ boardType: "Virtual", displayName: <user input>, channelCount: <user-selected, default 2> }` (no `boardId` — the server generates it). On success, refresh the triggers view (reuse the existing refresh function). Match the existing add-board fetch/error handling.
+
+- [ ] **Step 3: Add a per-channel override toggle**
+
+For each channel row, add an "Override" toggle reflecting `trigger.isOverridden`. On change, `PUT /api/triggers/boards/{encodeURIComponent(boardId)}/{channel}/override` with `{ on: <checked> }`, then refresh. Place it near the existing per-channel controls; label it clearly (e.g. "Manual override").
+
+- [ ] **Step 4: Show the MQTT-not-connected hint for virtual boards**
+
+When a board's type is `Virtual`, render a small note that it requires MQTT to be enabled/connected to reach Home Assistant (link to the MQTT settings section if one exists). Keep it lightweight; no new dependencies.
+
+- [ ] **Step 5: Manual verification**
+
+Run the app (`MOCK_HARDWARE=true dotnet run --project src/MultiRoomAudio/MultiRoomAudio.csproj`), open the UI, add a virtual board, toggle a channel override, and confirm the triggers view updates and the API calls succeed (check the network tab / logs). Kill the app afterward. If a browser isn't available in this environment, verify the fetch URLs/bodies by code inspection against the Task 4 endpoints and note that manual UI verification is pending.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/MultiRoomAudio/wwwroot/
+git commit -m "feat: add virtual board and override controls to triggers UI"
+```
+
+---
+
+### Task 13: Full verification pass
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the whole test suite**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests`
+Expected: all pass, including the new amp/override/virtual-board tests and the Phase 1 tests.
+
+- [ ] **Step 2: Build the solution**
+
+Run: `dotnet build squeezelite-docker.sln -c Debug`
+Expected: 0 errors; no new warnings from new files.
+
+- [ ] **Step 3: End-to-end against a local broker (manual, recommended)**
+
+With a broker (`docker run -it -p 1883:1883 eclipse-mosquitto`), set `MQTT_ENABLED=true MQTT_HOST=localhost`, run with `MOCK_HARDWARE=true`, add a virtual board with a sink-mapped channel, and `mosquitto_sub -t 'homeassistant/#' -v` + `-t 'multiroom-audio/#' -v`. Expected: amp discovery configs appear; toggling the HA override switch publishes to `multiroom-audio/amp/<zone>/override/set` and the amp `power` state flips. Note results.
+
+- [ ] **Step 4: Commit (if fixups were needed)**
+
+```bash
+git add -A
+git commit -m "test: verify MQTT bridge phase 2 end to end"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Sticky override (ON suspends auto, OFF re-evaluates) → Task 2 (`SetOverride` + guards) + tests.
+- `TriggersChanged` event → Task 2; consumed in Task 9.
+- `IsOverridden` in status → Tasks 1 + 2 (GetBoardStatus).
+- Virtual board (software, both factories, manual add, `VIRTUAL:` id) → Tasks 1, 3, 4.
+- Amp entities (power, scheduled-off, override switch, board-connected) → Tasks 6, 7.
+- Amp topics + command → Tasks 5, 8.
+- MqttService amp publish + override dispatch + TriggersChanged → Task 9.
+- HAOS enable: config.yaml options → Task 11; snake_case key alignment → Task 10.
+- Docker unchanged → Task 10 keeps `MQTT_*` env keys.
+- API (override endpoint, virtual add) → Task 4. UI → Task 12.
+- `sync_error_ms` dropped → no task (correct).
+- Non-blocking: no new startup phase; `TriggersChanged` handler swallows exceptions → Task 9.
+
+**2. Placeholder scan:** No TBD/TODO. Two tasks (4, 12) instruct reading an existing file to match its idiom before editing — they carry exact API contracts, routes, payloads, and behaviors, not vague directives. The `CustomSinksService` harness construction (Task 2) has an explicit fallback path rather than a placeholder.
+
+**3. Type consistency:** `RelayBoardType.Virtual` and `TriggerResponse.IsOverridden` (Task 1) are used in Tasks 2/3/6/7. `TriggersChanged`/`SetOverride` (Task 2) consumed in Tasks 4/9. `MqttTopics.AmpStateTopic/AmpCommandTopic/AmpCommandSubscription` (Task 5) used in Tasks 7/9. `MqttStatePayloads.Amp(TriggerResponse, bool)` (Task 6) used in Task 9. `HaDiscovery.ForAmp(string, string?, TriggerResponse)` (Task 7) used in Task 9. `ParsedCommand` extended fields `AmpZone`/`BoolValue` (Task 8) used in Task 9. HAOS keys (Task 10) match `config.yaml` (Task 11). Zone key formula `Sanitize(boardId)_channel` is identical in Tasks 5, 7, 8, 9.
+
+## Follow-ups (not in this plan)
+
+- Decouple discovery republish from every state tick (publish discovery only on player/board-set changes) — carried over from Phase 1; both player and amp discovery currently republish on each change (idempotent but chatty).
+- HAOS Supervisor `services/mqtt` broker auto-detect (optional convenience on top of the config-options path).
+- Onboarding wizard: decide whether the virtual-board/MQTT toggle belongs in `wwwroot/js/wizard.js` (raise at Task 12 time).

--- a/docs/superpowers/specs/2026-06-25-mqtt-home-assistant-bridge-phase2-design.md
+++ b/docs/superpowers/specs/2026-06-25-mqtt-home-assistant-bridge-phase2-design.md
@@ -57,7 +57,7 @@ The auto-logic guard is a single `if (state.IsOverridden) return;` (or equivalen
 - Created by **both** `RealRelayBoardFactory` and `MockRelayBoardFactory` for `RelayBoardType.Virtual` (it is software, so it exists in real deployments too). `CanCreate(... Virtual)` returns true in both.
 - **No MQTT dependency in the relay layer.** A zone's amp-power state reaches HA through the normal amp-state publish driven by `TriggersChanged` (Section 3). When the auto-logic drives a virtual channel on, the amp `binary_sensor` flips to ON in HA and the user's automation mirrors it onto their outlet.
 - **Added manually** via the trigger API/UI (not hardware-discovered). The user supplies a display name and channel count, assigns sinks + off-delays per channel like any board. `BoardId` is a stable `VIRTUAL:<id>` generated once on creation and persisted in `triggers.yaml`.
-- **MQTT-usable diagnostic.** A virtual board only does anything when MQTT is connected. Surface this: the board's "board connected" diagnostic (Section 3) reflects an MQTT-usable condition (MQTT enabled AND connected) rather than always-true, and the trigger status reflects "MQTT not connected" for virtual boards when the bridge is down/disabled.
+- **MQTT-down signal.** A virtual board only does anything when MQTT is connected. This is surfaced through the **bridge LWT availability**, not the per-board sensor: when MQTT drops or is disabled, the bridge's last-will marks every entity (including the amp zone) `unavailable` in Home Assistant — the clearest "not reaching HA" signal. The amp's `board_connected` diagnostic therefore reflects the board's own `IsConnected` (always true for a software board once opened), and the web UI shows a static "requires MQTT" hint on virtual boards. (Implementation note: an earlier draft had `board_connected` itself reflect MQTT-usable state; that was dropped because, while MQTT is connected we are publishing, and while it is down LWT already makes the entity unavailable — so a per-board MQTT-usable flag would never differ observably from `IsConnected`.)
 
 ## 3. MQTT layer extension
 
@@ -70,7 +70,7 @@ Builds on Phase 1's tested pure units; each extension is TDD'd in the same style
 | Amp power | binary_sensor (`device_class: power`) | R | `TriggerResponse.RelayState` |
 | Scheduled off | sensor (`device_class: timestamp`) | R | `TriggerResponse.ScheduledOffTime` |
 | Manual override | switch | R/W | `TriggerResponse.IsOverridden` ← / → `SetOverride` |
-| Board connected | binary_sensor (diagnostic, `device_class: connectivity`) | R | board `IsConnected`; for virtual boards, MQTT-usable |
+| Board connected | binary_sensor (diagnostic, `device_class: connectivity`) | R | board `IsConnected` (MQTT-down is surfaced via the bridge LWT availability — see §2) |
 
 All share one device identifier and the same availability/device-block pattern as Phase 1's player entities.
 

--- a/docs/superpowers/specs/2026-06-25-mqtt-home-assistant-bridge-phase2-design.md
+++ b/docs/superpowers/specs/2026-06-25-mqtt-home-assistant-bridge-phase2-design.md
@@ -1,0 +1,157 @@
+# MQTT → Home Assistant Bridge — Phase 2 Design
+
+**Date:** 2026-06-25
+**Status:** Approved (design); pending implementation plan
+**Builds on:** Phase 1 (`docs/superpowers/specs/2026-06-24-mqtt-home-assistant-bridge-design.md`), merged to `dev` via PR #235. Phase 2 branch `feat/mqtt-ha-bridge-phase2` is based off `dev` and targets `dev`.
+
+## Summary
+
+Phase 2 completes the MQTT bridge by exposing the **12V amp/relay zones** to Home Assistant, adding a **manual-override switch**, introducing a **virtual relay board** (a software relay whose power state is published over MQTT so an HA-controlled smart outlet can be driven by Multi-Room's playback auto-logic), and letting HAOS users **turn MQTT on from the add-on configuration**.
+
+It reuses Phase 1's bridge engine, command pipeline, and pure builders. Player volume/mute/transport remain out of scope (Music Assistant owns those); the per-player `sync_error_ms` sensor is explicitly **dropped** (the clock-synced binary_sensor already gives HA the actionable signal, and the raw value would add MQTT traffic for little gain).
+
+## Scope decisions
+
+| Decision | Choice |
+|---|---|
+| Override switch behavior | **Sticky override**: ON forces the amp on and suspends auto-logic for that channel; OFF releases back to auto (re-evaluates current playback — stays on if playing, else normal off-delay) |
+| Virtual relay → smart outlet | Decoupled (Phase 1 approach #1): the virtual amp's power state is published like any amp; the user writes one HA automation per zone to mirror it onto their outlet |
+| Virtual board MQTT path | None of its own — its power state flows to HA through the normal amp-state publish driven by `TriggersChanged` |
+| `sync_error_ms` sensor | Dropped (YAGNI; clock-synced binary_sensor suffices) |
+| HAOS enable | Add-on `config.yaml` options (`mqtt_enabled` + broker fields); Docker unchanged (env vars) |
+
+## Background / current state (Phase 1 + trigger layer)
+
+- Phase 1 shipped: `MqttService` (connection, LWT, retained discovery/state, reconnect, command dispatch), pure units (`MqttTopics`, `HaDiscovery`, `MqttStatePayloads`, `MqttCommand`), `MqttConfigService` (env → HAOS → yaml → default), the per-player + container devices, and `GET/PUT /api/mqtt`.
+- `TriggerService` manages multiple relay boards. Per-channel state lives in `TriggerChannelState` (`IsActive`, `LastActivated`, `OffDelayTimer`, `ActivePlayerCount`). Relays are driven by custom-sink activity → `IRelayBoard.SetRelay(channel, on)`, with off-delay timers.
+- `ManualControl(boardId, channel, on)` exists but is a **one-shot test** — it sets the relay and cancels the pending off-timer; it does NOT suspend the auto-logic, so the auto-pipeline can re-assert. A true override is new behavior.
+- Boards are built by `IRelayBoardFactory.CreateBoard(boardId, boardType)` (Real and Mock factories) and conform to the synchronous `IRelayBoard` interface (`SetRelay`/`GetRelay`/`CurrentState`/`IsConnected`/`Open`/`Close`/...).
+- `TriggerResponse` carries per-channel `RelayState`, `IsActive`, `LastActivated`, `ScheduledOffTime`. `TriggerBoardResponse` carries `IsConnected`.
+- HAOS add-on `config.yaml` currently exposes only `log_level`. `EnvironmentService.GetHaosOption<T>(key)` reads `/data/options.json` (existing keys use snake_case: `mock_hardware`, `buffer_seconds`).
+
+## 1. TriggerService changes (core)
+
+All additions live in `TriggerService`, above the board layer, so they work uniformly for every board type (HID/FTDI/Modbus/LCUS/Virtual).
+
+**Sticky override.** Extend `TriggerChannelState` with `bool IsOverridden`. New method:
+
+```csharp
+public bool SetOverride(string boardId, int channel, bool on)
+```
+
+- `on` → cancel the off-delay timer, `SetRelay(channel, true)`, set `IsOverridden = true`. While `IsOverridden`, the auto-logic path skips this channel (it neither turns it off nor schedules an off-timer).
+- `off` (release) → set `IsOverridden = false`, then re-evaluate auto: if `ActivePlayerCount > 0` leave the relay on; otherwise start the normal off-delay timer.
+- Validation and disconnected-board handling mirror `ManualControl` (log + return false, never throw).
+
+The auto-logic guard is a single `if (state.IsOverridden) return;` (or equivalent skip) in the existing sink-activity handler that would otherwise drive the channel.
+
+**Change event.** `public event Action? TriggersChanged;` raised wherever a channel/board state changes: auto on/off, off-timer fire, manual control, override set/release, board connect/disconnect. Coarse-grained — `MqttService` re-reads `GetStatus()` and republishes (same pattern as Phase 1's `PlayersChanged`).
+
+**Status surfacing.** Add `bool IsOverridden` to `TriggerResponse` so the API/UI and MQTT reflect override state.
+
+## 2. Virtual relay board
+
+`VirtualRelayBoard : IRelayBoard` + new `RelayBoardType.Virtual`.
+
+- Software-only: records `SetRelay`/`GetRelay`/`CurrentState` in memory; `IsConnected` is always true (the board itself is always ready). Essentially `MockRelayBoard` semantics, but a real user-facing board type.
+- Created by **both** `RealRelayBoardFactory` and `MockRelayBoardFactory` for `RelayBoardType.Virtual` (it is software, so it exists in real deployments too). `CanCreate(... Virtual)` returns true in both.
+- **No MQTT dependency in the relay layer.** A zone's amp-power state reaches HA through the normal amp-state publish driven by `TriggersChanged` (Section 3). When the auto-logic drives a virtual channel on, the amp `binary_sensor` flips to ON in HA and the user's automation mirrors it onto their outlet.
+- **Added manually** via the trigger API/UI (not hardware-discovered). The user supplies a display name and channel count, assigns sinks + off-delays per channel like any board. `BoardId` is a stable `VIRTUAL:<id>` generated once on creation and persisted in `triggers.yaml`.
+- **MQTT-usable diagnostic.** A virtual board only does anything when MQTT is connected. Surface this: the board's "board connected" diagnostic (Section 3) reflects an MQTT-usable condition (MQTT enabled AND connected) rather than always-true, and the trigger status reflects "MQTT not connected" for virtual boards when the bridge is down/disabled.
+
+## 3. MQTT layer extension
+
+Builds on Phase 1's tested pure units; each extension is TDD'd in the same style.
+
+**New amp/zone device per `(boardId, channel)`** — HA device id `mra_amp_<Sanitize(boardId)>_<channel>`:
+
+| Entity | Platform | R/W | Source |
+|---|---|---|---|
+| Amp power | binary_sensor (`device_class: power`) | R | `TriggerResponse.RelayState` |
+| Scheduled off | sensor (`device_class: timestamp`) | R | `TriggerResponse.ScheduledOffTime` |
+| Manual override | switch | R/W | `TriggerResponse.IsOverridden` ← / → `SetOverride` |
+| Board connected | binary_sensor (diagnostic, `device_class: connectivity`) | R | board `IsConnected`; for virtual boards, MQTT-usable |
+
+All share one device identifier and the same availability/device-block pattern as Phase 1's player entities.
+
+**Pure-unit extensions:**
+- `MqttTopics`: `AmpStateTopic(boardId, channel)`, `AmpCommandTopic(boardId, channel, command)`, `AmpCommandSubscription`. Zone key = `Sanitize(boardId)_<channel>`.
+- `MqttStatePayloads.Amp(TriggerResponse t, bool boardConnected)` → `{ power: ON/OFF, scheduled_off: <iso or null>, override: ON/OFF, board_connected: ON/OFF }`.
+- `HaDiscovery.ForAmp(string boardId, TriggerResponse t)` → the four entities above (power, scheduled-off, override switch with command_topic, board-connected diagnostic), shared device identifier, friendly names (e.g. zone name or `"<board> CH<n>"`).
+- `MqttCommand`: new `MqttCommandKind.AmpOverride`; parse `{base}/amp/{zone}/override/set` → `(boardId, channel, on)`. Zone→(board,channel) resolves by matching `Sanitize` over the live board list (same round-trip approach as players).
+
+**MqttService wiring:**
+- Subscribe to `TriggerService.TriggersChanged` → republish amp discovery + state (mirrors the `PlayersChanged` handler; fire-and-forget, swallows its own exceptions).
+- Add the amp command-topic subscription; dispatch `AmpOverride` → `TriggerService.SetOverride(boardId, channel, on)`.
+- On connect, publish amp discovery/state alongside players + container. Constructor gains a `TriggerService` dependency.
+
+## 4. API / UI
+
+- `POST /api/triggers/boards` extended to accept `BoardType.Virtual` (no enumeration; generates `VIRTUAL:<id>`).
+- New `PUT /api/triggers/boards/{boardId}/{channel}/override` → `SetOverride`.
+- Per-channel status response (`TriggerResponse`) gains `IsOverridden`.
+- **Web UI** (vanilla JS, in the existing triggers section): an "Add virtual board" affordance, a per-channel override toggle + indicator, and the "MQTT not connected" hint on virtual boards. Per the project UI guideline, confirm at implementation time whether the virtual-board option also belongs in the onboarding wizard (`wwwroot/js/wizard.js`).
+
+## 5. HAOS add-on MQTT options
+
+Add to `multiroom-audio/config.yaml`:
+
+```yaml
+options:
+  log_level: info
+  mqtt_enabled: false
+
+schema:
+  log_level: list(debug|info|warning|error)
+  mqtt_enabled: bool
+  mqtt_host: str?
+  mqtt_port: port?
+  mqtt_username: str?
+  mqtt_password: password?
+  mqtt_tls: bool?
+```
+
+- HAOS users get a toggle + broker fields in the add-on config panel; `password?` masks the secret.
+- **Docker unchanged** — keeps using the `MQTT_*` env vars from Phase 1.
+- **Key-casing alignment (fix from Phase 1):** `MqttConfigService` currently looks up HAOS options with env-var-style keys (`"MQTT_ENABLED"`, `"MQTT_HOST"`), which never match HAOS's snake_case option keys. Phase 2 changes the HAOS lookups to `mqtt_enabled`, `mqtt_host`, `mqtt_port`, `mqtt_username`, `mqtt_password`, `mqtt_tls`. Env-var keys (Docker) stay `MQTT_*`. Precedence is unchanged: env var → HAOS option → yaml → default. This also exercises the `"haos"` config source that Phase 1's review flagged as currently dead.
+
+## Error handling
+
+Consistent with Phase 1 and the non-blocking-startup rule:
+- `SetOverride` on a missing/disconnected board → validated like `ManualControl`; logs and returns false, never throws.
+- Amp command payloads validated like player commands; bad payloads logged and ignored.
+- A virtual board with MQTT off does not error — it records state; the diagnostic shows "MQTT not connected."
+- The `TriggersChanged` publish handler is fire-and-forget and swallows its own exceptions.
+- No new startup phase needed — Phase 1's `mqtt` phase already runs after `triggers`, so `TriggerService` is initialized before `MqttService` subscribes.
+
+## Testing
+
+- Pure units: `MqttTopics` amp topics, `MqttStatePayloads.Amp`, `HaDiscovery.ForAmp`, `MqttCommand` amp parsing — unit tests, Phase 1 style.
+- `VirtualRelayBoard` — unit-testable with no hardware (like `MockRelayBoard`): SetRelay/GetRelay/CurrentState round-trip, always connected.
+- `SetOverride` sticky semantics — unit tests against `TriggerService` with a mock board: ON suspends auto-off; release with active playback stays on; release while idle starts the off-delay.
+- `MqttConfigService` HAOS key resolution — unit test that snake_case HAOS options resolve and override yaml (the previously-dead `"haos"` source).
+- `MOCK_HARDWARE=true` + a virtual board — full end-to-end path with no USB.
+
+## Out of scope (Phase 2)
+
+- Player volume/mute/transport (MA owns these).
+- `sync_error_ms` sensor (dropped).
+- HAOS Supervisor `services/mqtt` broker auto-detect (the add-on config-options path in Section 5 supersedes the need for v1; Supervisor auto-fill remains a possible future enhancement).
+- Decoupling discovery republish from every state tick (Phase 1 follow-up; both player and amp discovery are currently republished on each change — idempotent but chatty).
+
+## File touch list (informs the plan)
+
+**Modify:**
+- `src/MultiRoomAudio/Services/TriggerService.cs` — `SetOverride`, `IsOverridden` state + auto-logic guard, `TriggersChanged` event.
+- `src/MultiRoomAudio/Models/TriggerModels.cs` — `RelayBoardType.Virtual`, `TriggerResponse.IsOverridden`.
+- `src/MultiRoomAudio/Relay/RealRelayBoardFactory.cs`, `MockRelayBoardFactory.cs` — create `Virtual`.
+- `src/MultiRoomAudio/Mqtt/MqttTopics.cs`, `MqttStatePayloads.cs`, `HaDiscovery.cs`, `MqttCommand.cs` — amp additions.
+- `src/MultiRoomAudio/Services/MqttService.cs` — `TriggerService` dep, `TriggersChanged` subscription, amp publish + command dispatch.
+- `src/MultiRoomAudio/Services/MqttConfigService.cs` — snake_case HAOS keys.
+- `src/MultiRoomAudio/Controllers/TriggersEndpoint.cs` — override endpoint, virtual board add.
+- `src/MultiRoomAudio/wwwroot/js/*` — virtual board + override UI.
+- `multiroom-audio/config.yaml` — MQTT options/schema.
+
+**Create:**
+- `src/MultiRoomAudio/Relay/VirtualRelayBoard.cs`
+- Tests under `tests/MultiRoomAudio.Tests/` for the pure units, `VirtualRelayBoard`, `SetOverride`, and HAOS key resolution.

--- a/multiroom-audio/config.yaml
+++ b/multiroom-audio/config.yaml
@@ -41,9 +41,16 @@ panel_title: Multi-Room Audio
 # User-configurable options
 options:
   log_level: info
+  mqtt_enabled: false
 
 schema:
   log_level: list(debug|info|warning|error)
+  mqtt_enabled: bool
+  mqtt_host: str?
+  mqtt_port: port?
+  mqtt_username: str?
+  mqtt_password: password?
+  mqtt_tls: bool?
 
 # Watchdog - auto-restart if health check fails
 watchdog: http://[HOST]:[PORT:8096]/api/health

--- a/src/MultiRoomAudio/Controllers/TriggersEndpoint.cs
+++ b/src/MultiRoomAudio/Controllers/TriggersEndpoint.cs
@@ -132,9 +132,14 @@ public static class TriggersEndpoint
             ILoggerFactory lf) =>
         {
             var logger = lf.CreateLogger("TriggersEndpoint");
-            logger.LogDebug("API: POST /api/triggers/boards - {BoardId}", request.BoardId);
 
-            if (string.IsNullOrWhiteSpace(request.BoardId))
+            var boardId = request.BoardId;
+            if (request.BoardType == RelayBoardType.Virtual && string.IsNullOrWhiteSpace(boardId))
+                boardId = $"VIRTUAL:{Guid.NewGuid():N}".Substring(0, 16);
+
+            logger.LogDebug("API: POST /api/triggers/boards - {BoardId}", boardId);
+
+            if (string.IsNullOrWhiteSpace(boardId))
             {
                 return Results.BadRequest(new ErrorResponse(false, "Board ID is required"));
             }
@@ -145,16 +150,16 @@ public static class TriggersEndpoint
                     $"Channel count must be one of: {string.Join(", ", ValidChannelCounts.Values)}"));
             }
 
-            var success = service.AddBoard(request.BoardId, request.DisplayName, request.ChannelCount, request.BoardType);
+            var success = service.AddBoard(boardId, request.DisplayName, request.ChannelCount, request.BoardType);
             if (success)
             {
-                var boardStatus = service.GetBoardStatus(request.BoardId);
-                logger.LogInformation("Added board '{BoardId}'", request.BoardId);
-                return Results.Created($"/api/triggers/boards/{request.BoardId}", boardStatus);
+                var boardStatus = service.GetBoardStatus(boardId);
+                logger.LogInformation("Added board '{BoardId}'", boardId);
+                return Results.Created($"/api/triggers/boards/{boardId}", boardStatus);
             }
             else
             {
-                return Results.Conflict(new ErrorResponse(false, $"Board '{request.BoardId}' already exists"));
+                return Results.Conflict(new ErrorResponse(false, $"Board '{boardId}' already exists"));
             }
         })
         .WithName("AddBoard")
@@ -582,6 +587,20 @@ public static class TriggersEndpoint
         })
         .WithName("TestBoardRelay")
         .WithDescription("Manually control a relay for testing on a specific board (path params)");
+
+        // PUT /api/triggers/boards/{boardId}/{channel}/override - Set trigger override
+        group.MapPut("/boards/{boardId}/{channel:int}/override", (string boardId, int channel, RelayManualControlRequest request, TriggerService triggers) =>
+        {
+            try
+            {
+                var ok = triggers.SetOverride(Uri.UnescapeDataString(boardId), channel, request.On);
+                return ok
+                    ? Results.Ok(new { success = true, message = $"Override {(request.On ? "engaged" : "released")}.", boardId, channel, on = request.On })
+                    : Results.BadRequest(new ErrorResponse(false, "Board not connected or channel unavailable."));
+            }
+            catch (ArgumentException ex) { return Results.BadRequest(new ErrorResponse(false, ex.Message)); }
+        })
+        .WithTags("Triggers").WithName("SetTriggerOverride");
 
         // ============================================
         // Legacy Endpoints (for backwards compatibility)

--- a/src/MultiRoomAudio/Models/TriggerModels.cs
+++ b/src/MultiRoomAudio/Models/TriggerModels.cs
@@ -51,6 +51,8 @@ public enum RelayBoardType
     Modbus,
     /// <summary>LCUS binary relay board (1-8 channel) - uses simple binary protocol over CH340/CH341.</summary>
     Lcus,
+    /// <summary>Software-only virtual board; power state is published over MQTT for HA to mirror onto a smart outlet.</summary>
+    Virtual,
     /// <summary>Mock board for testing.</summary>
     Mock
 }
@@ -294,7 +296,8 @@ public record TriggerResponse(
     RelayState RelayState,
     bool IsActive,
     DateTime? LastActivated,
-    DateTime? ScheduledOffTime
+    DateTime? ScheduledOffTime,
+    bool IsOverridden = false
 );
 
 /// <summary>

--- a/src/MultiRoomAudio/Mqtt/HaDiscovery.cs
+++ b/src/MultiRoomAudio/Mqtt/HaDiscovery.cs
@@ -125,6 +125,54 @@ public class HaDiscovery
         };
     }
 
+    public IReadOnlyList<DiscoveryMessage> ForAmp(string boardId, string? boardDisplayName, TriggerResponse t)
+    {
+        var zone = $"{MqttTopics.Sanitize(boardId)}_{t.Channel}";
+        var stateTopic = _topics.AmpStateTopic(boardId, t.Channel);
+        var deviceId = $"mra_amp_{zone}";
+        var label = !string.IsNullOrWhiteSpace(t.ZoneName) ? t.ZoneName
+                  : !string.IsNullOrWhiteSpace(boardDisplayName) ? $"{boardDisplayName} CH{t.Channel}"
+                  : $"{boardId} CH{t.Channel}";
+        var device = Device(deviceId, label!, "Amplifier Zone");
+
+        DiscoveryMessage Entity(string component, string key, string name, Action<Utf8JsonWriter> extra)
+            => Build(component, $"mra_amp_{zone}_{key}", name, deviceId, stateTopic, device, extra);
+
+        return new List<DiscoveryMessage>
+        {
+            Entity("binary_sensor", "power", $"{label} Power", w =>
+            {
+                w.WriteString("value_template", "{{ value_json.power }}");
+                w.WriteString("payload_on", "ON");
+                w.WriteString("payload_off", "OFF");
+                w.WriteString("device_class", "power");
+            }),
+            Entity("sensor", "scheduled_off", $"{label} Scheduled Off", w =>
+            {
+                w.WriteString("value_template", "{{ value_json.scheduled_off }}");
+                w.WriteString("device_class", "timestamp");
+                w.WriteString("entity_category", "diagnostic");
+            }),
+            Entity("switch", "override", $"{label} Override", w =>
+            {
+                w.WriteString("command_topic", _topics.AmpCommandTopic(boardId, t.Channel, "override"));
+                w.WriteString("value_template", "{{ value_json.override }}");
+                w.WriteString("state_on", "ON");
+                w.WriteString("state_off", "OFF");
+                w.WriteString("payload_on", "ON");
+                w.WriteString("payload_off", "OFF");
+            }),
+            Entity("binary_sensor", "board_connected", $"{label} Board Connected", w =>
+            {
+                w.WriteString("value_template", "{{ value_json.board_connected }}");
+                w.WriteString("payload_on", "ON");
+                w.WriteString("payload_off", "OFF");
+                w.WriteString("device_class", "connectivity");
+                w.WriteString("entity_category", "diagnostic");
+            }),
+        };
+    }
+
     private DiscoveryMessage Build(string component, string uniqueId, string name,
         string deviceId, string stateTopic, Action<Utf8JsonWriter> deviceBlock,
         Action<Utf8JsonWriter> extra)

--- a/src/MultiRoomAudio/Mqtt/HaDiscovery.cs
+++ b/src/MultiRoomAudio/Mqtt/HaDiscovery.cs
@@ -125,6 +125,9 @@ public class HaDiscovery
         };
     }
 
+    /// <summary>
+    /// Returns HA MQTT discovery config messages for all entities belonging to a single amplifier zone (relay channel).
+    /// </summary>
     public IReadOnlyList<DiscoveryMessage> ForAmp(string boardId, string? boardDisplayName, TriggerResponse t)
     {
         var zone = $"{MqttTopics.Sanitize(boardId)}_{t.Channel}";

--- a/src/MultiRoomAudio/Mqtt/MqttCommand.cs
+++ b/src/MultiRoomAudio/Mqtt/MqttCommand.cs
@@ -2,34 +2,59 @@ using System.Globalization;
 
 namespace MultiRoomAudio.Mqtt;
 
-public enum MqttCommandKind { Unknown, PlayerOffset, PlayerRestart }
+public enum MqttCommandKind { Unknown, PlayerOffset, PlayerRestart, AmpOverride }
 
-public record ParsedCommand(MqttCommandKind Kind, string PlayerClientId, int? IntValue);
+public record ParsedCommand(
+    MqttCommandKind Kind,
+    string PlayerClientId,
+    int? IntValue,
+    string? AmpZone = null,
+    bool? BoolValue = null);
 
 /// <summary>
 /// Parses inbound MQTT command topics into typed commands. Pure — no dispatch.
-/// Topic shape: {base}/player/{sanitizedClientId}/{command}/set
+/// Player: {base}/player/{sanitizedClientId}/{command}/set
+/// Amp:    {base}/amp/{sanitizedBoardId_channel}/{command}/set
 /// </summary>
 public static class MqttCommand
 {
     public static ParsedCommand Parse(string baseTopic, string topic, string payload)
     {
-        var prefix = baseTopic.TrimEnd('/') + "/player/";
-        if (!topic.StartsWith(prefix, StringComparison.Ordinal))
-            return new ParsedCommand(MqttCommandKind.Unknown, "", null);
+        var root = baseTopic.TrimEnd('/');
 
-        var rest = topic[prefix.Length..];           // {id}/{command}/set
-        var parts = rest.Split('/');
-        if (parts.Length != 3 || parts[2] != "set")
-            return new ParsedCommand(MqttCommandKind.Unknown, "", null);
-
-        var id = parts[0];
-        return parts[1] switch
+        var playerPrefix = root + "/player/";
+        if (topic.StartsWith(playerPrefix, StringComparison.Ordinal))
         {
-            "offset" => new ParsedCommand(MqttCommandKind.PlayerOffset, id,
-                int.TryParse(payload, NumberStyles.Integer, CultureInfo.InvariantCulture, out var v) ? v : null),
-            "restart" => new ParsedCommand(MqttCommandKind.PlayerRestart, id, null),
-            _ => new ParsedCommand(MqttCommandKind.Unknown, id, null),
-        };
+            var parts = topic[playerPrefix.Length..].Split('/');   // {id}/{command}/set
+            if (parts.Length != 3 || parts[2] != "set")
+                return Unknown();
+            var id = parts[0];
+            return parts[1] switch
+            {
+                "offset" => new ParsedCommand(MqttCommandKind.PlayerOffset, id,
+                    int.TryParse(payload, NumberStyles.Integer, CultureInfo.InvariantCulture, out var v) ? v : null),
+                "restart" => new ParsedCommand(MqttCommandKind.PlayerRestart, id, null),
+                _ => new ParsedCommand(MqttCommandKind.Unknown, id, null),
+            };
+        }
+
+        var ampPrefix = root + "/amp/";
+        if (topic.StartsWith(ampPrefix, StringComparison.Ordinal))
+        {
+            var parts = topic[ampPrefix.Length..].Split('/');      // {zone}/{command}/set
+            if (parts.Length != 3 || parts[2] != "set")
+                return Unknown();
+            var zone = parts[0];
+            return parts[1] switch
+            {
+                "override" => new ParsedCommand(MqttCommandKind.AmpOverride, "", null,
+                    AmpZone: zone, BoolValue: payload.Trim().Equals("ON", StringComparison.OrdinalIgnoreCase)),
+                _ => Unknown(),
+            };
+        }
+
+        return Unknown();
     }
+
+    private static ParsedCommand Unknown() => new(MqttCommandKind.Unknown, "", null);
 }

--- a/src/MultiRoomAudio/Mqtt/MqttStatePayloads.cs
+++ b/src/MultiRoomAudio/Mqtt/MqttStatePayloads.cs
@@ -33,4 +33,13 @@ public static class MqttStatePayloads
         audio_backend = audioBackend,
         environment,
     });
+
+    /// <summary>Per-amp/zone state document. RelayState.On → power ON; Unknown → OFF.</summary>
+    public static string Amp(MultiRoomAudio.Models.TriggerResponse t, bool boardConnected) => JsonSerializer.Serialize(new
+    {
+        power = OnOff(t.RelayState == MultiRoomAudio.Models.RelayState.On),
+        scheduled_off = t.ScheduledOffTime,
+        @override = OnOff(t.IsOverridden),
+        board_connected = OnOff(boardConnected),
+    });
 }

--- a/src/MultiRoomAudio/Mqtt/MqttTopics.cs
+++ b/src/MultiRoomAudio/Mqtt/MqttTopics.cs
@@ -33,6 +33,18 @@ public class MqttTopics
     /// <summary>Single wildcard subscription covering all player command topics.</summary>
     public string PlayerCommandSubscription => $"{_base}/player/+/+/set";
 
+    private string AmpZone(string boardId, int channel) => $"{Sanitize(boardId)}_{channel}";
+
+    /// <summary>State topic for an amp/zone (one JSON document per zone).</summary>
+    public string AmpStateTopic(string boardId, int channel) => $"{_base}/amp/{AmpZone(boardId, channel)}/state";
+
+    /// <summary>Command topic for an amp/zone control (e.g. "override").</summary>
+    public string AmpCommandTopic(string boardId, int channel, string command) =>
+        $"{_base}/amp/{AmpZone(boardId, channel)}/{command}/set";
+
+    /// <summary>Single wildcard subscription covering all amp command topics.</summary>
+    public string AmpCommandSubscription => $"{_base}/amp/+/+/set";
+
     /// <summary>Home Assistant MQTT discovery config topic for the given component type and object ID.</summary>
     public string DiscoveryTopic(string component, string objectId) =>
         $"{_prefix}/{component}/{objectId}/config";

--- a/src/MultiRoomAudio/Relay/MockRelayBoardFactory.cs
+++ b/src/MultiRoomAudio/Relay/MockRelayBoardFactory.cs
@@ -29,6 +29,9 @@ public class MockRelayBoardFactory : IRelayBoardFactory
         _logger.LogDebug("Creating mock relay board: BoardId={BoardId}, BoardType={BoardType}, Serial={Serial}, Channels={Channels}",
             boardId, boardType, serial, channelCount);
 
+        if (boardType == RelayBoardType.Virtual)
+            return new VirtualRelayBoard(_loggerFactory.CreateLogger<VirtualRelayBoard>(), boardId, channelCount);
+
         return new MockRelayBoard(
             logger: _loggerFactory.CreateLogger<MockRelayBoard>(),
             serialNumber: serial,

--- a/src/MultiRoomAudio/Relay/RealRelayBoardFactory.cs
+++ b/src/MultiRoomAudio/Relay/RealRelayBoardFactory.cs
@@ -27,6 +27,7 @@ public class RealRelayBoardFactory : IRelayBoardFactory
             RelayBoardType.Ftdi => new FtdiRelayBoard(_loggerFactory.CreateLogger<FtdiRelayBoard>()),
             RelayBoardType.Modbus => CreateModbusBoard(boardId),
             RelayBoardType.Lcus => CreateLcusBoard(boardId),
+            RelayBoardType.Virtual => new VirtualRelayBoard(_loggerFactory.CreateLogger<VirtualRelayBoard>(), boardId),
             _ => throw new ArgumentException($"Unsupported board type: {boardType}", nameof(boardType))
         };
     }
@@ -64,6 +65,7 @@ public class RealRelayBoardFactory : IRelayBoardFactory
             RelayBoardType.Ftdi => FtdiRelayBoard.IsLibraryAvailable(),
             RelayBoardType.Modbus => true, // Serial ports are always available via System.IO.Ports
             RelayBoardType.Lcus => true, // Serial ports are always available via System.IO.Ports
+            RelayBoardType.Virtual => true, // software board, always available
             RelayBoardType.Mock => false, // Real factory doesn't create mock boards
             _ => false
         };

--- a/src/MultiRoomAudio/Relay/VirtualRelayBoard.cs
+++ b/src/MultiRoomAudio/Relay/VirtualRelayBoard.cs
@@ -23,10 +23,16 @@ public sealed class VirtualRelayBoard : IRelayBoard
         _channelCount = Math.Clamp(channelCount, 1, 16);
     }
 
+    /// <inheritdoc />
     public bool IsConnected => _isConnected;
+
+    /// <inheritdoc />
     public string? SerialNumber => _serialNumber;
+
+    /// <inheritdoc />
     public int ChannelCount => _channelCount;
 
+    /// <inheritdoc />
     public int CurrentState
     {
         get
@@ -38,6 +44,7 @@ public sealed class VirtualRelayBoard : IRelayBoard
         }
     }
 
+    /// <inheritdoc />
     public bool Open()
     {
         if (_disposed) return false;
@@ -45,10 +52,13 @@ public sealed class VirtualRelayBoard : IRelayBoard
         return true;
     }
 
+    /// <inheritdoc />
     public bool OpenBySerial(string serialNumber) => Open();
 
+    /// <inheritdoc />
     public void Close() => _isConnected = false;
 
+    /// <inheritdoc />
     public bool SetRelay(int channel, bool on)
     {
         if (!_isConnected || channel < 1 || channel > _channelCount) return false;
@@ -57,12 +67,14 @@ public sealed class VirtualRelayBoard : IRelayBoard
         return true;
     }
 
+    /// <inheritdoc />
     public RelayState GetRelay(int channel)
     {
         if (!_isConnected || channel < 1 || channel > _channelCount) return RelayState.Unknown;
         return _states[channel - 1] ? RelayState.On : RelayState.Off;
     }
 
+    /// <inheritdoc />
     public bool AllOff()
     {
         if (!_isConnected) return false;
@@ -70,6 +82,7 @@ public sealed class VirtualRelayBoard : IRelayBoard
         return true;
     }
 
+    /// <inheritdoc />
     public void Dispose()
     {
         if (_disposed) return;

--- a/src/MultiRoomAudio/Relay/VirtualRelayBoard.cs
+++ b/src/MultiRoomAudio/Relay/VirtualRelayBoard.cs
@@ -1,0 +1,79 @@
+using MultiRoomAudio.Models;
+
+namespace MultiRoomAudio.Relay;
+
+/// <summary>
+/// Software-only relay board. Records channel state in memory and is always ready once opened.
+/// Its power state reaches Home Assistant through the normal amp-state publish (driven by
+/// TriggerService.TriggersChanged) — there is no MQTT dependency in the relay layer itself.
+/// </summary>
+public sealed class VirtualRelayBoard : IRelayBoard
+{
+    private readonly ILogger<VirtualRelayBoard>? _logger;
+    private readonly string _serialNumber;
+    private readonly int _channelCount;
+    private readonly bool[] _states = new bool[16];
+    private bool _isConnected;
+    private bool _disposed;
+
+    public VirtualRelayBoard(ILogger<VirtualRelayBoard>? logger = null, string? serialNumber = null, int channelCount = 8)
+    {
+        _logger = logger;
+        _serialNumber = serialNumber ?? "VIRTUAL";
+        _channelCount = Math.Clamp(channelCount, 1, 16);
+    }
+
+    public bool IsConnected => _isConnected;
+    public string? SerialNumber => _serialNumber;
+    public int ChannelCount => _channelCount;
+
+    public int CurrentState
+    {
+        get
+        {
+            int s = 0;
+            for (int i = 0; i < _channelCount; i++)
+                if (_states[i]) s |= (1 << i);
+            return s;
+        }
+    }
+
+    public bool Open()
+    {
+        if (_disposed) return false;
+        _isConnected = true;
+        return true;
+    }
+
+    public bool OpenBySerial(string serialNumber) => Open();
+
+    public void Close() => _isConnected = false;
+
+    public bool SetRelay(int channel, bool on)
+    {
+        if (!_isConnected || channel < 1 || channel > _channelCount) return false;
+        _states[channel - 1] = on;
+        _logger?.LogDebug("Virtual relay '{Serial}' channel {Channel} → {State}", _serialNumber, channel, on ? "ON" : "OFF");
+        return true;
+    }
+
+    public RelayState GetRelay(int channel)
+    {
+        if (!_isConnected || channel < 1 || channel > _channelCount) return RelayState.Unknown;
+        return _states[channel - 1] ? RelayState.On : RelayState.Off;
+    }
+
+    public bool AllOff()
+    {
+        if (!_isConnected) return false;
+        Array.Clear(_states);
+        return true;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _isConnected = false;
+    }
+}

--- a/src/MultiRoomAudio/Services/MqttConfigService.cs
+++ b/src/MultiRoomAudio/Services/MqttConfigService.cs
@@ -77,7 +77,7 @@ public class MqttConfigService : YamlFileService<MqttSettings>
     private string ResolveSource(IReadOnlyDictionary<string, string?> env)
     {
         if (!string.IsNullOrWhiteSpace(env["MQTT_HOST"])) return "env";
-        if (_env.IsHaos && !string.IsNullOrWhiteSpace(_env.GetHaosOption<string?>("MQTT_HOST"))) return "haos";
+        if (_env.IsHaos && !string.IsNullOrWhiteSpace(_env.GetHaosOption<string?>("mqtt_host"))) return "haos";
         if (!string.IsNullOrWhiteSpace(Data.Host)) return "yaml";
         return "default";
     }
@@ -101,16 +101,16 @@ public class MqttConfigService : YamlFileService<MqttSettings>
         return new MqttSettings
         {
             Enabled = EnvStr("MQTT_ENABLED") is { } en ? IsTruthy(en)
-                      : haosBool("MQTT_ENABLED") ?? fromYaml.Enabled,
-            Host = EnvStr("MQTT_HOST") ?? haosString("MQTT_HOST") ?? fromYaml.Host,
+                      : haosBool("mqtt_enabled") ?? fromYaml.Enabled,
+            Host = EnvStr("MQTT_HOST") ?? haosString("mqtt_host") ?? fromYaml.Host,
             Port = (EnvStr("MQTT_PORT") is { } p && int.TryParse(p, out var pv)) ? pv
-                   : haosInt("MQTT_PORT") ?? fromYaml.Port,
-            Username = EnvStr("MQTT_USERNAME") ?? haosString("MQTT_USERNAME") ?? fromYaml.Username,
-            Password = EnvStr("MQTT_PASSWORD") ?? haosString("MQTT_PASSWORD") ?? fromYaml.Password,
+                   : haosInt("mqtt_port") ?? fromYaml.Port,
+            Username = EnvStr("MQTT_USERNAME") ?? haosString("mqtt_username") ?? fromYaml.Username,
+            Password = EnvStr("MQTT_PASSWORD") ?? haosString("mqtt_password") ?? fromYaml.Password,
             UseTls = EnvStr("MQTT_TLS") is { } tls ? IsTruthy(tls)
-                     : haosBool("MQTT_TLS") ?? fromYaml.UseTls,
-            DiscoveryPrefix = EnvStr("MQTT_DISCOVERY_PREFIX") ?? haosString("MQTT_DISCOVERY_PREFIX") ?? fromYaml.DiscoveryPrefix,
-            BaseTopic = EnvStr("MQTT_BASE_TOPIC") ?? haosString("MQTT_BASE_TOPIC") ?? fromYaml.BaseTopic,
+                     : haosBool("mqtt_tls") ?? fromYaml.UseTls,
+            DiscoveryPrefix = EnvStr("MQTT_DISCOVERY_PREFIX") ?? haosString("mqtt_discovery_prefix") ?? fromYaml.DiscoveryPrefix,
+            BaseTopic = EnvStr("MQTT_BASE_TOPIC") ?? haosString("mqtt_base_topic") ?? fromYaml.BaseTopic,
         };
     }
 }

--- a/src/MultiRoomAudio/Services/MqttService.cs
+++ b/src/MultiRoomAudio/Services/MqttService.cs
@@ -14,6 +14,7 @@ public class MqttService
 {
     private readonly MqttConfigService _config;
     private readonly PlayerManagerService _players;
+    private readonly TriggerService _triggers;
     private readonly VersionService _version;
     private readonly EnvironmentService _env;
     private readonly StartupProgressService _startup;
@@ -30,6 +31,7 @@ public class MqttService
     public MqttService(
         MqttConfigService config,
         PlayerManagerService players,
+        TriggerService triggers,
         VersionService version,
         EnvironmentService env,
         StartupProgressService startup,
@@ -37,6 +39,7 @@ public class MqttService
     {
         _config = config;
         _players = players;
+        _triggers = triggers;
         _version = version;
         _env = env;
         _startup = startup;
@@ -96,6 +99,7 @@ public class MqttService
         await ConnectAndAnnounceAsync(ct);
 
         _players.PlayersChanged += OnPlayersChanged;
+        _triggers.TriggersChanged += OnTriggersChanged;
     }
 
     private MqttClientOptions? _options;
@@ -107,6 +111,7 @@ public class MqttService
         _logger.LogInformation("MQTT bridge connected to broker");
 
         await _client.SubscribeAsync(_topics!.PlayerCommandSubscription, MqttQualityOfServiceLevel.AtLeastOnce, ct);
+        await _client.SubscribeAsync(_topics!.AmpCommandSubscription, MqttQualityOfServiceLevel.AtLeastOnce, ct);
         await PublishAvailabilityAsync("online", ct);
         await PublishDiscoveryAsync(ct);
         await PublishAllStateAsync(ct);
@@ -123,6 +128,12 @@ public class MqttService
 
         foreach (var m in _discovery!.ForContainer(_env.EnvironmentName))
             await PublishAsync(m.Topic, m.Payload, retain: true, ct);
+
+        var trig = _triggers.GetStatus();
+        foreach (var board in trig.Boards)
+            foreach (var t in board.Triggers)
+                foreach (var m in _discovery!.ForAmp(board.BoardId, board.DisplayName, t))
+                    await PublishAsync(m.Topic, m.Payload, retain: true, ct);
     }
 
     private async Task PublishAllStateAsync(CancellationToken ct)
@@ -135,6 +146,12 @@ public class MqttService
             MqttStatePayloads.Container(_startup.IsStartupComplete, _version.Version,
                 players.Count, _env.AudioBackend, _env.EnvironmentName),
             retain: true, ct);
+
+        var trigState = _triggers.GetStatus();
+        foreach (var board in trigState.Boards)
+            foreach (var t in board.Triggers)
+                await PublishAsync(_topics!.AmpStateTopic(board.BoardId, t.Channel),
+                    MqttStatePayloads.Amp(t, board.IsConnected), retain: true, ct);
     }
 
     private void OnPlayersChanged()
@@ -155,6 +172,23 @@ public class MqttService
         });
     }
 
+    private void OnTriggersChanged()
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                if (!IsConnected) return;
+                await PublishDiscoveryAsync(CancellationToken.None);
+                await PublishAllStateAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to publish MQTT state on trigger change");
+            }
+        });
+    }
+
     private async Task OnMessageReceivedAsync(MqttApplicationMessageReceivedEventArgs e)
     {
         try
@@ -168,6 +202,23 @@ public class MqttService
             var payload = Encoding.UTF8.GetString(payloadBytes);
             var cmd = MqttCommand.Parse(_baseTopic, topic, payload);
             if (cmd.Kind == MqttCommandKind.Unknown) return;
+
+            if (cmd.Kind == MqttCommandKind.AmpOverride && cmd.AmpZone is not null)
+            {
+                foreach (var board in _triggers.GetStatus().Boards)
+                {
+                    foreach (var t in board.Triggers)
+                    {
+                        if ($"{MqttTopics.Sanitize(board.BoardId)}_{t.Channel}" == cmd.AmpZone)
+                        {
+                            _triggers.SetOverride(board.BoardId, t.Channel, cmd.BoolValue ?? false);
+                            return;
+                        }
+                    }
+                }
+                _logger.LogWarning("MQTT amp override for unknown zone {Zone}", cmd.AmpZone);
+                return;
+            }
 
             var player = _players.GetAllPlayers().Players
                 .FirstOrDefault(p => MqttTopics.Sanitize(p.ClientId) == cmd.PlayerClientId);
@@ -258,6 +309,7 @@ public class MqttService
     {
         _shuttingDown = true;
         _players.PlayersChanged -= OnPlayersChanged;
+        _triggers.TriggersChanged -= OnTriggersChanged;
         _reconnectCts?.Cancel();
         _reconnectCts?.Dispose();
         _reconnectCts = null;

--- a/src/MultiRoomAudio/Services/TriggerService.cs
+++ b/src/MultiRoomAudio/Services/TriggerService.cs
@@ -336,6 +336,8 @@ public class TriggerService : IAsyncDisposable
                 boardType = RelayBoardType.UsbHid;
             else if (boardId.StartsWith("MODBUS:", StringComparison.OrdinalIgnoreCase))
                 boardType = RelayBoardType.Modbus;
+            else if (boardId.StartsWith("VIRTUAL:", StringComparison.OrdinalIgnoreCase))
+                boardType = RelayBoardType.Virtual;
             else
                 boardType = RelayBoardType.Ftdi;
         }
@@ -816,6 +818,8 @@ public class TriggerService : IAsyncDisposable
                     boardType = RelayBoardType.UsbHid;
                 else if (boardId.StartsWith("MODBUS:", StringComparison.OrdinalIgnoreCase))
                     boardType = RelayBoardType.Modbus;
+                else if (boardId.StartsWith("VIRTUAL:", StringComparison.OrdinalIgnoreCase))
+                    boardType = RelayBoardType.Virtual;
                 else
                     boardType = RelayBoardType.Ftdi;
             }
@@ -903,6 +907,10 @@ public class TriggerService : IAsyncDisposable
                     _logger.LogWarning("Board '{BoardId}' is FTDI type but factory didn't create FtdiRelayBoard", boardId);
                     connected = board.Open();
                 }
+            }
+            else if (boardId.StartsWith("VIRTUAL:", StringComparison.OrdinalIgnoreCase))
+            {
+                connected = board.Open();
             }
             else
             {

--- a/src/MultiRoomAudio/Services/TriggerService.cs
+++ b/src/MultiRoomAudio/Services/TriggerService.cs
@@ -619,6 +619,10 @@ public class TriggerService : IAsyncDisposable
         if (!_channelStates.TryGetValue((boardId, channel), out var state))
             return false;
 
+        // No-op: releasing an override that was never set — nothing to do, avoid a spurious publish.
+        if (!on && !state.IsOverridden)
+            return true;
+
         var offDelay = boardConfig.Triggers.FirstOrDefault(t => t.Channel == channel)?.OffDelaySeconds ?? 60;
 
         lock (_stateLock)

--- a/src/MultiRoomAudio/Services/TriggerService.cs
+++ b/src/MultiRoomAudio/Services/TriggerService.cs
@@ -37,6 +37,15 @@ public class TriggerService : IAsyncDisposable
     private TriggerFeatureConfiguration _config = new();
     private bool _disposed;
 
+    /// <summary>
+    /// Raised whenever a relay/channel or board state changes (auto on/off, off-timer,
+    /// manual control, override, connect/disconnect). The MQTT bridge subscribes to
+    /// publish amp state without polling.
+    /// </summary>
+    public event Action? TriggersChanged;
+
+    private void RaiseTriggersChanged() => TriggersChanged?.Invoke();
+
     // Track active triggers and their off timers using composite key (boardId, channel)
     private readonly ConcurrentDictionary<(string BoardId, int Channel), TriggerChannelState> _channelStates = new();
 
@@ -49,6 +58,7 @@ public class TriggerService : IAsyncDisposable
         public DateTime? LastActivated { get; set; }
         public Timer? OffDelayTimer { get; set; }
         public int ActivePlayerCount { get; set; }
+        public bool IsOverridden { get; set; }
     }
 
     public TriggerService(
@@ -239,7 +249,8 @@ public class TriggerService : IAsyncDisposable
                 LastActivated: channelState.LastActivated,
                 ScheduledOffTime: channelState.OffDelayTimer?.Enabled == true
                     ? channelState.LastActivated?.AddSeconds(config.OffDelaySeconds)
-                    : null
+                    : null,
+                IsOverridden: channelState.IsOverridden
             ));
         }
 
@@ -588,6 +599,66 @@ public class TriggerService : IAsyncDisposable
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Sticky manual override for a channel. ON forces the relay on and suspends the
+    /// playback auto-logic for that channel; OFF releases back to auto (stays on if a
+    /// player is active, otherwise starts the configured off-delay).
+    /// </summary>
+    public bool SetOverride(string boardId, int channel, bool on)
+    {
+        var boardConfig = _config.Boards.FirstOrDefault(b => b.BoardId == boardId);
+        if (boardConfig == null)
+            throw new ArgumentException($"Board '{boardId}' not found", nameof(boardId));
+        if (channel < 1 || channel > boardConfig.ChannelCount)
+            throw new ArgumentOutOfRangeException(nameof(channel), $"Channel must be between 1 and {boardConfig.ChannelCount}");
+
+        if (!_channelStates.TryGetValue((boardId, channel), out var state))
+            return false;
+
+        var offDelay = boardConfig.Triggers.FirstOrDefault(t => t.Channel == channel)?.OffDelaySeconds ?? 60;
+
+        lock (_stateLock)
+        {
+            if (on)
+            {
+                CancelOffTimer(boardId, channel);
+                state.IsOverridden = true;
+                state.IsActive = true;
+                state.LastActivated ??= DateTime.UtcNow;
+                var board = TryGetOrReconnectBoard(boardId);
+                board?.SetRelay(channel, true);
+                _logger.LogInformation("Override ON: Board '{BoardId}' channel {Channel} (auto-logic suspended)", boardId, channel);
+            }
+            else
+            {
+                state.IsOverridden = false;
+                if (state.ActivePlayerCount > 0)
+                {
+                    // A player is still active — keep it on, ensure relay reflects that.
+                    state.IsActive = true;
+                    TryGetOrReconnectBoard(boardId)?.SetRelay(channel, true);
+                    _logger.LogInformation("Override released: Board '{BoardId}' channel {Channel} → stays ON (active playback)", boardId, channel);
+                }
+                else if (state.IsActive)
+                {
+                    if (offDelay <= 0)
+                    {
+                        state.IsActive = false;
+                        TryGetOrReconnectBoard(boardId)?.SetRelay(channel, false);
+                    }
+                    else
+                    {
+                        StartOffTimer(boardId, channel, offDelay);
+                    }
+                    _logger.LogInformation("Override released: Board '{BoardId}' channel {Channel} → returning to auto (off in {Delay}s)", boardId, channel, offDelay);
+                }
+            }
+        }
+
+        RaiseTriggersChanged();
+        return true;
     }
 
     #endregion
@@ -1099,6 +1170,7 @@ public class TriggerService : IAsyncDisposable
                     boardId, channel, playerName, state.ActivePlayerCount);
             }
         }
+        RaiseTriggersChanged();
     }
 
     private void DeactivateTrigger(string boardId, int channel, int offDelaySeconds, string playerName)
@@ -1116,7 +1188,11 @@ public class TriggerService : IAsyncDisposable
                 playerName, boardId, channel, state.ActivePlayerCount);
 
             // Only start off delay if no players are active
-            if (state.ActivePlayerCount == 0 && state.IsActive)
+            if (state.IsOverridden)
+            {
+                // Manual override holds the relay on; auto-off is suspended until released.
+            }
+            else if (state.ActivePlayerCount == 0 && state.IsActive)
             {
                 if (offDelaySeconds <= 0)
                 {
@@ -1141,6 +1217,7 @@ public class TriggerService : IAsyncDisposable
                 }
             }
         }
+        RaiseTriggersChanged();
     }
 
     private void StartOffTimer(string boardId, int channel, int delaySeconds)
@@ -1174,6 +1251,9 @@ public class TriggerService : IAsyncDisposable
 
         lock (_stateLock)
         {
+            if (state.IsOverridden)
+                return;   // override holds the relay on
+
             // Check if still should turn off (no new players started)
             if (state.ActivePlayerCount == 0 && state.IsActive)
             {
@@ -1195,6 +1275,7 @@ public class TriggerService : IAsyncDisposable
                     boardId, channel, state.ActivePlayerCount);
             }
         }
+        RaiseTriggersChanged();
     }
 
     #endregion

--- a/src/MultiRoomAudio/wwwroot/index.html
+++ b/src/MultiRoomAudio/wwwroot/index.html
@@ -566,10 +566,13 @@
                         </div>
                     </div>
 
-                    <!-- Add Board Button -->
+                    <!-- Add Board Buttons -->
                     <div class="mb-3">
-                        <button class="btn btn-outline-primary btn-sm" onclick="showAddBoardDialog()">
+                        <button class="btn btn-outline-primary btn-sm me-2" onclick="showAddBoardDialog()">
                             <i class="fas fa-plus me-1"></i> Add Relay Board
+                        </button>
+                        <button class="btn btn-outline-secondary btn-sm" onclick="showAddVirtualBoardDialog()">
+                            <i class="fas fa-plus me-1"></i> Add Virtual Board
                         </button>
                         <span id="triggersTotalChannels" class="ms-2 text-muted small"></span>
                     </div>
@@ -644,6 +647,43 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                     <button type="button" class="btn btn-primary" onclick="addBoard()">Add Board</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Add Virtual Board Modal -->
+    <div class="modal fade" id="addVirtualBoardModal" tabindex="-1">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title"><i class="fas fa-plus me-2"></i>Add Virtual Board</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="text-muted small">
+                        <i class="fas fa-info-circle me-1"></i>
+                        A virtual board has no physical hardware. Its relay state is published via MQTT so
+                        Home Assistant can mirror amp power automatically.
+                    </p>
+                    <div class="mb-3">
+                        <label class="form-label" for="addVirtualBoardDisplayName">Display Name (optional)</label>
+                        <input type="text" class="form-control" id="addVirtualBoardDisplayName"
+                               placeholder="e.g., Living Room Amp">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label" for="addVirtualBoardChannelCount">Channel Count</label>
+                        <select class="form-select" id="addVirtualBoardChannelCount">
+                            <option value="1">1</option>
+                            <option value="2" selected>2</option>
+                            <option value="4">4</option>
+                            <option value="8">8</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" onclick="addVirtualBoard()">Add Board</button>
                 </div>
             </div>
         </div>

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -4898,6 +4898,8 @@ function renderTriggers() {
             ? '<span class="badge bg-warning text-dark ms-1" title="Identified by USB port - may change if moved"><i class="fas fa-exclamation-triangle"></i> Port-based</span>'
             : '';
 
+        const isVirtualBoard = board.boardType === 'Virtual';
+
         const channelsHtml = board.triggers.map(trigger => {
             const isOn = trigger.relayState === 'On';
             const activeStatus = isOn
@@ -4905,6 +4907,7 @@ function renderTriggers() {
                 : '<span class="badge bg-secondary ms-1">Off</span>';
             const onBtnClass = isOn ? 'btn btn-success btn-sm' : 'btn btn-outline-secondary btn-sm';
             const offBtnClass = !isOn && trigger.relayState === 'Off' ? 'btn btn-secondary btn-sm' : 'btn btn-outline-secondary btn-sm';
+            const overrideChecked = trigger.isOverridden ? 'checked' : '';
 
             return `
                 <tr>
@@ -4932,6 +4935,16 @@ function renderTriggers() {
                             <span class="input-group-text">s</span>
                         </div>
                     </td>
+                    <td>
+                        <div class="form-check form-switch mb-0" title="Manual override — force the relay ON regardless of playback state">
+                            <input class="form-check-input" type="checkbox" role="switch"
+                                   id="trigger-override-${boardIdSafe}-${trigger.channel}"
+                                   ${overrideChecked}
+                                   ${controlsDisabled ? 'disabled' : ''}
+                                   onchange="setChannelOverride('${boardId}', ${trigger.channel}, this.checked)">
+                            <label class="form-check-label small text-muted" for="trigger-override-${boardIdSafe}-${trigger.channel}">Override</label>
+                        </div>
+                    </td>
                     <td class="text-end" style="white-space: nowrap;">
                         <button class="${onBtnClass}"
                                 onclick="testTrigger('${boardId}', ${trigger.channel}, true)"
@@ -4951,9 +4964,15 @@ function renderTriggers() {
         }).join('');
 
         // Board type badge
-        const boardTypeLabel = board.boardType === 'Ftdi' ? 'FTDI' : (board.boardType === 'UsbHid' ? 'HID' : board.boardType);
+        const boardTypeLabel = board.boardType === 'Ftdi' ? 'FTDI'
+            : board.boardType === 'UsbHid' ? 'HID'
+            : board.boardType === 'Virtual' ? 'Virtual'
+            : board.boardType;
+        const boardTypeBadgeClass = board.boardType === 'Ftdi' ? 'bg-primary'
+            : board.boardType === 'Virtual' ? 'bg-purple text-white'
+            : 'bg-info';
         const boardTypeBadge = board.boardType
-            ? `<span class="badge ${board.boardType === 'Ftdi' ? 'bg-primary' : 'bg-info'} ms-2">${boardTypeLabel}</span>`
+            ? `<span class="badge ${boardTypeBadgeClass} ms-2" style="${board.boardType === 'Virtual' ? 'background-color:#6f42c1' : ''}">${boardTypeLabel}</span>`
             : '';
 
         return `
@@ -5017,12 +5036,14 @@ function renderTriggers() {
                             </span>
                         </div>
                         ${board.errorMessage ? `<div class="alert alert-warning small mb-2"><i class="fas fa-exclamation-triangle me-1"></i>${escapeHtml(board.errorMessage)}</div>` : ''}
+                        ${isVirtualBoard ? '<div class="alert alert-info small mb-2 py-1 px-2"><i class="fas fa-wifi me-1"></i>Virtual board — relay state is published via MQTT. MQTT must be enabled and connected for Home Assistant to mirror amp power.</div>' : ''}
                         <table class="table table-sm table-hover mb-0">
                             <thead>
                                 <tr>
                                     <th>Channel</th>
                                     <th>Sink</th>
                                     <th>Off Delay</th>
+                                    <th>Override</th>
                                     <th class="text-end trigger-action-header"><span class="trigger-action-col">On</span><span class="trigger-action-col">Off</span></th>
                                 </tr>
                             </thead>
@@ -5223,6 +5244,44 @@ async function addBoard() {
     } catch (error) {
         console.error('Error adding board:', error);
         showAlert(`Failed to add board: ${error.message}`, 'danger');
+    }
+}
+
+// Show add virtual board dialog
+let addVirtualBoardModal = null;
+
+function showAddVirtualBoardDialog() {
+    if (!addVirtualBoardModal) {
+        addVirtualBoardModal = new bootstrap.Modal(document.getElementById('addVirtualBoardModal'));
+    }
+    document.getElementById('addVirtualBoardDisplayName').value = '';
+    document.getElementById('addVirtualBoardChannelCount').value = '2';
+    addVirtualBoardModal.show();
+}
+
+// Add a new virtual board
+async function addVirtualBoard() {
+    const displayName = document.getElementById('addVirtualBoardDisplayName').value.trim();
+    const channelCount = parseInt(document.getElementById('addVirtualBoardChannelCount').value, 10);
+
+    try {
+        const response = await fetch('./api/triggers/boards', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ boardType: 'Virtual', displayName: displayName || null, channelCount })
+        });
+
+        if (!response.ok) {
+            const error = await response.json();
+            throw new Error(error.message || 'Failed to add virtual board');
+        }
+
+        addVirtualBoardModal.hide();
+        await loadTriggers();
+        showAlert('Virtual board added successfully', 'success');
+    } catch (error) {
+        console.error('Error adding virtual board:', error);
+        showAlert(`Failed to add virtual board: ${error.message}`, 'danger');
     }
 }
 
@@ -5634,6 +5693,52 @@ async function testTrigger(boardId, channel, on) {
     } catch (error) {
         console.error('Error testing trigger:', error);
         showAlert(`Failed to test relay: ${error.message}`, 'danger');
+    } finally {
+        triggersOperationCount--;
+    }
+}
+
+// Set manual override for a channel (forces relay ON regardless of playback state)
+async function setChannelOverride(boardId, channel, on) {
+    triggersOperationCount++;
+
+    // Save expanded state before any async operations
+    const container = document.getElementById('triggersContainer');
+    container.querySelectorAll('.accordion-collapse.show').forEach(el => {
+        const match = el.id.match(/^board-(.+)$/);
+        if (match) {
+            expandedBoardsState.add(match[1]);
+        }
+    });
+
+    try {
+        const url = `./api/triggers/boards/${encodeURIComponent(boardId)}/${channel}/override`;
+        const response = await fetch(url, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ on })
+        });
+
+        if (!response.ok) {
+            const error = await response.json();
+            throw new Error(error.message || 'Failed to set override');
+        }
+
+        showAlert(`Channel ${channel} override ${on ? 'enabled' : 'disabled'}`, 'success', 2000);
+
+        // Update local data and re-render to reflect new state
+        const board = triggersData?.boards?.find(b => b.boardId === boardId);
+        if (board) {
+            const trigger = board.triggers?.find(t => t.channel === channel);
+            if (trigger) {
+                trigger.isOverridden = on;
+            }
+        }
+    } catch (error) {
+        console.error('Error setting channel override:', error);
+        showAlert(`Failed to set override: ${error.message}`, 'danger');
+        // Revert the toggle by reloading
+        await loadTriggers();
     } finally {
         triggersOperationCount--;
     }

--- a/tests/MultiRoomAudio.Tests/Mqtt/AmpCommandTests.cs
+++ b/tests/MultiRoomAudio.Tests/Mqtt/AmpCommandTests.cs
@@ -1,0 +1,32 @@
+using MultiRoomAudio.Mqtt;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Mqtt;
+
+public class AmpCommandTests
+{
+    [Fact]
+    public void Parse_AmpOverrideOn()
+    {
+        var c = MqttCommand.Parse("multiroom-audio", "multiroom-audio/amp/virtual_x_1/override/set", "ON");
+        Assert.Equal(MqttCommandKind.AmpOverride, c.Kind);
+        Assert.Equal("virtual_x_1", c.AmpZone);
+        Assert.True(c.BoolValue);
+    }
+
+    [Fact]
+    public void Parse_AmpOverrideOff()
+    {
+        var c = MqttCommand.Parse("multiroom-audio", "multiroom-audio/amp/virtual_x_1/override/set", "OFF");
+        Assert.Equal(MqttCommandKind.AmpOverride, c.Kind);
+        Assert.False(c.BoolValue);
+    }
+
+    [Fact]
+    public void Parse_PlayerOffset_StillWorks()
+    {
+        var c = MqttCommand.Parse("multiroom-audio", "multiroom-audio/player/abc123/offset/set", "250");
+        Assert.Equal(MqttCommandKind.PlayerOffset, c.Kind);
+        Assert.Equal(250, c.IntValue);
+    }
+}

--- a/tests/MultiRoomAudio.Tests/Mqtt/AmpDiscoveryTests.cs
+++ b/tests/MultiRoomAudio.Tests/Mqtt/AmpDiscoveryTests.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using System.Text.Json;
+using MultiRoomAudio.Models;
+using MultiRoomAudio.Mqtt;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Mqtt;
+
+public class AmpDiscoveryTests
+{
+    private readonly HaDiscovery _d = new(new MqttTopics("multiroom-audio", "homeassistant"), "1.2.3");
+
+    private static TriggerResponse Zone() => new(
+        Channel: 1, CustomSinkName: "sink", CustomSinkDisplayName: "Sink",
+        OffDelaySeconds: 30, ZoneName: "Living Room", RelayState: RelayState.On,
+        IsActive: true, LastActivated: null, ScheduledOffTime: null, IsOverridden: false);
+
+    [Fact]
+    public void Amp_EmitsOverrideSwitchWithCommandTopic()
+    {
+        var sw = _d.ForAmp("VIRTUAL:x", "Living Room Amp", Zone()).Single(m => m.Topic.Contains("/switch/"));
+        using var doc = JsonDocument.Parse(sw.Payload);
+        var root = doc.RootElement;
+        Assert.Equal("multiroom-audio/amp/virtual_x_1/override/set", root.GetProperty("command_topic").GetString());
+        Assert.Equal("multiroom-audio/amp/virtual_x_1/state", root.GetProperty("state_topic").GetString());
+    }
+
+    [Fact]
+    public void Amp_AllEntitiesShareDeviceIdentifier()
+    {
+        var ids = _d.ForAmp("VIRTUAL:x", "Living Room Amp", Zone()).Select(m =>
+        {
+            using var doc = JsonDocument.Parse(m.Payload);
+            return doc.RootElement.GetProperty("device").GetProperty("identifiers")[0].GetString();
+        }).Distinct().ToList();
+        Assert.Single(ids);
+        Assert.Equal("mra_amp_virtual_x_1", ids[0]);
+    }
+
+    [Fact]
+    public void Amp_EmitsPowerBinarySensor()
+        => Assert.Contains(_d.ForAmp("VIRTUAL:x", null, Zone()), m => m.Topic.Contains("/binary_sensor/") && m.Payload.Contains("value_json.power"));
+}

--- a/tests/MultiRoomAudio.Tests/Mqtt/AmpStatePayloadsTests.cs
+++ b/tests/MultiRoomAudio.Tests/Mqtt/AmpStatePayloadsTests.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using MultiRoomAudio.Models;
+using MultiRoomAudio.Mqtt;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Mqtt;
+
+public class AmpStatePayloadsTests
+{
+    private static TriggerResponse Zone(RelayState s, bool overridden) => new(
+        Channel: 1, CustomSinkName: "sink", CustomSinkDisplayName: "Sink",
+        OffDelaySeconds: 30, ZoneName: "Living Room", RelayState: s,
+        IsActive: s == RelayState.On, LastActivated: null, ScheduledOffTime: null,
+        IsOverridden: overridden);
+
+    [Fact]
+    public void Amp_SerializesPowerOverrideAndConnectivity()
+    {
+        using var doc = JsonDocument.Parse(MqttStatePayloads.Amp(Zone(RelayState.On, overridden: true), boardConnected: true));
+        var root = doc.RootElement;
+        Assert.Equal("ON", root.GetProperty("power").GetString());
+        Assert.Equal("ON", root.GetProperty("override").GetString());
+        Assert.Equal("ON", root.GetProperty("board_connected").GetString());
+    }
+
+    [Fact]
+    public void Amp_PowerOff_WhenRelayOff()
+    {
+        using var doc = JsonDocument.Parse(MqttStatePayloads.Amp(Zone(RelayState.Off, overridden: false), boardConnected: false));
+        var root = doc.RootElement;
+        Assert.Equal("OFF", root.GetProperty("power").GetString());
+        Assert.Equal("OFF", root.GetProperty("override").GetString());
+        Assert.Equal("OFF", root.GetProperty("board_connected").GetString());
+    }
+}

--- a/tests/MultiRoomAudio.Tests/Mqtt/AmpTopicsTests.cs
+++ b/tests/MultiRoomAudio.Tests/Mqtt/AmpTopicsTests.cs
@@ -1,0 +1,21 @@
+using MultiRoomAudio.Mqtt;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Mqtt;
+
+public class AmpTopicsTests
+{
+    private readonly MqttTopics _t = new("multiroom-audio", "homeassistant");
+
+    [Fact]
+    public void AmpState_UsesSanitizedBoardAndChannel()
+        => Assert.Equal("multiroom-audio/amp/virtual_x_1/state", _t.AmpStateTopic("VIRTUAL:x", 1));
+
+    [Fact]
+    public void AmpCommand_AppendsSetSuffix()
+        => Assert.Equal("multiroom-audio/amp/virtual_x_1/override/set", _t.AmpCommandTopic("VIRTUAL:x", 1, "override"));
+
+    [Fact]
+    public void AmpCommandSubscription_IsWildcard()
+        => Assert.Equal("multiroom-audio/amp/+/+/set", _t.AmpCommandSubscription);
+}

--- a/tests/MultiRoomAudio.Tests/Mqtt/MqttConfigServiceTests.cs
+++ b/tests/MultiRoomAudio.Tests/Mqtt/MqttConfigServiceTests.cs
@@ -49,3 +49,20 @@ public class MqttConfigOverrideTests
         Assert.Equal(1883, result.Port);
     }
 }
+
+public class MqttConfigHaosKeyTests
+{
+    [Fact]
+    public void HaosSnakeCaseKeys_Resolve_AndOverrideYaml()
+    {
+        var result = MultiRoomAudio.Services.MqttConfigService.ApplyOverrides(
+            new MqttSettings { Host = "yaml-host", Enabled = false },
+            new Dictionary<string, string?>(),                 // no env
+            haosBool: key => key == "mqtt_enabled" ? true : (bool?)null,
+            haosString: key => key == "mqtt_host" ? "haos-host" : null,
+            haosInt: _ => null);
+
+        Assert.True(result.Enabled);              // from mqtt_enabled
+        Assert.Equal("haos-host", result.Host);   // from mqtt_host overriding yaml
+    }
+}

--- a/tests/MultiRoomAudio.Tests/Relay/VirtualRelayBoardTests.cs
+++ b/tests/MultiRoomAudio.Tests/Relay/VirtualRelayBoardTests.cs
@@ -1,0 +1,39 @@
+using MultiRoomAudio.Models;
+using MultiRoomAudio.Relay;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Relay;
+
+public class VirtualRelayBoardTests
+{
+    [Fact]
+    public void SetAndGet_RoundTrips()
+    {
+        var b = new VirtualRelayBoard(serialNumber: "VIRTUAL:x", channelCount: 4);
+        Assert.True(b.Open());
+        Assert.True(b.IsConnected);
+        Assert.True(b.SetRelay(2, true));
+        Assert.Equal(RelayState.On, b.GetRelay(2));
+        Assert.Equal(RelayState.Off, b.GetRelay(1));
+        Assert.Equal(0b10, b.CurrentState);
+    }
+
+    [Fact]
+    public void AllOff_ClearsState()
+    {
+        var b = new VirtualRelayBoard(serialNumber: "VIRTUAL:x", channelCount: 4);
+        b.Open();
+        b.SetRelay(1, true);
+        Assert.True(b.AllOff());
+        Assert.Equal(0, b.CurrentState);
+    }
+
+    [Fact]
+    public void RealFactory_CreatesVirtualBoard()
+    {
+        var f = new RealRelayBoardFactory(Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance);
+        Assert.True(f.CanCreate("VIRTUAL:x", RelayBoardType.Virtual));
+        var board = f.CreateBoard("VIRTUAL:x", RelayBoardType.Virtual);
+        Assert.IsType<VirtualRelayBoard>(board);
+    }
+}

--- a/tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs
+++ b/tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs
@@ -1,0 +1,21 @@
+using MultiRoomAudio.Models;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Services;
+
+public class TriggerModelsTests
+{
+    [Fact]
+    public void TriggerResponse_IsOverridden_DefaultsFalse()
+    {
+        var r = new TriggerResponse(
+            Channel: 1, CustomSinkName: null, CustomSinkDisplayName: null,
+            OffDelaySeconds: 60, ZoneName: null, RelayState: RelayState.Off,
+            IsActive: false, LastActivated: null, ScheduledOffTime: null);
+        Assert.False(r.IsOverridden);
+    }
+
+    [Fact]
+    public void RelayBoardType_HasVirtual()
+        => Assert.True(System.Enum.IsDefined(typeof(RelayBoardType), RelayBoardType.Virtual));
+}

--- a/tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs
+++ b/tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs
@@ -1,7 +1,86 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
 using MultiRoomAudio.Models;
+using MultiRoomAudio.Relay;
+using MultiRoomAudio.Services;
 using Xunit;
 
 namespace MultiRoomAudio.Tests.Services;
+
+public class TriggerOverrideBehaviorTests
+{
+    // Builds a TriggerService in mock mode with one virtual board + one configured channel.
+    private static async Task<(TriggerService svc, string boardId)> SetupAsync()
+    {
+        var svc = TriggerTestHarness.CreateMockService();
+        svc.SetEnabled(true);
+        var boardId = "VIRTUAL:test01";
+        svc.AddBoard(boardId, "Test Zone", channelCount: 2, boardType: RelayBoardType.Virtual);
+        svc.ConfigureTrigger(boardId, channel: 1, customSinkName: "sink1", offDelaySeconds: 30, zoneName: "Zone 1");
+        await Task.CompletedTask;
+        return (svc, boardId);
+    }
+
+    [Fact]
+    public async Task Override_On_ForcesRelayOn_AndReportsOverridden()
+    {
+        var (svc, boardId) = await SetupAsync();
+        Assert.True(svc.SetOverride(boardId, 1, true));
+
+        var ch = svc.GetBoardStatus(boardId)!.Triggers.Single(t => t.Channel == 1);
+        Assert.Equal(RelayState.On, ch.RelayState);
+        Assert.True(ch.IsOverridden);
+    }
+
+    [Fact]
+    public async Task Override_Suspends_AutoOff_WhilePlaybackStops()
+    {
+        var (svc, boardId) = await SetupAsync();
+        svc.OnPlayerStarted("p1", "sink1");     // auto-on
+        svc.SetOverride(boardId, 1, true);      // grab manual control
+        svc.OnPlayerStopped("p1", "sink1");     // would normally schedule off
+
+        var ch = svc.GetBoardStatus(boardId)!.Triggers.Single(t => t.Channel == 1);
+        Assert.Equal(RelayState.On, ch.RelayState);   // still on — auto-off suppressed
+        Assert.True(ch.IsOverridden);
+        Assert.Null(ch.ScheduledOffTime);             // no off-timer scheduled
+    }
+
+    [Fact]
+    public async Task Release_WhileIdle_SchedulesOff()
+    {
+        var (svc, boardId) = await SetupAsync();
+        svc.SetOverride(boardId, 1, true);   // on, no players
+        svc.SetOverride(boardId, 1, false);  // release while idle
+
+        var ch = svc.GetBoardStatus(boardId)!.Triggers.Single(t => t.Channel == 1);
+        Assert.False(ch.IsOverridden);
+        Assert.NotNull(ch.ScheduledOffTime);  // off-delay started
+    }
+
+    [Fact]
+    public async Task Release_WhilePlaying_StaysOn_NoOffTimer()
+    {
+        var (svc, boardId) = await SetupAsync();
+        svc.OnPlayerStarted("p1", "sink1");
+        svc.SetOverride(boardId, 1, true);
+        svc.SetOverride(boardId, 1, false);  // release with a player still active
+
+        var ch = svc.GetBoardStatus(boardId)!.Triggers.Single(t => t.Channel == 1);
+        Assert.Equal(RelayState.On, ch.RelayState);
+        Assert.Null(ch.ScheduledOffTime);
+    }
+
+    [Fact]
+    public async Task TriggersChanged_FiresOnOverride()
+    {
+        var (svc, boardId) = await SetupAsync();
+        int fires = 0;
+        svc.TriggersChanged += () => fires++;
+        svc.SetOverride(boardId, 1, true);
+        Assert.True(fires >= 1);
+    }
+}
 
 public class TriggerModelsTests
 {

--- a/tests/MultiRoomAudio.Tests/Services/TriggerTestHarness.cs
+++ b/tests/MultiRoomAudio.Tests/Services/TriggerTestHarness.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MultiRoomAudio.Audio.Mock;
+using MultiRoomAudio.Relay;
+using MultiRoomAudio.Services;
+using MultiRoomAudio.Utilities;
+
+namespace MultiRoomAudio.Tests.Services;
+
+/// <summary>
+/// Builds a TriggerService wired entirely to mock/in-memory dependencies for unit tests.
+///
+/// Harness decisions:
+/// - CONFIG_PATH env var is set to a per-test temp directory so TriggerService writes
+///   triggers.yaml to a throwaway location (not the repo or /app/config).
+/// - CustomSinksService is constructed with MockPaModuleRunner and VolumeCommandRunner
+///   (both safe to run on Windows with no PulseAudio present).
+/// - IServiceProvider is a minimal ServiceCollection with no services registered
+///   (CustomSinksService uses it only for optional plugin lookups that don't run in tests).
+/// - VIRTUAL: boards connect via the else/OpenBySerial path in ConnectBoard, which the
+///   MockRelayBoard accepts unconditionally, so GetBoardStatus reflects relay state.
+/// - SetEnabled(true) must be called before AddBoard so ConnectBoard runs during AddBoard.
+/// </summary>
+internal static class TriggerTestHarness
+{
+    public static TriggerService CreateMockService()
+    {
+        // Point config at a temp dir so file I/O doesn't touch real paths or fail on Windows.
+        var tempConfig = Path.Combine(Path.GetTempPath(), "trigger-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempConfig);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", tempConfig);
+
+        var loggerFactory = NullLoggerFactory.Instance;
+        var env = new EnvironmentService(NullLogger<EnvironmentService>.Instance);
+
+        var moduleRunner = new MockPaModuleRunner(NullLogger<MockPaModuleRunner>.Instance);
+        var volumeRunner = new VolumeCommandRunner(NullLogger<VolumeCommandRunner>.Instance);
+        var services = new ServiceCollection().BuildServiceProvider();
+        var sinks = new CustomSinksService(
+            NullLogger<CustomSinksService>.Instance,
+            moduleRunner,
+            env,
+            volumeRunner,
+            services);
+
+        var enumerator = new MockRelayDeviceEnumerator(NullLogger<MockRelayDeviceEnumerator>.Instance);
+        var factory = new MockRelayBoardFactory(loggerFactory);
+
+        return new TriggerService(
+            NullLogger<TriggerService>.Instance,
+            loggerFactory,
+            sinks,
+            env,
+            enumerator,
+            factory,
+            hubContext: null);
+    }
+}

--- a/tests/MultiRoomAudio.Tests/Services/TriggerTestHarness.cs
+++ b/tests/MultiRoomAudio.Tests/Services/TriggerTestHarness.cs
@@ -23,15 +23,33 @@ namespace MultiRoomAudio.Tests.Services;
 /// </summary>
 internal static class TriggerTestHarness
 {
+    private static readonly object _envLock = new();
+
     public static TriggerService CreateMockService()
     {
         // Point config at a temp dir so file I/O doesn't touch real paths or fail on Windows.
         var tempConfig = Path.Combine(Path.GetTempPath(), "trigger-test-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempConfig);
-        Environment.SetEnvironmentVariable("CONFIG_PATH", tempConfig);
 
         var loggerFactory = NullLoggerFactory.Instance;
-        var env = new EnvironmentService(NullLogger<EnvironmentService>.Instance);
+        EnvironmentService env;
+
+        // Lock so that concurrent harness calls cannot interleave their CONFIG_PATH mutation
+        // with EnvironmentService construction (EnvironmentService reads CONFIG_PATH once, in
+        // its constructor, so restoring afterward is safe).
+        lock (_envLock)
+        {
+            var prev = Environment.GetEnvironmentVariable("CONFIG_PATH");
+            try
+            {
+                Environment.SetEnvironmentVariable("CONFIG_PATH", tempConfig);
+                env = new EnvironmentService(NullLogger<EnvironmentService>.Instance);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("CONFIG_PATH", prev);
+            }
+        }
 
         var moduleRunner = new MockPaModuleRunner(NullLogger<MockPaModuleRunner>.Instance);
         var volumeRunner = new VolumeCommandRunner(NullLogger<VolumeCommandRunner>.Instance);


### PR DESCRIPTION
## Summary

Phase 2 of the MQTT → Home Assistant bridge (Phase 1 = #235, merged). Exposes the **12V amp/relay zones** to Home Assistant, adds a **sticky manual-override switch**, introduces a **virtual relay board**, and lets HAOS users **turn MQTT on from the add-on configuration**.

Builds on Phase 1's bridge engine and command pipeline. Player volume/mute/transport stay out of scope (Music Assistant owns them); the per-player `sync_error_ms` sensor was intentionally dropped (keeps MQTT traffic lean — the clock-synced binary_sensor is the actionable signal).

## What's included

**Per amp/zone device** (one HA device per board+channel):
- `binary_sensor` amp power (device_class power)
- `sensor` scheduled-off (timestamp)
- `switch` manual override
- `binary_sensor` board connected (diagnostic)

**Sticky override** (`TriggerService.SetOverride`): switch ON forces the amp on and suspends the playback auto-logic for that channel; OFF releases back to auto — stays on if a player is active, otherwise starts the configured off-delay. Works uniformly for every board type (HID/FTDI/Modbus/LCUS/Virtual).

**Virtual relay board** (`RelayBoardType.Virtual`): a software `IRelayBoard` with no hardware and no MQTT coupling in the relay layer. Added manually via the triggers API/UI (`VIRTUAL:<id>`). Its power state reaches HA through the normal amp-state publish, so an HA automation can mirror it onto a smart outlet — driving a non-12V amp from Multi-Room's playback logic.

**Plumbing:**
- New `TriggersChanged` event drives amp publishing (mirrors Phase 1's `PlayersChanged`); fire-and-forget, exception-contained.
- Amp discovery/state/command builders extend the Phase 1 pure units; override commands dispatched via the existing command pipeline.
- HAOS add-on `config.yaml` MQTT options (`mqtt_enabled` + broker fields); `MqttConfigService` HAOS lookups aligned to snake_case keys. **Docker unchanged** (`MQTT_*` env vars).
- Triggers web UI: add-virtual-board + per-channel override toggle. (Onboarding wizard intentionally untouched — advanced/optional feature.)

## MQTT-down behavior

A virtual zone reaching HA depends on MQTT being connected. This is surfaced via the bridge **LWT availability** — if MQTT drops, the whole amp device goes `unavailable` in HA. (The design spec documents why this supersedes a per-board `board_connected=OFF` flag.)

## Testing

- 64/64 unit tests pass (new: amp topics/state/discovery/command, `VirtualRelayBoard`, sticky-override behavior, HAOS snake_case resolution).
- Solution builds 0 errors / 0 warnings.
- Live API smoke: created a `VIRTUAL:` board and engaged/released override via the new endpoints.
- UI not browser-smoke-tested (verified by inspection) — worth a manual click-through.

## Tracked follow-ups (not in this PR)

- Decouple discovery republish from every state tick (Phase 1 carryover; idempotent but chatty).
- HAOS Supervisor `services/mqtt` broker auto-detect (convenience on top of the config-options path).
- Minor UI polish: override toggle uses optimistic update (no full re-render); override endpoint decode idiom.

Design spec and plan are under `docs/superpowers/`.