### PR TITLE
fix: load custom sinks in dependency order so combine-of-remaps survives restart

### DIFF
--- a/multiroom-audio/CHANGELOG.md
+++ b/multiroom-audio/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [5.2.1] - Combine Sink Startup Fix
+
+### Fixed
+- Combine sinks built from custom remap sinks now reload correctly after an add-on restart. Startup loading is ordered by actual sink dependencies (topological sort) instead of a fixed combine-then-remap order, so a combine sink no longer initializes before the remap sinks it depends on (#247)
+- Stopped sink migration from treating references to other custom sinks as missing hardware, removing a misleading "slave sink not found" warning on startup
+
 ## [5.2.0] - Home Assistant MQTT Bridge & Amp Override Controls
 
 ### Highlights

--- a/src/MultiRoomAudio/Services/CustomSinksService.cs
+++ b/src/MultiRoomAudio/Services/CustomSinksService.cs
@@ -86,11 +86,10 @@ public class CustomSinksService : IAsyncDisposable
         // Migrate old configs that don't have identifiers or have stale sink names
         configs = MigrateConfigurations(configs);
 
-        // Sort by dependency order: combine sinks first, then remap sinks
-        // (remap sinks might depend on combine sinks as their master)
-        var sorted = configs
-            .OrderBy(c => c.Type == CustomSinkType.Combine ? 0 : 1)
-            .ToList();
+        // Sort so each sink is loaded only after the custom sinks it references.
+        // Both directions occur: a remap can use a combine as its master, and a combine
+        // can use remaps as its slaves. A topological sort handles either topology (#247).
+        var sorted = SortByDependencyOrder(configs);
 
         var loadedCount = 0;
         var failedCount = 0;
@@ -686,9 +685,17 @@ public class CustomSinksService : IAsyncDisposable
 
         var needsSave = false;
 
+        // Names of all custom sinks. References that name another custom sink are resolved by
+        // load ordering (SortByDependencyOrder), not hardware migration - skip them below so we
+        // don't spuriously warn or mis-map a custom-sink name onto a hardware device.
+        var customSinkNames = new HashSet<string>(
+            configs.Select(c => c.Name), StringComparer.OrdinalIgnoreCase);
+
         foreach (var config in configs)
         {
-            if (config.Type == CustomSinkType.Remap && !string.IsNullOrEmpty(config.MasterSink))
+            if (config.Type == CustomSinkType.Remap
+                && !string.IsNullOrEmpty(config.MasterSink)
+                && !customSinkNames.Contains(config.MasterSink))
             {
                 // Check if master sink exists
                 var masterExists = currentDevices.Any(d => d.Id.Equals(config.MasterSink, StringComparison.OrdinalIgnoreCase));
@@ -798,6 +805,15 @@ public class CustomSinksService : IAsyncDisposable
                 for (int i = 0; i < config.Slaves.Count; i++)
                 {
                     var slave = config.Slaves[i];
+
+                    // A slave that names another custom sink isn't a hardware device - keep it
+                    // as-is and let load ordering satisfy the dependency.
+                    if (customSinkNames.Contains(slave))
+                    {
+                        resolvedSlaves.Add(slave);
+                        continue;
+                    }
+
                     var slaveExists = currentDevices.Any(d => d.Id.Equals(slave, StringComparison.OrdinalIgnoreCase));
 
                     if (!slaveExists && i < slaveIdentifiers.Count && slaveIdentifiers[i] != null)
@@ -910,6 +926,94 @@ public class CustomSinksService : IAsyncDisposable
         }
 
         return configs;
+    }
+
+    /// <summary>
+    /// Orders custom sinks so each one is loaded only after the other custom sinks it references.
+    /// A combine sink references its <see cref="CustomSinkConfiguration.Slaves"/>; a remap sink
+    /// references its <see cref="CustomSinkConfiguration.MasterSink"/>. Both directions occur
+    /// (a combine of remaps, or a remap of a combine), so a fixed type-based order is insufficient.
+    /// References to hardware sinks (not custom sinks) are ignored; dependency cycles fall back to
+    /// the original order for the affected sinks.
+    /// </summary>
+    private List<CustomSinkConfiguration> SortByDependencyOrder(List<CustomSinkConfiguration> configs)
+    {
+        var ordered = OrderByDependencies(configs, out var cycleNames);
+        foreach (var name in cycleNames)
+        {
+            _logger.LogWarning(
+                "Dependency cycle detected involving custom sink '{Name}'; loading in fallback order",
+                name);
+        }
+        return ordered;
+    }
+
+    /// <summary>
+    /// Pure topological sort over the custom-sink dependency graph. Separated from logging so it can
+    /// be unit tested. <paramref name="cycleNames"/> lists sinks where a dependency cycle forced a
+    /// fallback (one edge dropped); cycles are not expected in valid configurations.
+    /// </summary>
+    internal static List<CustomSinkConfiguration> OrderByDependencies(
+        List<CustomSinkConfiguration> configs,
+        out List<string> cycleNames)
+    {
+        var byName = new Dictionary<string, CustomSinkConfiguration>(StringComparer.OrdinalIgnoreCase);
+        foreach (var config in configs)
+            byName[config.Name] = config;
+
+        var ordered = new List<CustomSinkConfiguration>(configs.Count);
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var inProgress = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var cycles = new List<string>();
+
+        void Visit(CustomSinkConfiguration config)
+        {
+            if (visited.Contains(config.Name))
+                return;
+
+            if (!inProgress.Add(config.Name))
+            {
+                // Cycle: stop descending. The sink is still emitted by whichever call started it.
+                cycles.Add(config.Name);
+                return;
+            }
+
+            foreach (var dependency in GetCustomSinkDependencies(config, byName))
+                Visit(dependency);
+
+            inProgress.Remove(config.Name);
+            if (visited.Add(config.Name))
+                ordered.Add(config);
+        }
+
+        foreach (var config in configs)
+            Visit(config);
+
+        cycleNames = cycles;
+        return ordered;
+    }
+
+    /// <summary>
+    /// Returns the custom sinks that <paramref name="config"/> depends on (i.e. references that name
+    /// another custom sink in the set). References to hardware sinks are not returned.
+    /// </summary>
+    private static IEnumerable<CustomSinkConfiguration> GetCustomSinkDependencies(
+        CustomSinkConfiguration config,
+        IReadOnlyDictionary<string, CustomSinkConfiguration> byName)
+    {
+        var references = config.Type == CustomSinkType.Combine
+            ? config.Slaves ?? Enumerable.Empty<string>()
+            : new[] { config.MasterSink ?? string.Empty };
+
+        foreach (var reference in references)
+        {
+            if (!string.IsNullOrEmpty(reference)
+                && byName.TryGetValue(reference, out var dependency)
+                && !ReferenceEquals(dependency, config))
+            {
+                yield return dependency;
+            }
+        }
     }
 
     /// <summary>

--- a/tests/MultiRoomAudio.Tests/Services/CustomSinkOrderingTests.cs
+++ b/tests/MultiRoomAudio.Tests/Services/CustomSinkOrderingTests.cs
@@ -1,0 +1,98 @@
+using MultiRoomAudio.Models;
+using MultiRoomAudio.Services;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="CustomSinksService.OrderByDependencies"/>, the topological sort that
+/// decides the order custom sinks are loaded on startup. Regression coverage for #247, where a
+/// combine sink whose slaves are remap sinks failed to load because the remaps were loaded after it.
+/// </summary>
+public class CustomSinkOrderingTests
+{
+    private static CustomSinkConfiguration Combine(string name, params string[] slaves) => new()
+    {
+        Name = name,
+        Type = CustomSinkType.Combine,
+        Slaves = slaves.ToList(),
+    };
+
+    private static CustomSinkConfiguration Remap(string name, string master) => new()
+    {
+        Name = name,
+        Type = CustomSinkType.Remap,
+        MasterSink = master,
+    };
+
+    private static int IndexOf(IReadOnlyList<CustomSinkConfiguration> ordered, string name) =>
+        ordered.ToList().FindIndex(c => c.Name == name);
+
+    [Fact]
+    public void CombineOfRemaps_LoadsRemapsBeforeCombine()
+    {
+        // The #247 topology: a combine sink "Master" built from two remap sinks.
+        var configs = new List<CustomSinkConfiguration>
+        {
+            Combine("Master", "Center", "FrontLR"),
+            Remap("Center", "alsa_output.usb-card"),
+            Remap("FrontLR", "alsa_output.usb-card"),
+        };
+
+        var ordered = CustomSinksService.OrderByDependencies(configs, out var cycles);
+
+        Assert.Empty(cycles);
+        Assert.True(IndexOf(ordered, "Center") < IndexOf(ordered, "Master"));
+        Assert.True(IndexOf(ordered, "FrontLR") < IndexOf(ordered, "Master"));
+    }
+
+    [Fact]
+    public void RemapOfCombine_LoadsCombineBeforeRemap()
+    {
+        // The reverse topology the old type-based sort assumed: a remap using a combine as master.
+        var configs = new List<CustomSinkConfiguration>
+        {
+            Remap("Zone1", "Combined"),
+            Combine("Combined", "alsa_output.a", "alsa_output.b"),
+        };
+
+        var ordered = CustomSinksService.OrderByDependencies(configs, out var cycles);
+
+        Assert.Empty(cycles);
+        Assert.True(IndexOf(ordered, "Combined") < IndexOf(ordered, "Zone1"));
+    }
+
+    [Fact]
+    public void HardwareReferences_AreIgnoredAndAllSinksPreserved()
+    {
+        var configs = new List<CustomSinkConfiguration>
+        {
+            Combine("Master", "alsa_output.hw1", "alsa_output.hw2"),
+            Remap("Solo", "alsa_output.hw3"),
+        };
+
+        var ordered = CustomSinksService.OrderByDependencies(configs, out var cycles);
+
+        Assert.Empty(cycles);
+        Assert.Equal(
+            configs.Select(c => c.Name).OrderBy(n => n),
+            ordered.Select(c => c.Name).OrderBy(n => n));
+    }
+
+    [Fact]
+    public void Cycle_DoesNotHangAndReportsCycle()
+    {
+        // Not a valid real-world config, but the sort must terminate and surface the cycle
+        // rather than recurse forever.
+        var configs = new List<CustomSinkConfiguration>
+        {
+            Remap("A", "B"),
+            Remap("B", "A"),
+        };
+
+        var ordered = CustomSinksService.OrderByDependencies(configs, out var cycles);
+
+        Assert.NotEmpty(cycles);
+        Assert.Equal(2, ordered.Count);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #247 — a combine sink built from custom remap sinks fails to initialize after an add-on restart and won't recover until reconfigured.

Startup loaded **combine sinks before remap sinks**, on the assumption that remaps depend on combines (a remap using a combine as its master). But the reverse topology — a **combine that depends on remap sinks as its slaves** — is equally valid, and that's the reported setup (a combine of one stereo + one mono remap on the same USB card). The combine `module-combine-sink` loaded before its slave remaps existed, so PulseAudio aborted with `Failure: Module initialization failed`, which then cascaded into the player targeting that sink failing with `PulseAudio sink 'Master' not found`.

## Changes

- **Dependency-aware load ordering.** Replaced the fixed `combine-first` ordering in `CustomSinksService.InitializeAsync` with a topological sort (`OrderByDependencies`) over the real custom-sink reference graph — `Slaves` for combine sinks, `MasterSink` for remap sinks. Each sink now loads only after the custom sinks it references. Handles either topology and is cycle-safe (defensive fallback + warning).
- **Migration no longer mistakes custom-sink references for hardware.** `MigrateConfigurations` (ALSA-renumbering re-matching) now skips any master/slave reference that names another custom sink. This removes the misleading `Slave sink 'Center' for 'Master' not found and no identifiers stored` warning and prevents mis-mapping a custom-sink name onto a hardware device.

## Tests

New `CustomSinkOrderingTests` (4 tests): combine-of-remaps (the bug), remap-of-combine (reverse), hardware references ignored, and cycle termination. Full unit suite: **70/70 pass**. `dotnet build` succeeds.

The actual combine-sink reload exercises PulseAudio, so this needs verification on a real HAOS install with the reproduction (two remaps + a combine, then restart the add-on).