### PR TITLE
style: fix whitespace formatting in MQTT/relay files

### DIFF
--- a/src/MultiRoomAudio/Mqtt/MqttStatePayloads.cs
+++ b/src/MultiRoomAudio/Mqtt/MqttStatePayloads.cs
@@ -26,13 +26,13 @@ public static class MqttStatePayloads
     /// <summary>Container/hub health document.</summary>
     public static string Container(bool ready, string version, int playerCount,
         string audioBackend, string environment) => JsonSerializer.Serialize(new
-    {
-        ready = OnOff(ready),
-        version,
-        player_count = playerCount,
-        audio_backend = audioBackend,
-        environment,
-    });
+        {
+            ready = OnOff(ready),
+            version,
+            player_count = playerCount,
+            audio_backend = audioBackend,
+            environment,
+        });
 
     /// <summary>Per-amp/zone state document. RelayState.On → power ON; Unknown → OFF.</summary>
     public static string Amp(MultiRoomAudio.Models.TriggerResponse t, bool boardConnected) => JsonSerializer.Serialize(new

--- a/src/MultiRoomAudio/Relay/VirtualRelayBoard.cs
+++ b/src/MultiRoomAudio/Relay/VirtualRelayBoard.cs
@@ -39,7 +39,8 @@ public sealed class VirtualRelayBoard : IRelayBoard
         {
             int s = 0;
             for (int i = 0; i < _channelCount; i++)
-                if (_states[i]) s |= (1 << i);
+                if (_states[i])
+                    s |= (1 << i);
             return s;
         }
     }
@@ -47,7 +48,8 @@ public sealed class VirtualRelayBoard : IRelayBoard
     /// <inheritdoc />
     public bool Open()
     {
-        if (_disposed) return false;
+        if (_disposed)
+            return false;
         _isConnected = true;
         return true;
     }
