### PR TITLE
fix: expose MQTT options in dev add-on config

### DIFF
--- a/multiroom-audio-dev/config.yaml
+++ b/multiroom-audio-dev/config.yaml
@@ -43,11 +43,18 @@ options:
   log_level: info
   mock_hardware: false
   enable_advanced_formats: false
+  mqtt_enabled: false
 
 schema:
   log_level: list(debug|info|warning|error)
   mock_hardware: bool?
   enable_advanced_formats: bool?
+  mqtt_enabled: bool
+  mqtt_host: str?
+  mqtt_port: port?
+  mqtt_username: str?
+  mqtt_password: password?
+  mqtt_tls: bool?
 
 # Watchdog - auto-restart if health check fails
 watchdog: http://[HOST]:[PORT:8096]/api/health


### PR DESCRIPTION
## Summary

Follow-up to the MQTT bridge (PRs #235, #236). The HAOS add-on MQTT options were added to the **stable** add-on (`multiroom-audio/config.yaml`) but not the **dev** add-on (`multiroom-audio-dev/config.yaml`). Since the dev add-on (slug `multiroom-audio-dev`) is what's installed for testing, its Configuration screen showed no MQTT controls.

This mirrors the same `options`/`schema` additions into the dev add-on, alongside its existing dev-only toggles (`mock_hardware`, `enable_advanced_formats`):

```yaml
options:
  mqtt_enabled: false
schema:
  mqtt_enabled: bool
  mqtt_host: str?
  mqtt_port: port?
  mqtt_username: str?
  mqtt_password: password?
  mqtt_tls: bool?
```

Keys are snake_case to match `MqttConfigService`'s HAOS option lookups. Docker is unaffected (env vars).

## Note

HAOS only refreshes the add-on Configuration schema on an **update/reinstall** (new version), not a plain restart — so the dev add-on must be rebuilt for the new options to appear.