### PR TITLE
fix: stop reporting benign startup discard as a buffer overflow (#233)

### DIFF
--- a/src/MultiRoomAudio/Audio/BufferedAudioSampleSource.cs
+++ b/src/MultiRoomAudio/Audio/BufferedAudioSampleSource.cs
@@ -149,6 +149,7 @@ public sealed class BufferedAudioSampleSource : IAudioSampleSource
     private long _lastKnownDroppedSamples;
     private long _lastKnownOverrunCount;
     private bool _hasLoggedOverrunStart;
+    private bool _hasLoggedStartupDiscard;
 
     // Startup tracking for deadband widening
     private long _correctionStartTime;  // Timestamp when first correction was considered
@@ -608,11 +609,21 @@ public sealed class BufferedAudioSampleSource : IAudioSampleSource
         var currentDropped = stats.DroppedSamples;
         var currentOverruns = stats.OverrunCount;
 
-        if (currentDropped > _lastKnownDroppedSamples || currentOverruns > _lastKnownOverrunCount)
-        {
-            var newDrops = currentDropped - _lastKnownDroppedSamples;
-            var newOverruns = currentOverruns - _lastKnownOverrunCount;
+        var newDrops = currentDropped - _lastKnownDroppedSamples;
+        var newOverruns = currentOverruns - _lastKnownOverrunCount;
 
+        if (newDrops <= 0 && newOverruns <= 0)
+        {
+            return;
+        }
+
+        // A genuine overflow is signalled by the SDK's OverrunCount advancing: the buffer filled and
+        // Read() failed to consume in time. A rise in DroppedSamples *without* an overrun increment is a
+        // benign one-time startup discard - the SDK re-anchors playback and drops samples whose scheduled
+        // play-time already passed (see issue #233). At startup the buffer is nowhere near capacity and
+        // Read() is consuming normally, so reporting that as a buffer-full overrun is a false alarm.
+        if (newOverruns > 0 || _hasLoggedOverrunStart)
+        {
             if (!_hasLoggedOverrunStart)
             {
                 _hasLoggedOverrunStart = true;
@@ -634,10 +645,21 @@ public sealed class BufferedAudioSampleSource : IAudioSampleSource
                     "bufferedMs={BufferedMs:F0}, isPlaybackActive={IsPlaybackActive}",
                     newDrops, currentDropped, currentOverruns, stats.BufferedMs, stats.IsPlaybackActive);
             }
-
-            _lastKnownDroppedSamples = currentDropped;
-            _lastKnownOverrunCount = currentOverruns;
         }
+        else if (!_hasLoggedStartupDiscard)
+        {
+            // One-time, non-alarming: the SDK aligned playback to the schedule by discarding stale samples.
+            _hasLoggedStartupDiscard = true;
+            var approxMs = newDrops * 1000.0 / (_sampleRate * _channels);
+            _logger.LogInformation(
+                "Startup alignment discard: SDK dropped {Dropped} samples (~{Ms:F0}ms) aligning playback to the schedule. " +
+                "bufferedMs={BufferedMs:F0}, overrunCount={Overruns} (no overrun - buffer not full, Read consuming). " +
+                "One-time startup transient.",
+                newDrops, approxMs, stats.BufferedMs, currentOverruns);
+        }
+
+        _lastKnownDroppedSamples = currentDropped;
+        _lastKnownOverrunCount = currentOverruns;
     }
 
     /// <summary>
@@ -651,6 +673,7 @@ public sealed class BufferedAudioSampleSource : IAudioSampleSource
         _totalDropped = 0;
         _totalInserted = 0;
         _hasLoggedOverrunStart = false;  // Allow ERROR level logging on next overrun
+        _hasLoggedStartupDiscard = false;  // Allow startup-discard INFO on next playback
 
         // Reset anti-oscillation state
         _currentDirection = CorrectionDirection.None;

--- a/tests/MultiRoomAudio.Tests/CapturingLogger.cs
+++ b/tests/MultiRoomAudio.Tests/CapturingLogger.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Logging;
+
+namespace MultiRoomAudio.Tests;
+
+/// <summary>
+/// In-memory <see cref="ILogger{T}"/> that records each entry's level and rendered message,
+/// for asserting on log output in tests.
+/// </summary>
+internal sealed class CapturingLogger<T> : ILogger<T>
+{
+    public List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        Entries.Add((logLevel, formatter(state, exception)));
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+        public void Dispose() { }
+    }
+}