@@ -61,7 +63,8 @@ public sealed class VirtualRelayBoard : IRelayBoard
     /// <inheritdoc />
     public bool SetRelay(int channel, bool on)
     {
-        if (!_isConnected || channel < 1 || channel > _channelCount) return false;
+        if (!_isConnected || channel < 1 || channel > _channelCount)
+            return false;
         _states[channel - 1] = on;
         _logger?.LogDebug("Virtual relay '{Serial}' channel {Channel} → {State}", _serialNumber, channel, on ? "ON" : "OFF");
         return true;
@@ -70,14 +73,16 @@ public sealed class VirtualRelayBoard : IRelayBoard
     /// <inheritdoc />
     public RelayState GetRelay(int channel)
     {
-        if (!_isConnected || channel < 1 || channel > _channelCount) return RelayState.Unknown;
+        if (!_isConnected || channel < 1 || channel > _channelCount)
+            return RelayState.Unknown;
         return _states[channel - 1] ? RelayState.On : RelayState.Off;
     }
 
     /// <inheritdoc />
     public bool AllOff()
     {
-        if (!_isConnected) return false;
+        if (!_isConnected)
+            return false;
         Array.Clear(_states);
         return true;
     }
@@ -85,7 +90,8 @@ public sealed class VirtualRelayBoard : IRelayBoard
     /// <inheritdoc />
     public void Dispose()
     {
-        if (_disposed) return;
+        if (_disposed)
+            return;
         _disposed = true;
         _isConnected = false;
     }

--- a/src/MultiRoomAudio/Services/MqttConfigService.cs
+++ b/src/MultiRoomAudio/Services/MqttConfigService.cs
@@ -57,14 +57,22 @@ public class MqttConfigService : YamlFileService<MqttSettings>
         Lock.EnterWriteLock();
         try
         {
-            if (request.Enabled is { } enabled) Data.Enabled = enabled;
-            if (request.Host is not null) Data.Host = string.IsNullOrWhiteSpace(request.Host) ? null : request.Host;
-            if (request.Port is { } port) Data.Port = port;
-            if (request.Username is not null) Data.Username = string.IsNullOrWhiteSpace(request.Username) ? null : request.Username;
-            if (request.Password is not null) Data.Password = request.Password.Length == 0 ? null : request.Password;
-            if (request.UseTls is { } tls) Data.UseTls = tls;
-            if (!string.IsNullOrWhiteSpace(request.DiscoveryPrefix)) Data.DiscoveryPrefix = request.DiscoveryPrefix;
-            if (!string.IsNullOrWhiteSpace(request.BaseTopic)) Data.BaseTopic = request.BaseTopic;
+            if (request.Enabled is { } enabled)
+                Data.Enabled = enabled;
+            if (request.Host is not null)
+                Data.Host = string.IsNullOrWhiteSpace(request.Host) ? null : request.Host;
+            if (request.Port is { } port)
+                Data.Port = port;
+            if (request.Username is not null)
+                Data.Username = string.IsNullOrWhiteSpace(request.Username) ? null : request.Username;
+            if (request.Password is not null)
+                Data.Password = request.Password.Length == 0 ? null : request.Password;
+            if (request.UseTls is { } tls)
+                Data.UseTls = tls;
+            if (!string.IsNullOrWhiteSpace(request.DiscoveryPrefix))
+                Data.DiscoveryPrefix = request.DiscoveryPrefix;
+            if (!string.IsNullOrWhiteSpace(request.BaseTopic))
+                Data.BaseTopic = request.BaseTopic;
         }
         finally
         {
@@ -76,9 +84,12 @@ public class MqttConfigService : YamlFileService<MqttSettings>
 
     private string ResolveSource(IReadOnlyDictionary<string, string?> env)
     {
-        if (!string.IsNullOrWhiteSpace(env["MQTT_HOST"])) return "env";
-        if (_env.IsHaos && !string.IsNullOrWhiteSpace(_env.GetHaosOption<string?>("mqtt_host"))) return "haos";
-        if (!string.IsNullOrWhiteSpace(Data.Host)) return "yaml";
+        if (!string.IsNullOrWhiteSpace(env["MQTT_HOST"]))
+            return "env";
+        if (_env.IsHaos && !string.IsNullOrWhiteSpace(_env.GetHaosOption<string?>("mqtt_host")))
+            return "haos";
+        if (!string.IsNullOrWhiteSpace(Data.Host))
+            return "yaml";
         return "default";
     }
 

--- a/src/MultiRoomAudio/Services/MqttService.cs
+++ b/src/MultiRoomAudio/Services/MqttService.cs
@@ -171,7 +171,8 @@ public class MqttService
         {
             try
             {
-                if (!IsConnected) return;
+                if (!IsConnected)
+                    return;
                 await PublishDiscoveryAsync(CancellationToken.None);
                 await PublishAllStateAsync(CancellationToken.None);
             }
@@ -188,7 +189,8 @@ public class MqttService
         {
             try
             {
-                if (!IsConnected) return;
+                if (!IsConnected)
+                    return;
                 await PublishDiscoveryAsync(CancellationToken.None);
                 await PublishAllStateAsync(CancellationToken.None);
             }
@@ -211,7 +213,8 @@ public class MqttService
                 : System.Buffers.BuffersExtensions.ToArray(seq);
             var payload = Encoding.UTF8.GetString(payloadBytes);
             var cmd = MqttCommand.Parse(_baseTopic, topic, payload);
-            if (cmd.Kind == MqttCommandKind.Unknown) return;
+            if (cmd.Kind == MqttCommandKind.Unknown)
+                return;
 
             if (cmd.Kind == MqttCommandKind.AmpOverride && cmd.AmpZone is not null)
             {
@@ -256,7 +259,8 @@ public class MqttService
 
     private async Task OnDisconnectedAsync(MqttClientDisconnectedEventArgs e)
     {
-        if (_shuttingDown) return;
+        if (_shuttingDown)
+            return;
 
         LastError = e.Exception?.Message ?? e.ReasonString;
         _logger.LogWarning("MQTT disconnected: {Reason}. Reconnecting...", LastError);
@@ -278,7 +282,8 @@ public class MqttService
 
     private async Task PublishAsync(string topic, string payload, bool retain, CancellationToken ct)
     {
-        if (_client is null) return;
+        if (_client is null)
+            return;
         await _publishLock.WaitAsync(ct);
         try
         {
@@ -305,7 +310,8 @@ public class MqttService
     {
         try
         {
-            if (!IsConnected) return;
+            if (!IsConnected)
+                return;
             await PublishAllStateAsync(ct);
         }
         catch (Exception ex)


### PR DESCRIPTION
The `Lint and Build` workflow has been red on `main` since the 5.2.0 MQTT bridge merge — `dotnet format --verify-no-changes` flags whitespace in four files that were committed without running the formatter:

- `Mqtt/MqttStatePayloads.cs`
- `Relay/VirtualRelayBoard.cs`
- `Services/MqttConfigService.cs`
- `Services/MqttService.cs`

This runs `dotnet format` (pinned to the .NET 8 SDK to match CI) on just those four files. Changes are limited to splitting single-line `if` statements per the project `.editorconfig`; no behavioral change.

Unblocks the open Dependabot PRs (#241-#246), which all inherit this failure from `main`.