### PR TITLE
feat: improve MQTT discovery for HA automations (#249)

### DIFF
--- a/src/MultiRoomAudio/Mqtt/HaDiscovery.cs
+++ b/src/MultiRoomAudio/Mqtt/HaDiscovery.cs
@@ -10,6 +10,10 @@ namespace MultiRoomAudio.Mqtt;
 /// </summary>
 public class HaDiscovery
 {
+    /// <summary>Possible values of the player State sensor, derived from <see cref="PlayerState"/> to stay in sync with the published payload.</summary>
+    private static readonly string[] PlayerStateOptions =
+        Enum.GetNames<PlayerState>().Select(n => n.ToLowerInvariant()).ToArray();
+
     private readonly MqttTopics _topics;
     private readonly string _version;
 
@@ -38,7 +42,14 @@ public class HaDiscovery
         return new List<DiscoveryMessage>
         {
             Entity("sensor", "state", $"{p.Name} State", w =>
-                w.WriteString("value_template", "{{ value_json.state }}")),
+            {
+                w.WriteString("value_template", "{{ value_json.state }}");
+                w.WriteString("device_class", "enum");
+                w.WritePropertyName("options");
+                w.WriteStartArray();
+                foreach (var s in PlayerStateOptions) w.WriteStringValue(s);
+                w.WriteEndArray();
+            }),
             Entity("sensor", "server", $"{p.Name} Server", w =>
             {
                 w.WriteString("value_template", "{{ value_json.server_name }}");
@@ -109,6 +120,7 @@ public class HaDiscovery
             {
                 w.WriteString("value_template", "{{ value_json.version }}");
                 w.WriteString("entity_category", "diagnostic");
+                w.WriteBoolean("enabled_by_default", false);
             }),
             Entity("sensor", "player_count", "Multi-Room Audio Players", w =>
                 w.WriteString("value_template", "{{ value_json.player_count }}")),
@@ -116,11 +128,13 @@ public class HaDiscovery
             {
                 w.WriteString("value_template", "{{ value_json.audio_backend }}");
                 w.WriteString("entity_category", "diagnostic");
+                w.WriteBoolean("enabled_by_default", false);
             }),
             Entity("sensor", "environment", "Multi-Room Audio Environment", w =>
             {
                 w.WriteString("value_template", "{{ value_json.environment }}");
                 w.WriteString("entity_category", "diagnostic");
+                w.WriteBoolean("enabled_by_default", false);
             }),
         };
     }

--- a/tests/MultiRoomAudio.Tests/Mqtt/HaDiscoveryTests.cs
+++ b/tests/MultiRoomAudio.Tests/Mqtt/HaDiscoveryTests.cs
@@ -63,4 +63,39 @@ public class HaDiscoveryTests
             return doc.RootElement.GetProperty("value_template").GetString()!.Contains("value_json.ready");
         });
     }
+
+    [Theory]
+    [InlineData("version")]
+    [InlineData("audio_backend")]
+    [InlineData("environment")]
+    public void Container_DiagnosticSensorsDisabledByDefault(string key)
+    {
+        var msg = _d.ForContainer("instance1").Single(m => m.Topic.Contains($"_{key}/"));
+        using var doc = JsonDocument.Parse(msg.Payload);
+        Assert.False(doc.RootElement.GetProperty("enabled_by_default").GetBoolean());
+    }
+
+    [Fact]
+    public void Player_DiagnosticSensorsRemainEnabled()
+    {
+        // Issue #249 only disables the container version/backend/environment sensors;
+        // player diagnostics stay enabled.
+        var server = _d.ForPlayer(Player()).Single(m => m.Topic.Contains("_server/"));
+        using var doc = JsonDocument.Parse(server.Payload);
+        Assert.Equal("diagnostic", doc.RootElement.GetProperty("entity_category").GetString());
+        Assert.False(doc.RootElement.TryGetProperty("enabled_by_default", out _));
+    }
+
+    [Fact]
+    public void Player_StateSensorIsEnumWithAllPlayerStateOptions()
+    {
+        var state = _d.ForPlayer(Player()).Single(m => m.Topic.Contains("_state/"));
+        using var doc = JsonDocument.Parse(state.Payload);
+        var root = doc.RootElement;
+        Assert.Equal("enum", root.GetProperty("device_class").GetString());
+
+        var options = root.GetProperty("options").EnumerateArray().Select(e => e.GetString()!).ToList();
+        var expected = Enum.GetNames<PlayerState>().Select(n => n.ToLowerInvariant()).ToList();
+        Assert.Equal(expected, options);
+    }
 }


### PR DESCRIPTION
Closes #249.

## What

Two Home Assistant MQTT Discovery improvements, both confined to `HaDiscovery.cs`:

1. **Disable container diagnostics by default** — the Version, Backend, and Environment sensors now emit `"enabled_by_default": false`. They still register (existing automations keep working) but stay hidden until a user enables them. Player and amp diagnostics are left enabled.
2. **Advertise possible player states** — the player State sensor now declares `"device_class": "enum"` with an `options` array of all `PlayerState` values, so HA offers them in automation trigger/condition dropdowns.

The options are derived from `Enum.GetNames<PlayerState>()` rather than hardcoded, so they can't drift out of sync with the published state payload.

## Tests

- New tests: container diagnostics disabled, player diagnostics remain enabled, state sensor enum/options match the enum.
- Full MQTT suite green (38/38), no new build warnings.

## Note

The enum values are raw lowercased enum names (e.g. `waitingforserver`). Functional but not pretty — friendlier labels would need a shared name→label map touching both the payload and the options; left out for now to keep scope tight.