--- a/tests/MultiRoomAudio.Tests/FakeTimedAudioBuffer.cs
+++ b/tests/MultiRoomAudio.Tests/FakeTimedAudioBuffer.cs
@@ -1,0 +1,61 @@
+using Sendspin.SDK.Audio;
+using Sendspin.SDK.Models;
+
+namespace MultiRoomAudio.Tests;
+
+/// <summary>
+/// Minimal <see cref="ITimedAudioBuffer"/> test double for exercising
+/// <see cref="MultiRoomAudio.Audio.BufferedAudioSampleSource"/>'s read and overrun-detection paths.
+/// <see cref="ReadRaw"/> returns a full buffer of silence; <see cref="GetStats"/> returns the
+/// caller-supplied snapshot. Members not used by those paths throw.
+/// </summary>
+internal sealed class FakeTimedAudioBuffer : ITimedAudioBuffer
+{
+    private readonly AudioBufferStats _stats;
+
+    public FakeTimedAudioBuffer(AudioFormat format, AudioBufferStats stats)
+    {
+        Format = format;
+        _stats = stats;
+    }
+
+    public AudioFormat Format { get; }
+
+    public int ReadRaw(Span<float> destination, long currentTimeMicroseconds)
+    {
+        destination.Clear();
+        return destination.Length;
+    }
+
+    public AudioBufferStats GetStats() => _stats;
+
+    public double SmoothedSyncErrorMicroseconds => 0;
+
+    public void NotifyExternalCorrection(int droppedSamples, int insertedSamples)
+    {
+    }
+
+    // --- Unused by the sample-source read/overrun path ---
+    public SyncCorrectionOptions SyncOptions => throw new NotSupportedException();
+    public double BufferedMilliseconds => throw new NotSupportedException();
+    public double TargetBufferMilliseconds { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+    public bool IsReadyForPlayback => throw new NotSupportedException();
+    public long OutputLatencyMicroseconds { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+    public long CalibratedStartupLatencyMicroseconds { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+    public string TimingSourceName { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+    public long SyncErrorMicroseconds => throw new NotSupportedException();
+    public double TargetPlaybackRate => throw new NotSupportedException();
+
+    public event Action<double>? TargetPlaybackRateChanged
+    {
+        add { }
+        remove { }
+    }
+
+    public void Write(ReadOnlySpan<float> samples, long timestampMicroseconds) => throw new NotSupportedException();
+    public int Read(Span<float> destination, long currentTimeMicroseconds) => throw new NotSupportedException();
+    public void ReportExternalPlaybackRate(double rate) => throw new NotSupportedException();
+    public void NotifyReconnect() => throw new NotSupportedException();
+    public void Clear() => throw new NotSupportedException();
+    public void Dispose() { }
+}

--- a/tests/MultiRoomAudio.Tests/OverrunDetectionTests.cs
+++ b/tests/MultiRoomAudio.Tests/OverrunDetectionTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.Logging;
+using MultiRoomAudio.Audio;
+using Sendspin.SDK.Audio;
+using Sendspin.SDK.Models;
+using Xunit;
+
+namespace MultiRoomAudio.Tests;
+
+/// <summary>
+/// Guards <see cref="BufferedAudioSampleSource"/>'s overrun detection (issue #233): a one-time
+/// startup sample discard (SDK re-anchors playback, dropping samples whose scheduled play-time
+/// already passed) must NOT be reported as a buffer-full overrun. Only a genuine overrun — where
+/// the SDK's <c>OverrunCount</c> advances — should raise the loud ERROR.
+/// </summary>
+public class OverrunDetectionTests
+{
+    private static AudioFormat Stereo48k => new()
+    {
+        Codec = "pcm",
+        SampleRate = 48000,
+        Channels = 2,
+        BitDepth = 32
+    };
+
+    /// <summary>
+    /// The reporter's residual case: 9216 samples dropped, but <c>OverrunCount == 0</c> and the
+    /// buffer is at 838ms of a 30s capacity (not full). This is a benign startup discard and must
+    /// not produce an ERROR claiming "buffer is full and Read() isn't consuming".
+    /// </summary>
+    [Fact]
+    public void StartupDiscard_WithoutOverrunIncrement_DoesNotLogError()
+    {
+        var stats = new AudioBufferStats
+        {
+            DroppedSamples = 9216,
+            OverrunCount = 0,
+            BufferedMs = 838,
+            TargetMs = 250,
+            IsPlaybackActive = true
+        };
+        var (source, logger) = CreateSource(stats);
+
+        ReadOnce(source);
+
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+        Assert.Contains(
+            logger.Entries,
+            e => e.Level == LogLevel.Information && e.Message.Contains("discard", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Regression guard: a real overrun (the SDK's <c>OverrunCount</c> advances while the buffer is
+    /// near capacity) must still be reported loudly at ERROR.
+    /// </summary>
+    [Fact]
+    public void GenuineOverrun_WithOverrunIncrement_LogsError()
+    {
+        var stats = new AudioBufferStats
+        {
+            DroppedSamples = 9216,
+            OverrunCount = 1,
+            BufferedMs = 29988,
+            TargetMs = 250,
+            IsPlaybackActive = true
+        };
+        var (source, logger) = CreateSource(stats);
+
+        ReadOnce(source);
+
+        Assert.Contains(
+            logger.Entries,
+            e => e.Level == LogLevel.Error && e.Message.Contains("BUFFER OVERFLOW DETECTED"));
+    }
+
+    private static (BufferedAudioSampleSource Source, CapturingLogger<BufferedAudioSampleSource> Logger) CreateSource(
+        AudioBufferStats stats)
+    {
+        var buffer = new FakeTimedAudioBuffer(Stereo48k, stats);
+        var logger = new CapturingLogger<BufferedAudioSampleSource>();
+        var source = new BufferedAudioSampleSource(buffer, () => 1_000_000, logger);
+        return (source, logger);
+    }
+
+    private static void ReadOnce(BufferedAudioSampleSource source)
+    {
+        var output = new float[480 * 2]; // one 10ms stereo callback
+        source.Read(output, 0, output.Length);
+    }
+}


### PR DESCRIPTION
## Problem

Issue #233. After the SDK/timing fixes, a residual startup case remains:

```
[Kitchen] BUFFER OVERFLOW DETECTED: SDK is dropping samples because buffer is
full and Read() isn't consuming. bufferedMs=838, targetMs=250,
isPlaybackActive=True, totalDropped=9216, overrunCount=0.
```

Every claim in that ERROR is false here: `overrunCount=0` (no overrun event), `bufferedMs=838` of a 30 000ms capacity (2.8% full, not full), `isPlaybackActive=True` (Read **is** consuming).

## Root cause

`CheckForOverruns` raised the ERROR whenever `stats.DroppedSamples` increased. But `DroppedSamples` (mapped to `SamplesDroppedOverflow`) is a **different counter** from `OverrunCount`. It also rises on a one-time startup discard: the SDK re-anchors playback and drops ~96ms of samples whose scheduled play-time already passed (consistent with the initial 70ms latency estimate vs the measured ~200ms). That is benign and self-correcting — but it was being misreported as a buffer-full overrun.

## Fix

Gate the overflow ERROR/WARN on the SDK's `OverrunCount` actually advancing (a genuine buffer-full event). A `DroppedSamples` rise **without** an overrun increment is now logged once at INFO as a startup alignment discard, with accurate detail. Genuine overruns are still reported loudly (regression-guarded).

This is a **logging/diagnosis** fix — it does not change audio behavior. The brief startup discard itself originates in the SDK's re-anchor path; reducing it is a separate, SDK-coordinated effort.

## Tests

`OverrunDetectionTests` (new), with a fake `ITimedAudioBuffer` and a capturing logger:
- startup discard (`OverrunCount==0`, buffer not full) → no ERROR, one INFO
- genuine overrun (`OverrunCount` advances, buffer near capacity) → ERROR

Full suite: 68 passed.