### PR TITLE
fix: add MQTT options to dev add-on config on main

### DIFF
--- a/multiroom-audio-dev/config.yaml
+++ b/multiroom-audio-dev/config.yaml
@@ -43,11 +43,18 @@ options:
   log_level: info
   mock_hardware: false
   enable_advanced_formats: false
+  mqtt_enabled: false
 
 schema:
   log_level: list(debug|info|warning|error)
   mock_hardware: bool?
   enable_advanced_formats: bool?
+  mqtt_enabled: bool
+  mqtt_host: str?
+  mqtt_port: port?
+  mqtt_username: str?
+  mqtt_password: password?
+  mqtt_tls: bool?
 
 # Watchdog - auto-restart if health check fails
 watchdog: http://[HOST]:[PORT:8096]/api/health


### PR DESCRIPTION
## Why this targets `main` (not `dev`)

HAOS reads the **dev add-on** Configuration schema from `multiroom-audio-dev/config.yaml` on the repo's **default branch (`main`)**. The CI `update-addon-version-dev` job (on every `dev` push) checks out `main` and `sed`s only the `version:`/`image:` lines of that file — it does **not** sync `options`/`schema` from `dev`.

So the MQTT options added on `dev` (PRs #235/#236/#237) reached the *image* (the running container has the MQTT backend, version `sha-12692be`) but never reached `main`'s schema — which is why the add-on's **Configuration tab showed no MQTT controls** despite the feature being live.

## Change

Adds the MQTT `options`/`schema` to `multiroom-audio-dev/config.yaml` **on `main`**, alongside the existing dev toggles. The CI-managed `version:`/`image:` lines are untouched (and the next dev-push `sed` only rewrites those, so these options persist).

```yaml
options:
  mqtt_enabled: false
schema:
  mqtt_enabled: bool
  mqtt_host: str?
  mqtt_port: port?
  mqtt_username: str?
  mqtt_password: password?
  mqtt_tls: bool?
```

Keys are snake_case to match `MqttConfigService`'s HAOS lookups.

## After merge

Rebuild/refresh the dev add-on so HAOS re-reads the schema — the **Mqtt enabled** toggle + broker fields will appear in the Configuration tab.

## Follow-up

The stable add-on (`multiroom-audio/config.yaml`) gets these options via the normal `dev → main` release (they're already on `dev`). This PR only fixes the dev add-on, whose schema is maintained directly on `main`.