### PR TITLE
feat: allow a relay trigger to reference multiple sinks (#250)

### DIFF
--- a/docs/superpowers/plans/2026-06-26-multi-sink-triggers.md
+++ b/docs/superpowers/plans/2026-06-26-multi-sink-triggers.md
@@ -1,0 +1,920 @@
+# Multi-Sink Triggers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a single relay trigger channel reference multiple sinks/zones (issue #250), with full many-to-many sink↔channel mapping, surfaced in the main app and the onboarding wizard via a tag/chip picker.
+
+**Architecture:** Replace the single `CustomSinkName` field on `TriggerConfiguration` with a `List<string> CustomSinkNames`, keeping the old field as a write-only YAML migration shim. The relay engine's existing `ActivePlayerCount` reference counter already keeps a channel ON until its last contributing sink stops; the only engine change is to match **all** channels containing a sink instead of the first. The UI gets a reusable chip-picker.
+
+**Tech Stack:** C# / ASP.NET Core 8.0, YamlDotNet (UnderscoredNamingConvention), xUnit, vanilla JS + Bootstrap 5.
+
+## Global Constraints
+
+- Target framework: **.NET 8.0**, nullable enabled.
+- YAML config uses **UnderscoredNamingConvention**; deserializer has `IgnoreUnmatchedProperties()`; serializer has `DefaultValuesHandling.OmitNull | OmitDefaults`.
+- JSON API casing is **camelCase** (ASP.NET default) — JS reads `trigger.customSinkNames`, etc.
+- Vanilla JS only (no frameworks); use `textContent`/`escapeHtml` for any user-derived strings (XSS).
+- Do **not** add unused `using` directives (the repo enforces unused-usings as build errors).
+- Build: `dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj`
+- Test: `dotnet test tests/MultiRoomAudio.Tests/MultiRoomAudio.Tests.csproj`
+- Two PRs against `dev`: **PR 1** = Tasks 1–2 (closes #250); **PR 2** = Task 3 (wizard step).
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `src/MultiRoomAudio/Models/TriggerModels.cs` | Data models for triggers | Modify: `TriggerConfiguration`, `TriggerResponse`, `TriggerConfigureRequest` |
+| `src/MultiRoomAudio/Services/TriggerService.cs` | Engine + persistence | Modify: matching, `ConfigureTrigger`, `OnSinkDeleted`, response builder, save filter |
+| `src/MultiRoomAudio/Controllers/TriggersEndpoint.cs` | REST endpoints | Modify: 3 `ConfigureTrigger` call sites + 2 unassign sites |
+| `tests/MultiRoomAudio.Tests/Services/MultiSinkTriggerTests.cs` | New test coverage | Create |
+| `tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs` | Existing tests | Modify: update to new signatures |
+| `src/MultiRoomAudio/wwwroot/js/app.js` | Main-app trigger panel | Modify: chip picker |
+| `src/MultiRoomAudio/wwwroot/js/wizard.js` | Onboarding wizard | Modify: new relay step (PR 2) |
+
+---
+
+## Task 1: Backend — multi-sink data model, engine, and API
+
+This is an atomic compile unit: renaming `CustomSinkName` cascades through the
+service, controller, response/request models, and existing tests. All changes
+land together so the project compiles and tests pass.
+
+**Files:**
+- Modify: `src/MultiRoomAudio/Models/TriggerModels.cs`
+- Modify: `src/MultiRoomAudio/Services/TriggerService.cs`
+- Modify: `src/MultiRoomAudio/Controllers/TriggersEndpoint.cs`
+- Create: `tests/MultiRoomAudio.Tests/Services/MultiSinkTriggerTests.cs`
+- Modify: `tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `TriggerConfiguration.CustomSinkNames` : `List<string>` (default `new()`)
+  - `TriggerConfiguration.CustomSinkName` : write-only `string?` shim (getter returns `null`)
+  - `TriggerService.ConfigureTrigger(string boardId, int channel, List<string> customSinkNames, int offDelaySeconds, string? zoneName)` : `bool`
+  - `TriggerResponse(int Channel, List<string> CustomSinkNames, List<string> CustomSinkDisplayNames, int OffDelaySeconds, string? ZoneName, RelayState RelayState, bool IsActive, DateTime? LastActivated, DateTime? ScheduledOffTime, bool IsOverridden = false)`
+  - `TriggerConfigureRequest.CustomSinkNames` : `List<string>`; `TriggerConfigureRequest.ResolveSinkNames()` : `List<string>`
+- Consumes (existing, unchanged): `TriggerService.OnPlayerStarted/OnPlayerStopped/GetBoardStatus/AddBoard/SetEnabled`, `TriggerTestHarness.CreateMockService()`.
+
+---
+
+- [ ] **Step 1: Write the failing migration + many-to-many tests**
+
+Create `tests/MultiRoomAudio.Tests/Services/MultiSinkTriggerTests.cs`:
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MultiRoomAudio.Models;
+using MultiRoomAudio.Relay;
+using MultiRoomAudio.Services;
+using Xunit;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace MultiRoomAudio.Tests.Services;
+
+public class MultiSinkTriggerMigrationTests
+{
+    private static IDeserializer Deserializer() => new DeserializerBuilder()
+        .WithNamingConvention(UnderscoredNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    private static ISerializer Serializer() => new SerializerBuilder()
+        .WithNamingConvention(UnderscoredNamingConvention.Instance)
+        .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitDefaults)
+        .Build();
+
+    [Fact]
+    public void LegacySingleSink_MigratesIntoList()
+    {
+        var yaml = "channel: 1\ncustom_sink_name: sink1\noff_delay_seconds: 30\n";
+        var cfg = Deserializer().Deserialize<TriggerConfiguration>(yaml);
+        Assert.Equal(new[] { "sink1" }, cfg.CustomSinkNames);
+    }
+
+    [Fact]
+    public void Serialization_OmitsLegacyKey_EmitsPluralKey()
+    {
+        var cfg = new TriggerConfiguration { Channel = 1, CustomSinkNames = { "sink1" } };
+        var outYaml = Serializer().Serialize(cfg);
+        // Note: "custom_sink_name:" (singular + colon) is NOT a substring of "custom_sink_names:".
+        Assert.DoesNotContain("custom_sink_name:", outYaml);
+        Assert.Contains("custom_sink_names", outYaml);
+    }
+}
+
+public class MultiSinkTriggerEngineTests
+{
+    private static (TriggerService svc, string boardId) Setup()
+    {
+        var svc = TriggerTestHarness.CreateMockService();
+        svc.SetEnabled(true);
+        var boardId = "VIRTUAL:multi01";
+        svc.AddBoard(boardId, "Test", channelCount: 2, boardType: RelayBoardType.Virtual);
+        return (svc, boardId);
+    }
+
+    private static TriggerResponse Channel(TriggerService svc, string boardId, int channel)
+        => svc.GetBoardStatus(boardId)!.Triggers.Single(t => t.Channel == channel);
+
+    [Fact]
+    public void OneSinkOnTwoChannels_ActivatesBoth()
+    {
+        var (svc, boardId) = Setup();
+        svc.ConfigureTrigger(boardId, 1, new List<string> { "zoneA" }, 30, "Zone A");
+        svc.ConfigureTrigger(boardId, 2, new List<string> { "zoneA", "zoneB" }, 30, "Master");
+
+        svc.OnPlayerStarted("p1", "zoneA");
+
+        Assert.Equal(RelayState.On, Channel(svc, boardId, 1).RelayState);
+        Assert.Equal(RelayState.On, Channel(svc, boardId, 2).RelayState);
+    }
+
+    [Fact]
+    public void ChannelWithTwoSinks_StaysOnUntilLastStops()
+    {
+        var (svc, boardId) = Setup();
+        svc.ConfigureTrigger(boardId, 2, new List<string> { "zoneA", "zoneB" }, 0, "Master");
+
+        svc.OnPlayerStarted("p1", "zoneA");
+        svc.OnPlayerStarted("p2", "zoneB");
+        svc.OnPlayerStopped("p1", "zoneA");
+        Assert.Equal(RelayState.On, Channel(svc, boardId, 2).RelayState);   // zoneB still active
+
+        svc.OnPlayerStopped("p2", "zoneB");
+        Assert.Equal(RelayState.Off, Channel(svc, boardId, 2).RelayState);  // last sink stopped, delay 0 ⇒ immediate off
+    }
+
+    [Fact]
+    public void DeletingSink_RemovesItFromTriggerLists()
+    {
+        var (svc, boardId) = Setup();
+        svc.ConfigureTrigger(boardId, 2, new List<string> { "zoneA", "zoneB" }, 30, "Master");
+
+        svc.OnSinkDeleted("zoneA");
+
+        Assert.Equal(new[] { "zoneB" }, Channel(svc, boardId, 2).CustomSinkNames);
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail to compile**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests/MultiRoomAudio.Tests.csproj`
+Expected: BUILD FAILS — `TriggerConfiguration` has no `CustomSinkNames`, `ConfigureTrigger` has no `List<string>` overload, `TriggerResponse` has no `CustomSinkNames`. This confirms the tests exercise the new API.
+
+- [ ] **Step 3: Update the data models** — `src/MultiRoomAudio/Models/TriggerModels.cs`
+
+In `TriggerConfiguration`, replace the `CustomSinkName` property (the `string?` around line 132) with:
+
+```csharp
+/// <summary>
+/// Names of the custom sinks that trigger this relay.
+/// Empty means this trigger is not assigned. The relay turns on when any
+/// listed sink starts and off (after the delay) when all have stopped.
+/// </summary>
+public List<string> CustomSinkNames { get; set; } = new();
+
+/// <summary>
+/// Legacy single-sink property. Retained ONLY so old triggers.yaml
+/// (custom_sink_name) migrates into <see cref="CustomSinkNames"/> on load.
+/// The null getter combined with the serializer's OmitNull handling means it
+/// is never written back to disk.
+/// </summary>
+[Obsolete("Use CustomSinkNames. Retained for config migration.")]
+public string? CustomSinkName
+{
+    get => null;
+    set
+    {
+        if (!string.IsNullOrEmpty(value) && !CustomSinkNames.Contains(value))
+            CustomSinkNames.Add(value);
+    }
+}
+```
+
+Replace the `TriggerResponse` record (around line 290) `CustomSinkName` / `CustomSinkDisplayName` members with lists:
+
+```csharp
+public record TriggerResponse(
+    int Channel,
+    List<string> CustomSinkNames,
+    List<string> CustomSinkDisplayNames,
+    int OffDelaySeconds,
+    string? ZoneName,
+    RelayState RelayState,
+    bool IsActive,
+    DateTime? LastActivated,
+    DateTime? ScheduledOffTime,
+    bool IsOverridden = false
+);
+```
+
+In `TriggerConfigureRequest` (around line 405), replace the `CustomSinkName` property with the plural list, keep a legacy singular, and add a resolver:
+
+```csharp
+/// <summary>
+/// Custom sink names to assign to this trigger. Empty list unassigns.
+/// </summary>
+public List<string> CustomSinkNames { get; set; } = new();
+
+/// <summary>
+/// Legacy single-sink field. If <see cref="CustomSinkNames"/> is empty and this
+/// is set, it is folded into the list (back-compat for older API callers).
+/// </summary>
+public string? CustomSinkName { get; set; }
+
+/// <summary>
+/// Resolve the effective sink list, folding in the legacy singular field.
+/// </summary>
+public List<string> ResolveSinkNames()
+{
+    if (CustomSinkNames.Count == 0 && !string.IsNullOrEmpty(CustomSinkName))
+        return new List<string> { CustomSinkName };
+    return CustomSinkNames;
+}
+```
+
+- [ ] **Step 4: Update the response builder** — `src/MultiRoomAudio/Services/TriggerService.cs` (~L231–254)
+
+Replace the single-sink display-name block and the `TriggerResponse` construction with list-based versions:
+
+```csharp
+// Resolve display names for each assigned sink.
+var sinkNames = config.CustomSinkNames ?? new List<string>();
+var sinkDisplayNames = sinkNames
+    .Select(n =>
+    {
+        var sink = _sinksService.GetSink(n);
+        return sink?.Description ?? sink?.Name ?? n;
+    })
+    .ToList();
+
+var relayState = relayBoard?.GetRelay(channel) ?? RelayState.Unknown;
+
+triggers.Add(new TriggerResponse(
+    Channel: channel,
+    CustomSinkNames: sinkNames,
+    CustomSinkDisplayNames: sinkDisplayNames,
+    OffDelaySeconds: config.OffDelaySeconds,
+    ZoneName: config.ZoneName,
+    RelayState: relayState,
+    IsActive: channelState.IsActive,
+    LastActivated: channelState.LastActivated,
+    ScheduledOffTime: channelState.OffDelayTimer?.Enabled == true
+        ? channelState.LastActivated?.AddSeconds(config.OffDelaySeconds)
+        : null,
+    IsOverridden: channelState.IsOverridden
+));
+```
+
+- [ ] **Step 5: Update the player-event matching to many-to-many** — `src/MultiRoomAudio/Services/TriggerService.cs` (~L701–741)
+
+Replace the bodies of `OnPlayerStarted` and `OnPlayerStopped`:
+
+```csharp
+public void OnPlayerStarted(string playerName, string? deviceId)
+{
+    if (!_config.Enabled || string.IsNullOrEmpty(deviceId))
+        return;
+
+    // Activate EVERY channel that lists this sink (full many-to-many).
+    foreach (var boardConfig in _config.Boards)
+    {
+        if (!_boardStates.ContainsKey(boardConfig.BoardId))
+            continue;
+
+        foreach (var trigger in boardConfig.Triggers)
+        {
+            if (trigger.CustomSinkNames.Any(s =>
+                    string.Equals(s, deviceId, StringComparison.OrdinalIgnoreCase)))
+            {
+                ActivateTrigger(boardConfig.BoardId, trigger.Channel, playerName);
+            }
+        }
+    }
+}
+
+public void OnPlayerStopped(string playerName, string? deviceId)
+{
+    if (!_config.Enabled || string.IsNullOrEmpty(deviceId))
+        return;
+
+    foreach (var boardConfig in _config.Boards)
+    {
+        if (!_boardStates.ContainsKey(boardConfig.BoardId))
+            continue;
+
+        foreach (var trigger in boardConfig.Triggers)
+        {
+            if (trigger.CustomSinkNames.Any(s =>
+                    string.Equals(s, deviceId, StringComparison.OrdinalIgnoreCase)))
+            {
+                DeactivateTrigger(boardConfig.BoardId, trigger.Channel, trigger.OffDelaySeconds, playerName);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Update `ConfigureTrigger`** — `src/MultiRoomAudio/Services/TriggerService.cs` (~L510–564)
+
+Change the signature and body to take a list:
+
+```csharp
+public bool ConfigureTrigger(string boardId, int channel, List<string> customSinkNames, int offDelaySeconds, string? zoneName)
+{
+    var boardConfig = _config.Boards.FirstOrDefault(b => b.BoardId == boardId);
+    if (boardConfig == null)
+        throw new ArgumentException($"Board '{boardId}' not found", nameof(boardId));
+
+    if (channel < 1 || channel > boardConfig.ChannelCount)
+        throw new ArgumentOutOfRangeException(nameof(channel), $"Channel must be between 1 and {boardConfig.ChannelCount}");
+
+    var sinks = customSinkNames ?? new List<string>();
+
+    lock (_configLock)
+    {
+        var trigger = boardConfig.Triggers.FirstOrDefault(t => t.Channel == channel);
+        if (trigger == null)
+        {
+            trigger = new TriggerConfiguration { Channel = channel };
+            boardConfig.Triggers.Add(trigger);
+        }
+
+        // Validate each sink exists (warn but do not fail — a sink may be created later).
+        foreach (var sinkName in sinks)
+        {
+            if (_sinksService.GetSink(sinkName) == null)
+            {
+                _logger.LogWarning("Custom sink '{SinkName}' not found for trigger {BoardId}/{Channel}",
+                    sinkName, boardId, channel);
+            }
+        }
+
+        trigger.CustomSinkNames = sinks;
+        trigger.OffDelaySeconds = offDelaySeconds;
+        trigger.ZoneName = zoneName;
+
+        // If unassigning (no sinks), turn off the relay and cancel timer.
+        if (sinks.Count == 0)
+        {
+            CancelOffTimer(boardId, channel);
+            if (_relayBoards.TryGetValue(boardId, out var board))
+            {
+                board.SetRelay(channel, false);
+            }
+            if (_channelStates.TryGetValue((boardId, channel), out var state))
+            {
+                state.IsActive = false;
+                state.ActivePlayerCount = 0;
+            }
+        }
+
+        SaveConfiguration();
+        _logger.LogInformation("Trigger {BoardId}/{Channel} configured: sinks=[{Sinks}], delay={Delay}s, zone={Zone}",
+            boardId, channel, string.Join(", ", sinks), offDelaySeconds, zoneName ?? "(none)");
+
+        return true;
+    }
+}
+```
+
+- [ ] **Step 7: Update `OnSinkDeleted`** — `src/MultiRoomAudio/Services/TriggerService.cs` (~L746–785)
+
+Replace its body so deletion prunes the sink from each list and only clears a channel when its list empties:
+
+```csharp
+public void OnSinkDeleted(string sinkName)
+{
+    lock (_configLock)
+    {
+        var affected = false;
+
+        foreach (var boardConfig in _config.Boards)
+        {
+            foreach (var trigger in boardConfig.Triggers)
+            {
+                var removed = trigger.CustomSinkNames
+                    .RemoveAll(s => string.Equals(s, sinkName, StringComparison.OrdinalIgnoreCase));
+                if (removed == 0)
+                    continue;
+
+                affected = true;
+                _logger.LogInformation("Removed sink '{SinkName}' from trigger {BoardId}/{Channel} (deleted)",
+                    sinkName, boardConfig.BoardId, trigger.Channel);
+
+                // Only turn the channel off when no sinks remain on it.
+                if (trigger.CustomSinkNames.Count == 0)
+                {
+                    CancelOffTimer(boardConfig.BoardId, trigger.Channel);
+                    if (_relayBoards.TryGetValue(boardConfig.BoardId, out var board))
+                    {
+                        board.SetRelay(trigger.Channel, false);
+                    }
+                    if (_channelStates.TryGetValue((boardConfig.BoardId, trigger.Channel), out var state))
+                    {
+                        state.IsActive = false;
+                        state.ActivePlayerCount = 0;
+                    }
+                }
+            }
+        }
+
+        if (affected)
+        {
+            SaveConfiguration();
+        }
+    }
+}
+```
+
+- [ ] **Step 8: Update the save-cleanup filter** — `src/MultiRoomAudio/Services/TriggerService.cs` (~L1355–1359)
+
+```csharp
+board.Triggers = board.Triggers
+    .Where(t => (t.CustomSinkNames?.Count ?? 0) > 0 ||
+                !string.IsNullOrEmpty(t.ZoneName) ||
+                t.OffDelaySeconds != 60)
+    .ToList();
+```
+
+- [ ] **Step 9: Update the controller call sites** — `src/MultiRoomAudio/Controllers/TriggersEndpoint.cs`
+
+For the three configure sites (~L404, ~L448, ~L706), replace `request.CustomSinkName` with `request.ResolveSinkNames()`:
+
+```csharp
+var success = service.ConfigureTrigger(
+    boardId,
+    channel,
+    request.ResolveSinkNames(),
+    request.OffDelaySeconds,
+    request.ZoneName);
+```
+
+(For the legacy first-board site at ~L706 the first argument is `firstBoard.BoardId`.)
+
+For the two unassign sites (~L481, ~L744), replace the `null` sink argument with an empty list:
+
+```csharp
+service.ConfigureTrigger(boardId, channel, new List<string>(), 60, null);
+```
+
+(At ~L744 the first argument is `firstBoard.BoardId`.) Ensure `using System.Collections.Generic;` is present at the top of the file (add it only if missing — do not duplicate).
+
+- [ ] **Step 10: Update existing trigger tests to the new signatures** — `tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs`
+
+At the `SetupAsync` helper (line ~19), change:
+
+```csharp
+svc.ConfigureTrigger(boardId, channel: 1, customSinkNames: new List<string> { "sink1" }, offDelaySeconds: 30, zoneName: "Zone 1");
+```
+
+Add `using System.Collections.Generic;` to the file's usings if not already present.
+
+In `TriggerModelsTests.TriggerResponse_IsOverridden_DefaultsFalse` (line ~90), update the constructor call to the new record shape:
+
+```csharp
+var r = new TriggerResponse(
+    Channel: 1,
+    CustomSinkNames: new List<string>(),
+    CustomSinkDisplayNames: new List<string>(),
+    OffDelaySeconds: 60, ZoneName: null, RelayState: RelayState.Off,
+    IsActive: false, LastActivated: null, ScheduledOffTime: null);
+Assert.False(r.IsOverridden);
+```
+
+- [ ] **Step 11: Build and run all tests**
+
+Run: `dotnet test tests/MultiRoomAudio.Tests/MultiRoomAudio.Tests.csproj`
+Expected: PASS — all new `MultiSinkTriggerTests`, the updated `TriggerOverrideTests`, and the rest of the suite are green.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/MultiRoomAudio/Models/TriggerModels.cs \
+        src/MultiRoomAudio/Services/TriggerService.cs \
+        src/MultiRoomAudio/Controllers/TriggersEndpoint.cs \
+        tests/MultiRoomAudio.Tests/Services/MultiSinkTriggerTests.cs \
+        tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs
+git commit -m "feat: support multiple sinks per relay trigger (#250)
+
+Replace TriggerConfiguration.CustomSinkName with a CustomSinkNames list and
+match all channels containing a sink (full many-to-many). Legacy single-sink
+config migrates via a write-only shim. Closes the backend half of #250."
+```
+
+---
+
+## Task 2: Main-app chip-picker UI
+
+**Files:**
+- Modify: `src/MultiRoomAudio/wwwroot/js/app.js`
+
+**Interfaces:**
+- Consumes: `triggersData.boards[].triggers[].customSinkNames` (array, from Task 1 API), `escapeHtml`, `showAlert`.
+- Produces (globals reused by Task 3): `renderSinkChips(boardId, channel, names, allSinks, disabled)`, `addTriggerSink`, `removeTriggerSink`.
+
+> No JS unit harness exists in this repo; this task is verified by building and
+> exercising the UI manually.
+
+- [ ] **Step 1: Stash the sink list for handler reuse** — in `renderTriggers`, right after `sinkOptions` is built (~L4869), add:
+
+```javascript
+// Expose the current sink list to chip-picker handlers (and the wizard).
+triggerSinksList = customSinksList;
+```
+
+At the top of `app.js` near other module-level state, add:
+
+```javascript
+let triggerSinksList = [];
+```
+
+- [ ] **Step 2: Add the chip-picker render + helpers** (place near the other trigger functions, e.g. just above `updateTriggerSink`)
+
+```javascript
+// Look up the in-memory trigger object for a board/channel.
+function getTrigger(boardId, channel) {
+    const board = triggersData?.boards?.find(b => b.boardId === boardId);
+    return board?.triggers?.find(t => t.channel === channel);
+}
+
+// Render the selected-sink chips plus an "add" dropdown for a channel.
+function renderSinkChips(boardId, channel, names, allSinks, disabled) {
+    const safeNames = names || [];
+    const chips = safeNames.map(name => {
+        const sink = (allSinks || []).find(s => s.name === name);
+        const label = sink ? (sink.description || sink.name) : name;
+        const remove = disabled ? '' :
+            `<button type="button" class="btn-close btn-close-white ms-1" style="font-size:.5rem"
+                     aria-label="Remove" title="Remove zone"
+                     onclick="removeTriggerSink('${boardId}', ${channel}, '${escapeHtml(name)}')"></button>`;
+        return `<span class="badge bg-primary d-inline-flex align-items-center me-1 mb-1">${escapeHtml(label)}${remove}</span>`;
+    }).join('');
+
+    const remaining = (allSinks || []).filter(s => !safeNames.includes(s.name));
+    const addControl = (disabled || remaining.length === 0) ? '' : `
+        <select class="form-select form-select-sm mt-1"
+                onchange="addTriggerSink('${boardId}', ${channel}, this.value); this.value='';">
+            <option value="">+ Add zone…</option>
+            ${remaining.map(s => `<option value="${escapeHtml(s.name)}">${escapeHtml(s.description || s.name)}</option>`).join('')}
+        </select>`;
+
+    const empty = safeNames.length === 0 ? '<span class="text-muted small">Not assigned</span>' : '';
+    return `<div class="d-flex flex-wrap align-items-center">${chips}${empty}</div>${addControl}`;
+}
+
+async function addTriggerSink(boardId, channel, sinkName) {
+    if (!sinkName) return;
+    const t = getTrigger(boardId, channel);
+    if (!t) return;
+    t.customSinkNames = t.customSinkNames || [];
+    if (!t.customSinkNames.includes(sinkName)) t.customSinkNames.push(sinkName);
+    await saveTriggerSinks(boardId, channel);
+}
+
+async function removeTriggerSink(boardId, channel, sinkName) {
+    const t = getTrigger(boardId, channel);
+    if (!t) return;
+    t.customSinkNames = (t.customSinkNames || []).filter(n => n !== sinkName);
+    await saveTriggerSinks(boardId, channel);
+}
+
+// Persist the channel's full sink list (+ current delay) and re-render its chips.
+async function saveTriggerSinks(boardId, channel) {
+    const boardIdSafe = boardId.replace(/[^a-zA-Z0-9]/g, '_');
+    const t = getTrigger(boardId, channel);
+    const names = t ? (t.customSinkNames || []) : [];
+    const delayInput = document.getElementById(`trigger-delay-${boardIdSafe}-${channel}`);
+    const delay = delayInput ? parseInt(delayInput.value, 10) : 60;
+
+    try {
+        const url = boardId.includes('/')
+            ? `./api/triggers/boards/channel?boardId=${encodeURIComponent(boardId)}&channel=${channel}`
+            : `./api/triggers/boards/${encodeURIComponent(boardId)}/${channel}`;
+        const response = await fetch(url, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds: delay })
+        });
+        if (!response.ok) {
+            const error = await response.json();
+            throw new Error(error.message || 'Failed to update trigger');
+        }
+        const container = document.getElementById(`trigger-sink-${boardIdSafe}-${channel}`);
+        if (container) {
+            container.innerHTML = renderSinkChips(boardId, channel, names, triggerSinksList, false);
+        }
+        showAlert('Trigger updated', 'success', 2000);
+    } catch (error) {
+        console.error('Error updating trigger:', error);
+        showAlert(`Failed to update trigger: ${error.message}`, 'danger');
+    }
+}
+```
+
+- [ ] **Step 3: Replace the `<select>` sink cell with the chip container** — in the `channelsHtml` map (~L4918–4926), replace the `<td>` containing the sink `<select>` with:
+
+```javascript
+                    <td>
+                        <div id="trigger-sink-${boardIdSafe}-${trigger.channel}"
+                             class="trigger-sink-picker">
+                            ${renderSinkChips(boardId, trigger.channel, trigger.customSinkNames, customSinksList, controlsDisabled)}
+                        </div>
+                    </td>
+```
+
+The container keeps the `trigger-sink-${boardIdSafe}-${channel}` id so existing
+`updateChannelState` row-lookup logic still finds the row via `closest('tr')`.
+
+- [ ] **Step 4: Remove the now-dead single-select code**
+
+- Delete the old `updateTriggerSink` function (~L5552–5583) — nothing references it after Step 3.
+- Delete the `restoreTriggerSelections`/select-value restore block (~L5064–5071) and its call site (search for where it is invoked after `renderTriggers`). The chips render from data directly, so no post-render restore is needed.
+- In `updateTriggerDelay` (~L5586–5616), replace the `<select>` read with the in-memory list:
+
+```javascript
+async function updateTriggerDelay(boardId, channel, delay) {
+    const t = getTrigger(boardId, channel);
+    const names = t ? (t.customSinkNames || []) : [];
+
+    try {
+        const url = boardId.includes('/')
+            ? `./api/triggers/boards/channel?boardId=${encodeURIComponent(boardId)}&channel=${channel}`
+            : `./api/triggers/boards/${encodeURIComponent(boardId)}/${channel}`;
+        const response = await fetch(url, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds: parseInt(delay, 10) })
+        });
+        if (!response.ok) {
+            const error = await response.json();
+            throw new Error(error.message || 'Failed to update trigger');
+        }
+        showAlert('Delay updated', 'success', 2000);
+    } catch (error) {
+        console.error('Error updating trigger delay:', error);
+        showAlert(`Failed to update trigger: ${error.message}`, 'danger');
+    }
+}
+```
+
+- In `updateChannelState` (~L5632), the variable named `sinkSelect` now resolves
+  to the container div — rename it to `sinkCell` for clarity and keep the
+  `closest('tr')` logic unchanged:
+
+```javascript
+    const sinkCell = document.getElementById(`trigger-sink-${boardIdSafe}-${channel}`);
+    if (!sinkCell) return;
+    const row = sinkCell.closest('tr');
+    if (!row) return;
+```
+
+- [ ] **Step 5: Build the app and verify manually**
+
+Run: `dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj`
+Expected: build succeeds.
+
+Then run with mock hardware and verify in a browser:
+
+Run: `MOCK_HARDWARE=true dotnet run --project src/MultiRoomAudio/MultiRoomAudio.csproj`
+Verify on the Triggers panel:
+1. A channel with no sinks shows "Not assigned" and a "+ Add zone…" dropdown.
+2. Selecting a zone adds a chip and persists (refresh the page — chip remains).
+3. Adding a second zone shows two chips; the dropdown no longer lists chosen zones.
+4. The `×` on a chip removes it and persists.
+5. Assigning the **same** zone to two channels is allowed (dropdown still offers it on the second channel).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/MultiRoomAudio/wwwroot/js/app.js
+git commit -m "feat: chip picker for multi-sink trigger assignment (#250)"
+```
+
+> **End of PR 1.** Push branch and open PR against `dev` covering Tasks 1–2.
+> PR body: closes #250 (backend + main-app multi-sink support).
+
+---
+
+## Task 3: Wizard relay-assignment step (PR 2)
+
+**Files:**
+- Modify: `src/MultiRoomAudio/wwwroot/js/wizard.js`
+
+**Interfaces:**
+- Consumes: global `renderSinkChips` (Task 2), existing wizard helpers
+  (`this.customSinks`, `renderProgress`, `renderStep`), and trigger REST APIs:
+  - `GET /api/triggers` → `{ enabled, boards: [{ boardId, displayName, channelCount, triggers: [{channel, customSinkNames}] }] }`
+  - `PUT /api/triggers/enabled` → `{ enabled: true }`
+  - `PUT /api/triggers/boards/{boardId}/{channel}` → `{ channel, customSinkNames, offDelaySeconds }`
+- Produces: a new onboarding step shown only when relay boards already exist.
+
+> Verified manually (no JS test harness). This step is **read-mostly**: it
+> assigns sinks to channels on boards the user already added in the main app /
+> hardware detection. Board *creation* remains in the main app to keep onboarding
+> scope bounded.
+
+- [ ] **Step 1: Add the step to `STEPS`** — `src/MultiRoomAudio/wwwroot/js/wizard.js` (~L81)
+
+Insert before the `complete` step:
+
+```javascript
+        { id: 'triggers', title: 'Amp Triggers' },
+```
+
+So the array becomes: welcome, cards, identify, sinks, players, **triggers**, complete.
+
+- [ ] **Step 2: Add wizard state for trigger boards** — in the wizard state block (near `customSinks: []`, ~L75):
+
+```javascript
+    triggerBoards: [],     // boards fetched from /api/triggers
+    triggersEnabled: false,
+```
+
+- [ ] **Step 3: Handle the step in `renderStep`** — in the `switch (step.id)` (~L284), add a case that self-skips when there is no relay hardware:
+
+```javascript
+            case 'triggers':
+                await this.loadTriggerBoards();
+                if (this.triggerBoards.length === 0) {
+                    // No relay boards configured — skip this step entirely.
+                    this.currentStep++;
+                    this.renderProgress();
+                    await this.renderStep();
+                    return;
+                }
+                content.innerHTML = this.renderTriggers();
+                break;
+```
+
+- [ ] **Step 4: Add the loader and renderer + assignment handlers** — add these methods to the `Wizard` object (near the other `render*` methods):
+
+```javascript
+    // Load configured relay boards for the triggers step.
+    async loadTriggerBoards() {
+        try {
+            const response = await fetch('./api/triggers');
+            if (!response.ok) { this.triggerBoards = []; return; }
+            const data = await response.json();
+            this.triggerBoards = data.boards || [];
+            this.triggersEnabled = !!data.enabled;
+        } catch (error) {
+            console.error('Failed to load trigger boards:', error);
+            this.triggerBoards = [];
+        }
+    },
+
+    // Step: assign zones/sinks to relay channels using the shared chip picker.
+    renderTriggers() {
+        const sinkList = this.customSinks.map(s => ({ name: s.name, description: s.label || s.name }));
+        const boardsHtml = this.triggerBoards.map(board => {
+            const rows = (board.triggers || []).map(t => `
+                <tr>
+                    <td><span class="badge bg-primary">CH ${t.channel}</span></td>
+                    <td>
+                        <div id="wizard-trigger-sink-${board.boardId.replace(/[^a-zA-Z0-9]/g, '_')}-${t.channel}">
+                            ${renderSinkChips(board.boardId, t.channel, t.customSinkNames, sinkList, false)}
+                        </div>
+                    </td>
+                </tr>`).join('');
+            return `
+                <h6 class="mt-3">${escapeHtml(board.displayName || board.boardId)}</h6>
+                <table class="table table-sm align-middle">
+                    <thead><tr><th style="width:6rem">Channel</th><th>Zones</th></tr></thead>
+                    <tbody>${rows}</tbody>
+                </table>`;
+        }).join('');
+
+        return `
+            <div class="py-2">
+                <h4>Amplifier Triggers</h4>
+                <p class="text-muted">Assign one or more zones to each relay channel. The relay
+                   switches on when any assigned zone plays and off when all of them stop —
+                   ideal for powering a multi-zone amplifier from a single trigger.</p>
+                ${boardsHtml}
+            </div>`;
+    },
+```
+
+> The chip picker's `addTriggerSink`/`removeTriggerSink`/`saveTriggerSinks`
+> (from app.js) operate on `triggersData`, which is the **main app's** state and
+> is not populated inside the wizard. The wizard therefore defines its own
+> persistence in the next step and overrides the container's handlers by passing
+> wizard-scoped callbacks. To keep it simple and self-contained, the wizard uses
+> a thin local save that calls the same API.
+
+- [ ] **Step 5: Add wizard-local chip handlers** — because the wizard does not use the main app's `triggersData`, add wizard-scoped add/remove that update `this.triggerBoards` and persist immediately:
+
+```javascript
+    wizardGetTrigger(boardId, channel) {
+        const board = this.triggerBoards.find(b => b.boardId === boardId);
+        return board?.triggers?.find(t => t.channel === channel);
+    },
+
+    async wizardAddTriggerSink(boardId, channel, sinkName) {
+        if (!sinkName) return;
+        const t = this.wizardGetTrigger(boardId, channel);
+        if (!t) return;
+        t.customSinkNames = t.customSinkNames || [];
+        if (!t.customSinkNames.includes(sinkName)) t.customSinkNames.push(sinkName);
+        await this.wizardSaveTriggerSinks(boardId, channel);
+    },
+
+    async wizardRemoveTriggerSink(boardId, channel, sinkName) {
+        const t = this.wizardGetTrigger(boardId, channel);
+        if (!t) return;
+        t.customSinkNames = (t.customSinkNames || []).filter(n => n !== sinkName);
+        await this.wizardSaveTriggerSinks(boardId, channel);
+    },
+
+    async wizardSaveTriggerSinks(boardId, channel) {
+        const t = this.wizardGetTrigger(boardId, channel);
+        const names = t ? (t.customSinkNames || []) : [];
+        // Ensure the feature is enabled before the first assignment.
+        if (!this.triggersEnabled) {
+            await fetch('./api/triggers/enabled', {
+                method: 'PUT', headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ enabled: true })
+            });
+            this.triggersEnabled = true;
+        }
+        const url = boardId.includes('/')
+            ? `./api/triggers/boards/channel?boardId=${encodeURIComponent(boardId)}&channel=${channel}`
+            : `./api/triggers/boards/${encodeURIComponent(boardId)}/${channel}`;
+        await fetch(url, {
+            method: 'PUT', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds: 60 })
+        });
+        const safe = boardId.replace(/[^a-zA-Z0-9]/g, '_');
+        const container = document.getElementById(`wizard-trigger-sink-${safe}-${channel}`);
+        const sinkList = this.customSinks.map(s => ({ name: s.name, description: s.label || s.name }));
+        if (container) container.innerHTML = renderSinkChips(boardId, channel, names, sinkList, false);
+    },
+```
+
+- [ ] **Step 6: Point the chip picker at the wizard handlers in the triggers step**
+
+`renderSinkChips` emits `onclick="removeTriggerSink(...)"` / `onchange="addTriggerSink(...)"` referencing the app.js globals. Inside the wizard, alias those globals to the wizard methods while the triggers step is shown, by adding this at the start of `renderTriggers()`:
+
+```javascript
+        // Route chip-picker callbacks to wizard-scoped handlers for this step.
+        window.addTriggerSink = (b, c, s) => this.wizardAddTriggerSink(b, c, s);
+        window.removeTriggerSink = (b, c, s) => this.wizardRemoveTriggerSink(b, c, s);
+```
+
+And restore the app.js handlers when the wizard closes — in `hide()` (or `complete()`), reset them so the main app's panel keeps working:
+
+```javascript
+        // Restore main-app chip handlers (defined in app.js).
+        if (typeof appAddTriggerSink === 'function') window.addTriggerSink = appAddTriggerSink;
+        if (typeof appRemoveTriggerSink === 'function') window.removeTriggerSink = appRemoveTriggerSink;
+```
+
+In `app.js`, after defining `addTriggerSink`/`removeTriggerSink`, capture the originals once so the wizard can restore them:
+
+```javascript
+// Preserve references so the onboarding wizard can restore these after overriding.
+const appAddTriggerSink = addTriggerSink;
+const appRemoveTriggerSink = removeTriggerSink;
+```
+
+> Design note: this global-aliasing is a small wart caused by the chip markup
+> using inline `onclick`. It is acceptable here because both scripts share one
+> page and the alias is scoped to the wizard's lifetime. If a cleaner approach is
+> wanted later, `renderSinkChips` could take handler-name parameters — out of
+> scope for this PR.
+
+- [ ] **Step 7: Build and verify manually**
+
+Run: `dotnet build src/MultiRoomAudio/MultiRoomAudio.csproj`
+Expected: build succeeds.
+
+Run with mock hardware and a configured board, then trigger onboarding
+(`POST /api/onboarding/reset`, reload):
+1. With **no** relay boards: the wizard skips straight from Players to Done (no triggers step).
+2. With a relay board configured: the triggers step appears, lists the board's channels, and lets you add/remove zones via chips.
+3. Assignments persist (check the main-app Triggers panel after finishing).
+4. After finishing onboarding, the main-app chip picker still adds/removes correctly (handlers restored).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/MultiRoomAudio/wwwroot/js/wizard.js src/MultiRoomAudio/wwwroot/js/app.js
+git commit -m "feat: add relay-trigger assignment step to onboarding wizard (#250)"
+```
+
+> **End of PR 2.** Push branch and open PR against `dev` for the wizard step.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** data model + migration (Task 1 Steps 3, 1–2), many-to-many engine (Step 5), `ConfigureTrigger`/`OnSinkDeleted`/response/save-filter (Steps 4,6,7,8), API request/response + controller (Steps 3,9), main-app chip picker (Task 2), wizard step (Task 3), testing (Task 1 Steps 1,11). All spec sections map to a task.
+- **Migration safety:** the write-only `CustomSinkName` shim + `IgnoreUnmatchedProperties()` + `OmitNull` is covered by the two migration tests in Task 1 Step 1.
+- **Type consistency:** `CustomSinkNames` (list) and `ConfigureTrigger(..., List<string>, ...)` are used identically across service, controller, request resolver, and tests. `TriggerResponse` positional order is fixed in Step 3 and matched in the updated test (Step 10) and response builder (Step 4).

--- a/docs/superpowers/specs/2026-06-26-multi-sink-triggers-design.md
+++ b/docs/superpowers/specs/2026-06-26-multi-sink-triggers-design.md
@@ -1,0 +1,209 @@
+# Multi-Sink Triggers — Design
+
+**Issue:** #250 — _"allow trigger to reference more than one sink"_
+**Date:** 2026-06-26
+**Branch:** `feat/multi-sink-triggers` (off `dev`)
+
+## Problem
+
+Each relay trigger channel currently references exactly one sink/zone via
+`TriggerConfiguration.CustomSinkName` (a single `string?`). For whole-amp power
+control (e.g. one relay powering a 6-zone amplifier), a user wants a single
+channel to switch ON when **any** of several zones starts and OFF only when
+**all** of them have stopped.
+
+The runtime engine already supports the OFF-when-last-stops behavior via the
+`TriggerChannelState.ActivePlayerCount` reference counter — it is simply not
+reachable today because the config models a 1:1 sink→channel mapping. This is a
+**data-model change, not an engine rewrite.**
+
+## Scope
+
+Two parts, shipped as two PRs against `dev`:
+
+- **Part 1 — Core multi-sink** (backend + main-app UI). Fully closes #250.
+- **Part 2 — Wizard relay step** (new onboarding step). Builds on Part 1.
+
+### Mapping model: full many-to-many
+
+A channel may list many sinks **and** a sink may appear on many channels.
+Example:
+
+```
+CH7 (master amp): [zoneA, zoneB, zoneC, zoneD, zoneE, zoneF]
+CH1 (zone A amp): [zoneA]
+
+zoneA plays  → CH1 ON + CH7 ON
+zoneA stops  → CH1 OFF; CH7 stays ON until B–F stop
+```
+
+This requires removing the early `return` in the player-event handlers so that
+**all** matching channels activate, not just the first.
+
+---
+
+## Part 1 — Core multi-sink
+
+### 1. Data model — `Models/TriggerModels.cs`
+
+Replace the single field with a list, plus a write-only migration shim for the
+legacy property:
+
+```csharp
+public class TriggerConfiguration
+{
+    public int Channel { get; set; }
+
+    /// <summary>Sinks whose playback activates this relay. Empty = unassigned.</summary>
+    public List<string> CustomSinkNames { get; set; } = new();
+
+    // Legacy single-sink property — retained ONLY so old YAML migrates cleanly.
+    [Obsolete("Use CustomSinkNames. Retained for config migration.")]
+    public string? CustomSinkName
+    {
+        get => null;  // null + serializer OmitNull ⇒ never written back to disk
+        set
+        {
+            if (!string.IsNullOrEmpty(value) && !CustomSinkNames.Contains(value))
+                CustomSinkNames.Add(value);
+        }
+    }
+
+    public int OffDelaySeconds { get; set; } = 60;
+    public string? ZoneName { get; set; }
+}
+```
+
+**Why the shim is mandatory:** the deserializer is configured with
+`UnderscoredNamingConvention` + `IgnoreUnmatchedProperties()`
+(`TriggerService` ctor). Without a settable `CustomSinkName`, an old
+`custom_sink_name:` line would be silently ignored and users would lose their
+trigger assignments on upgrade. The null getter combined with the serializer's
+existing `DefaultValuesHandling.OmitNull` means the legacy key vanishes from
+disk on the next save — a clean one-way migration with no version flag.
+
+### 2. Engine — many-to-many matching — `Services/TriggerService.cs`
+
+`OnPlayerStarted` / `OnPlayerStopped` (~L701–741): remove the
+`FirstOrDefault(...) + return` and instead iterate **all** boards and channels,
+activating/deactivating **every** channel whose `CustomSinkNames` contains the
+device id:
+
+```csharp
+foreach (var boardConfig in _config.Boards)
+{
+    if (!_boardStates.ContainsKey(boardConfig.BoardId)) continue;
+    foreach (var trigger in boardConfig.Triggers)
+    {
+        if (trigger.CustomSinkNames.Any(s =>
+                string.Equals(s, deviceId, StringComparison.OrdinalIgnoreCase)))
+        {
+            ActivateTrigger(boardConfig.BoardId, trigger.Channel, playerName);
+        }
+    }
+}
+```
+
+`ActivateTrigger` / `DeactivateTrigger` and the `ActivePlayerCount`
+reference-counting logic are **unchanged** — they already keep a channel ON
+until its last contributing sink stops.
+
+### 3. Supporting backend changes — `Services/TriggerService.cs`
+
+- **`ConfigureTrigger`** (~L510): signature takes `List<string> customSinkNames`;
+  validate each sink (warn if missing, non-fatal); empty list = unassign
+  (turn relay off, cancel timer, reset channel state).
+- **`OnSinkDeleted`** (~L746): remove the deleted sink from each trigger's list;
+  only clear the channel (relay off, cancel timer, reset state) when a list
+  becomes empty.
+- **Response builder** (~L223): build `CustomSinkNames` plus a parallel
+  `CustomSinkDisplayNames` list (resolve each via `_sinksService.GetSink`).
+- **`SaveConfigurationInternal` cleanup filter** (~L1356): keep a trigger when
+  `CustomSinkNames.Count > 0 || !IsNullOrEmpty(ZoneName) || OffDelaySeconds != 60`.
+
+### 4. API — `Models/TriggerModels.cs` + `Controllers/TriggersEndpoint.cs`
+
+- **`TriggerResponse`**: replace `CustomSinkName` / `CustomSinkDisplayName` with
+  `CustomSinkNames` / `CustomSinkDisplayNames` (lists).
+- **`TriggerConfigureRequest`**: add `List<string> CustomSinkNames`. Keep the
+  singular `CustomSinkName` accepted for back-compat — if the list is empty and
+  the singular is present, fold it in. (The web UI is the only known consumer,
+  but this keeps any external automation working.)
+- **Controller**: the three `ConfigureTrigger` call sites (main + 2 legacy)
+  pass the list through.
+
+### 5. Main-app UI — `wwwroot/js/app.js`
+
+Replace the single `<select>` sink cell (~L4919) with a **reusable chip
+picker**:
+
+- Selected sinks render as removable pills (chip text = display name, `×` removes).
+- A dropdown lists the remaining (not-yet-selected) sinks; choosing one adds a chip.
+- Any add/remove issues a `PUT /api/triggers/boards/{boardId}/{channel}` with the
+  full `customSinkNames` array (plus existing `offDelaySeconds` / `zoneName`).
+- Selection-restore logic (~L5064) and the delay/override handlers that currently
+  read the `<select>` value (~L5588, ~L5632) updated to read the chip state.
+
+Implemented as a single function (e.g. `renderSinkChipPicker(containerId, selected, available, onChange)`)
+so Part 2 reuses it verbatim.
+
+---
+
+## Part 2 — Wizard relay step (new onboarding step)
+
+### Overview
+
+The onboarding wizard (`wwwroot/js/wizard.js`) currently has no relay/trigger
+step (`STEPS`: Welcome → Devices → Identify → Sinks → Players → Done). Add a new
+step that lets users assign zones/sinks to relay channels during setup, using
+the same chip picker.
+
+### Changes
+
+- **New step** `{ id: 'triggers', title: 'Amp Triggers' }` inserted before
+  `complete` in the `STEPS` array (~L81).
+- **Self-skip when no relay hardware:** on entering the step, fetch relay boards
+  (`GET /api/triggers/boards`, or device detection). If none are present, advance
+  past the step automatically — mirrors the existing `cards`-step skip pattern
+  (~L294) so hardware-less users never see it.
+- **Render** the shared chip-picker component per detected channel.
+- **Persist** via the existing `PUT /api/triggers/boards/{boardId}/{channel}`
+  API. No new onboarding endpoint is required: triggers reference
+  devices/sinks (hardware that already exists at this point), so assignment works
+  even though players are not created until `complete()`.
+
+### Open implementation detail (resolve during planning)
+
+Whether trigger assignments are written immediately on each chip change (simplest,
+consistent with the main app) or batched and applied in `complete()`. Default:
+write immediately via the existing API, matching main-app behavior.
+
+---
+
+## Testing
+
+Extend the existing `tests/MultiRoomAudio.Tests` project:
+
+- **Migration:** YAML containing `custom_sink_name: X` deserializes to
+  `CustomSinkNames == [X]`; re-serialization emits only `custom_sink_names`
+  (no legacy key).
+- **Engine many-to-many:**
+  - One sink on two channels → both channels activate on start, both deactivate
+    on stop.
+  - Two sinks on one channel → channel stays ON until both stop (ref-count
+    correctness).
+- **Sink deletion:** removing a sink prunes it from every trigger list; a
+  channel left with an empty list is cleared.
+
+## Sequencing
+
+1. **PR 1 — Part 1** (backend + main-app UI). Low-risk, self-contained, closes #250.
+2. **PR 2 — Part 2** (wizard relay step). Builds on the shipped chip-picker.
+
+Both target `dev`.
+
+## Non-goals
+
+- No change to the relay reference-counting engine internals.
+- No new persistence format beyond the field rename + migration shim.
+- No unrelated refactoring of the trigger panel or wizard.

--- a/src/MultiRoomAudio/Controllers/DiagnosticsEndpoint.cs
+++ b/src/MultiRoomAudio/Controllers/DiagnosticsEndpoint.cs
@@ -342,7 +342,7 @@ public static class DiagnosticsEndpoint
             {
                 foreach (var board in status.Boards)
                 {
-                    var channelsInUse = board.Triggers.Count(t => t.CustomSinkName != null);
+                    var channelsInUse = board.Triggers.Count(t => t.CustomSinkNames.Count > 0);
                     sb.AppendLine($"  {board.BoardId} - {board.BoardType} - {board.State} - {channelsInUse}/{board.ChannelCount} channels");
                 }
             }
@@ -377,7 +377,7 @@ public static class DiagnosticsEndpoint
             var playersWithDevices = players.Players.Count(p => !string.IsNullOrEmpty(p.Device));
             var playingCount = players.Players.Count(p => p.State == PlayerState.Playing);
             var connectedBoards = triggerStatus.Boards.Count(b => b.State == TriggerFeatureState.Connected);
-            var assignedChannels = triggerStatus.Boards.SelectMany(b => b.Triggers).Count(t => t.CustomSinkName != null);
+            var assignedChannels = triggerStatus.Boards.SelectMany(b => b.Triggers).Count(t => t.CustomSinkNames.Count > 0);
 
             sb.AppendLine($"  Audio Devices:  {hardwareDeviceCount} total, {playersWithDevices} with players");
             sb.AppendLine($"  Custom Sinks:   {sinks.Count}");
@@ -710,7 +710,9 @@ public static class DiagnosticsEndpoint
                 sb.AppendLine("  Channel Mappings:");
                 foreach (var trigger in board.Triggers)
                 {
-                    var assignedTo = trigger.CustomSinkName ?? "(unassigned)";
+                    var assignedTo = trigger.CustomSinkNames.Count > 0
+                        ? string.Join(", ", trigger.CustomSinkNames)
+                        : "(unassigned)";
                     var stateStr = trigger.RelayState == RelayState.On ? "ON" : "OFF";
                     sb.AppendLine($"    Ch {trigger.Channel}: {stateStr} -> {assignedTo}");
                 }

--- a/src/MultiRoomAudio/Controllers/TriggersEndpoint.cs
+++ b/src/MultiRoomAudio/Controllers/TriggersEndpoint.cs
@@ -404,7 +404,7 @@ public static class TriggersEndpoint
                 var success = service.ConfigureTrigger(
                     boardId,
                     channel,
-                    request.CustomSinkName,
+                    request.ResolveSinkNames(),
                     request.OffDelaySeconds,
                     request.ZoneName);
 
@@ -448,7 +448,7 @@ public static class TriggersEndpoint
                 var success = service.ConfigureTrigger(
                     boardId,
                     channel,
-                    request.CustomSinkName,
+                    request.ResolveSinkNames(),
                     request.OffDelaySeconds,
                     request.ZoneName);
 
@@ -478,7 +478,7 @@ public static class TriggersEndpoint
 
             try
             {
-                service.ConfigureTrigger(boardId, channel, null, 60, null);
+                service.ConfigureTrigger(boardId, channel, new List<string>(), 60, null);
                 logger.LogInformation("Trigger channel {BoardId}/{Channel} unassigned", boardId, channel);
                 return Results.Ok(new SuccessResponse(true, $"Trigger channel {boardId}/{channel} unassigned"));
             }
@@ -706,7 +706,7 @@ public static class TriggersEndpoint
                 var success = service.ConfigureTrigger(
                     firstBoard.BoardId,
                     channel,
-                    request.CustomSinkName,
+                    request.ResolveSinkNames(),
                     request.OffDelaySeconds,
                     request.ZoneName);
 
@@ -741,7 +741,7 @@ public static class TriggersEndpoint
 
             try
             {
-                service.ConfigureTrigger(firstBoard.BoardId, channel, null, 60, null);
+                service.ConfigureTrigger(firstBoard.BoardId, channel, new List<string>(), 60, null);
                 logger.LogInformation("Trigger channel {Channel} unassigned on board {BoardId}",
                     channel, firstBoard.BoardId);
                 return Results.Ok(new SuccessResponse(true, $"Trigger channel {channel} unassigned"));

--- a/src/MultiRoomAudio/Models/TriggerModels.cs
+++ b/src/MultiRoomAudio/Models/TriggerModels.cs
@@ -126,10 +126,28 @@ public class TriggerConfiguration
     public int Channel { get; set; }
 
     /// <summary>
-    /// Name of the custom sink that triggers this relay.
-    /// Null or empty means this trigger is not assigned.
+    /// Names of the custom sinks that trigger this relay.
+    /// Empty means this trigger is not assigned. The relay turns on when any
+    /// listed sink starts and off (after the delay) when all have stopped.
     /// </summary>
-    public string? CustomSinkName { get; set; }
+    public List<string> CustomSinkNames { get; set; } = new();
+
+    /// <summary>
+    /// Legacy single-sink property. Retained ONLY so old triggers.yaml
+    /// (custom_sink_name) migrates into <see cref="CustomSinkNames"/> on load.
+    /// The null getter combined with the serializer's OmitNull handling means it
+    /// is never written back to disk.
+    /// </summary>
+    [Obsolete("Use CustomSinkNames. Retained for config migration.")]
+    public string? CustomSinkName
+    {
+        get => null;
+        set
+        {
+            if (!string.IsNullOrEmpty(value) && !CustomSinkNames.Contains(value))
+                CustomSinkNames.Add(value);
+        }
+    }
 
     /// <summary>
     /// Delay in seconds before turning off the relay after playback stops.
@@ -289,8 +307,8 @@ public class TriggerFeatureConfiguration
 /// </summary>
 public record TriggerResponse(
     int Channel,
-    string? CustomSinkName,
-    string? CustomSinkDisplayName,
+    List<string> CustomSinkNames,
+    List<string> CustomSinkDisplayNames,
     int OffDelaySeconds,
     string? ZoneName,
     RelayState RelayState,
@@ -412,10 +430,25 @@ public class TriggerConfigureRequest
     public int Channel { get; set; }
 
     /// <summary>
-    /// Custom sink name to assign to this trigger.
-    /// Set to null or empty to unassign.
+    /// Custom sink names to assign to this trigger. Empty list unassigns.
+    /// </summary>
+    public List<string> CustomSinkNames { get; set; } = new();
+
+    /// <summary>
+    /// Legacy single-sink field. If <see cref="CustomSinkNames"/> is empty and this
+    /// is set, it is folded into the list (back-compat for older API callers).
     /// </summary>
     public string? CustomSinkName { get; set; }
+
+    /// <summary>
+    /// Resolve the effective sink list, folding in the legacy singular field.
+    /// </summary>
+    public List<string> ResolveSinkNames()
+    {
+        if (CustomSinkNames.Count == 0 && !string.IsNullOrEmpty(CustomSinkName))
+            return new List<string> { CustomSinkName };
+        return CustomSinkNames;
+    }
 
     /// <summary>
     /// Off delay in seconds (0-3600).

--- a/src/MultiRoomAudio/Services/TriggerService.cs
+++ b/src/MultiRoomAudio/Services/TriggerService.cs
@@ -228,20 +228,22 @@ public class TriggerService : IAsyncDisposable
 
             var channelState = _channelStates.GetValueOrDefault((boardId, channel)) ?? new TriggerChannelState();
 
-            // Get display name for the sink
-            string? sinkDisplayName = null;
-            if (!string.IsNullOrEmpty(config.CustomSinkName))
-            {
-                var sink = _sinksService.GetSink(config.CustomSinkName);
-                sinkDisplayName = sink?.Description ?? sink?.Name ?? config.CustomSinkName;
-            }
+            // Resolve display names for each assigned sink.
+            var sinkNames = config.CustomSinkNames ?? new List<string>();
+            var sinkDisplayNames = sinkNames
+                .Select(n =>
+                {
+                    var sink = _sinksService.GetSink(n);
+                    return sink?.Description ?? sink?.Name ?? n;
+                })
+                .ToList();
 
             var relayState = relayBoard?.GetRelay(channel) ?? RelayState.Unknown;
 
             triggers.Add(new TriggerResponse(
                 Channel: channel,
-                CustomSinkName: config.CustomSinkName,
-                CustomSinkDisplayName: sinkDisplayName,
+                CustomSinkNames: sinkNames,
+                CustomSinkDisplayNames: sinkDisplayNames,
                 OffDelaySeconds: config.OffDelaySeconds,
                 ZoneName: config.ZoneName,
                 RelayState: relayState,
@@ -507,7 +509,7 @@ public class TriggerService : IAsyncDisposable
     /// <summary>
     /// Configure a trigger channel on a specific board.
     /// </summary>
-    public bool ConfigureTrigger(string boardId, int channel, string? customSinkName, int offDelaySeconds, string? zoneName)
+    public bool ConfigureTrigger(string boardId, int channel, List<string> customSinkNames, int offDelaySeconds, string? zoneName)
     {
         var boardConfig = _config.Boards.FirstOrDefault(b => b.BoardId == boardId);
         if (boardConfig == null)
@@ -516,9 +518,10 @@ public class TriggerService : IAsyncDisposable
         if (channel < 1 || channel > boardConfig.ChannelCount)
             throw new ArgumentOutOfRangeException(nameof(channel), $"Channel must be between 1 and {boardConfig.ChannelCount}");
 
+        var sinks = customSinkNames ?? new List<string>();
+
         lock (_configLock)
         {
-            // Find or create the trigger config
             var trigger = boardConfig.Triggers.FirstOrDefault(t => t.Channel == channel);
             if (trigger == null)
             {
@@ -526,23 +529,22 @@ public class TriggerService : IAsyncDisposable
                 boardConfig.Triggers.Add(trigger);
             }
 
-            // Validate custom sink exists (if specified)
-            if (!string.IsNullOrEmpty(customSinkName))
+            // Validate each sink exists (warn but do not fail — a sink may be created later).
+            foreach (var sinkName in sinks)
             {
-                var sink = _sinksService.GetSink(customSinkName);
-                if (sink == null)
+                if (_sinksService.GetSink(sinkName) == null)
                 {
                     _logger.LogWarning("Custom sink '{SinkName}' not found for trigger {BoardId}/{Channel}",
-                        customSinkName, boardId, channel);
+                        sinkName, boardId, channel);
                 }
             }
 
-            trigger.CustomSinkName = customSinkName;
+            trigger.CustomSinkNames = sinks;
             trigger.OffDelaySeconds = offDelaySeconds;
             trigger.ZoneName = zoneName;
 
-            // If unassigning, turn off the relay and cancel timer
-            if (string.IsNullOrEmpty(customSinkName))
+            // If unassigning (no sinks), turn off the relay and cancel timer.
+            if (sinks.Count == 0)
             {
                 CancelOffTimer(boardId, channel);
                 if (_relayBoards.TryGetValue(boardId, out var board))
@@ -557,8 +559,8 @@ public class TriggerService : IAsyncDisposable
             }
 
             SaveConfiguration();
-            _logger.LogInformation("Trigger {BoardId}/{Channel} configured: sink={Sink}, delay={Delay}s, zone={Zone}",
-                boardId, channel, customSinkName ?? "(none)", offDelaySeconds, zoneName ?? "(none)");
+            _logger.LogInformation("Trigger {BoardId}/{Channel} configured: sinks=[{Sinks}], delay={Delay}s, zone={Zone}",
+                boardId, channel, string.Join(", ", sinks), offDelaySeconds, zoneName ?? "(none)");
 
             return true;
         }
@@ -703,17 +705,19 @@ public class TriggerService : IAsyncDisposable
         if (!_config.Enabled || string.IsNullOrEmpty(deviceId))
             return;
 
-        // Find the trigger for this device across all boards
+        // Activate EVERY channel that lists this sink (full many-to-many).
         foreach (var boardConfig in _config.Boards)
         {
-            var trigger = boardConfig.Triggers.FirstOrDefault(t =>
-                !string.IsNullOrEmpty(t.CustomSinkName) &&
-                string.Equals(t.CustomSinkName, deviceId, StringComparison.OrdinalIgnoreCase));
+            if (!_boardStates.ContainsKey(boardConfig.BoardId))
+                continue;
 
-            if (trigger != null && _boardStates.ContainsKey(boardConfig.BoardId))
+            foreach (var trigger in boardConfig.Triggers)
             {
-                ActivateTrigger(boardConfig.BoardId, trigger.Channel, playerName);
-                return;
+                if (trigger.CustomSinkNames.Any(s =>
+                        string.Equals(s, deviceId, StringComparison.OrdinalIgnoreCase)))
+                {
+                    ActivateTrigger(boardConfig.BoardId, trigger.Channel, playerName);
+                }
             }
         }
     }
@@ -728,14 +732,16 @@ public class TriggerService : IAsyncDisposable
 
         foreach (var boardConfig in _config.Boards)
         {
-            var trigger = boardConfig.Triggers.FirstOrDefault(t =>
-                !string.IsNullOrEmpty(t.CustomSinkName) &&
-                string.Equals(t.CustomSinkName, deviceId, StringComparison.OrdinalIgnoreCase));
+            if (!_boardStates.ContainsKey(boardConfig.BoardId))
+                continue;
 
-            if (trigger != null && _boardStates.ContainsKey(boardConfig.BoardId))
+            foreach (var trigger in boardConfig.Triggers)
             {
-                DeactivateTrigger(boardConfig.BoardId, trigger.Channel, trigger.OffDelaySeconds, playerName);
-                return;
+                if (trigger.CustomSinkNames.Any(s =>
+                        string.Equals(s, deviceId, StringComparison.OrdinalIgnoreCase)))
+                {
+                    DeactivateTrigger(boardConfig.BoardId, trigger.Channel, trigger.OffDelaySeconds, playerName);
+                }
             }
         }
     }
@@ -751,29 +757,31 @@ public class TriggerService : IAsyncDisposable
 
             foreach (var boardConfig in _config.Boards)
             {
-                var affectedTriggers = boardConfig.Triggers
-                    .Where(t => string.Equals(t.CustomSinkName, sinkName, StringComparison.OrdinalIgnoreCase))
-                    .ToList();
-
-                foreach (var trigger in affectedTriggers)
+                foreach (var trigger in boardConfig.Triggers)
                 {
-                    _logger.LogInformation("Unassigning trigger {BoardId}/{Channel} - sink '{SinkName}' was deleted",
-                        boardConfig.BoardId, trigger.Channel, sinkName);
+                    var removed = trigger.CustomSinkNames
+                        .RemoveAll(s => string.Equals(s, sinkName, StringComparison.OrdinalIgnoreCase));
+                    if (removed == 0)
+                        continue;
 
-                    trigger.CustomSinkName = null;
-
-                    // Turn off relay and cancel timer
-                    CancelOffTimer(boardConfig.BoardId, trigger.Channel);
-                    if (_relayBoards.TryGetValue(boardConfig.BoardId, out var board))
-                    {
-                        board.SetRelay(trigger.Channel, false);
-                    }
-                    if (_channelStates.TryGetValue((boardConfig.BoardId, trigger.Channel), out var state))
-                    {
-                        state.IsActive = false;
-                        state.ActivePlayerCount = 0;
-                    }
                     affected = true;
+                    _logger.LogInformation("Removed sink '{SinkName}' from trigger {BoardId}/{Channel} (deleted)",
+                        sinkName, boardConfig.BoardId, trigger.Channel);
+
+                    // Only turn the channel off when no sinks remain on it.
+                    if (trigger.CustomSinkNames.Count == 0)
+                    {
+                        CancelOffTimer(boardConfig.BoardId, trigger.Channel);
+                        if (_relayBoards.TryGetValue(boardConfig.BoardId, out var board))
+                        {
+                            board.SetRelay(trigger.Channel, false);
+                        }
+                        if (_channelStates.TryGetValue((boardConfig.BoardId, trigger.Channel), out var state))
+                        {
+                            state.IsActive = false;
+                            state.ActivePlayerCount = 0;
+                        }
+                    }
                 }
             }
 
@@ -1353,7 +1361,7 @@ public class TriggerService : IAsyncDisposable
                 foreach (var board in config.Boards)
                 {
                     board.Triggers = board.Triggers
-                        .Where(t => !string.IsNullOrEmpty(t.CustomSinkName) ||
+                        .Where(t => (t.CustomSinkNames?.Count ?? 0) > 0 ||
                                     !string.IsNullOrEmpty(t.ZoneName) ||
                                     t.OffDelaySeconds != 60)
                         .ToList();

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -4650,6 +4650,7 @@ let triggersModal = null;
 let addBoardModal = null;
 let triggersData = null;
 let customSinksList = [];
+let triggerSinksList = [];
 let ftdiDevicesData = null;
 let triggersRefreshInterval = null;
 let triggersOperationCount = 0; // Counter to prevent refresh interval from clobbering state during overlapping operations
@@ -4863,10 +4864,8 @@ function renderTriggers() {
         errorDiv.classList.add('d-none');
     }
 
-    // Build sink options HTML
-    const sinkOptions = customSinksList.map(sink =>
-        `<option value="${escapeHtml(sink.name)}">${escapeHtml(sink.description || sink.name)}</option>`
-    ).join('');
+    // Expose the current sink list to chip-picker handlers (and the wizard).
+    triggerSinksList = customSinksList;
 
     // Build accordion for each board
     if (triggersData.boards.length === 0) {
@@ -4916,13 +4915,10 @@ function renderTriggers() {
                         ${activeStatus}
                     </td>
                     <td>
-                        <select class="form-select form-select-sm"
-                                id="trigger-sink-${boardIdSafe}-${trigger.channel}"
-                                onchange="updateTriggerSink('${boardId}', ${trigger.channel}, this.value)"
-                                ${controlsDisabled ? 'disabled' : ''}>
-                            <option value="">Not assigned</option>
-                            ${sinkOptions}
-                        </select>
+                        <div id="trigger-sink-${boardIdSafe}-${trigger.channel}"
+                             class="trigger-sink-picker">
+                            ${renderSinkChips(boardId, trigger.channel, trigger.customSinkNames, customSinksList, controlsDisabled)}
+                        </div>
                     </td>
                     <td>
                         <div class="input-group input-group-sm">
@@ -5549,33 +5545,79 @@ async function reconnectBoard(boardId) {
     }
 }
 
-// Update trigger sink assignment (multi-board)
-async function updateTriggerSink(boardId, channel, sinkName) {
+// Look up the in-memory trigger object for a board/channel.
+function getTrigger(boardId, channel) {
+    const board = triggersData?.boards?.find(b => b.boardId === boardId);
+    return board?.triggers?.find(t => t.channel === channel);
+}
+
+// Render the selected-sink chips plus an "add" dropdown for a channel.
+function renderSinkChips(boardId, channel, names, allSinks, disabled) {
+    const safeNames = names || [];
+    const chips = safeNames.map(name => {
+        const sink = (allSinks || []).find(s => s.name === name);
+        const label = sink ? (sink.description || sink.name) : name;
+        const remove = disabled ? '' :
+            `<button type="button" class="btn-close btn-close-white ms-1" style="font-size:.5rem"
+                     aria-label="Remove" title="Remove zone"
+                     onclick="removeTriggerSink('${boardId}', ${channel}, '${escapeHtml(name)}')"></button>`;
+        return `<span class="badge bg-primary d-inline-flex align-items-center me-1 mb-1">${escapeHtml(label)}${remove}</span>`;
+    }).join('');
+
+    const remaining = (allSinks || []).filter(s => !safeNames.includes(s.name));
+    const addControl = (disabled || remaining.length === 0) ? '' : `
+        <select class="form-select form-select-sm mt-1"
+                onchange="addTriggerSink('${boardId}', ${channel}, this.value); this.value='';">
+            <option value="">+ Add zone…</option>
+            ${remaining.map(s => `<option value="${escapeHtml(s.name)}">${escapeHtml(s.description || s.name)}</option>`).join('')}
+        </select>`;
+
+    const empty = safeNames.length === 0 ? '<span class="text-muted small">Not assigned</span>' : '';
+    return `<div class="d-flex flex-wrap align-items-center">${chips}${empty}</div>${addControl}`;
+}
+
+async function addTriggerSink(boardId, channel, sinkName) {
+    if (!sinkName) return;
+    const t = getTrigger(boardId, channel);
+    if (!t) return;
+    t.customSinkNames = t.customSinkNames || [];
+    if (!t.customSinkNames.includes(sinkName)) t.customSinkNames.push(sinkName);
+    await saveTriggerSinks(boardId, channel);
+}
+
+async function removeTriggerSink(boardId, channel, sinkName) {
+    const t = getTrigger(boardId, channel);
+    if (!t) return;
+    t.customSinkNames = (t.customSinkNames || []).filter(n => n !== sinkName);
+    await saveTriggerSinks(boardId, channel);
+}
+
+// Persist the channel's full sink list (+ current delay) and re-render its chips.
+async function saveTriggerSinks(boardId, channel) {
     const boardIdSafe = boardId.replace(/[^a-zA-Z0-9]/g, '_');
+    const t = getTrigger(boardId, channel);
+    const names = t ? (t.customSinkNames || []) : [];
     const delayInput = document.getElementById(`trigger-delay-${boardIdSafe}-${channel}`);
     const delay = delayInput ? parseInt(delayInput.value, 10) : 60;
 
     try {
-        // Use query params for board IDs that contain slashes (e.g., LCUS:/dev/ttyUSB0)
         const url = boardId.includes('/')
             ? `./api/triggers/boards/channel?boardId=${encodeURIComponent(boardId)}&channel=${channel}`
             : `./api/triggers/boards/${encodeURIComponent(boardId)}/${channel}`;
         const response = await fetch(url, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                channel,
-                customSinkName: sinkName || null,
-                offDelaySeconds: delay
-            })
+            body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds: delay })
         });
-
         if (!response.ok) {
             const error = await response.json();
             throw new Error(error.message || 'Failed to update trigger');
         }
-
-        showAlert(`Trigger updated`, 'success', 2000);
+        const container = document.getElementById(`trigger-sink-${boardIdSafe}-${channel}`);
+        if (container) {
+            container.innerHTML = renderSinkChips(boardId, channel, names, triggerSinksList, false);
+        }
+        showAlert('Trigger updated', 'success', 2000);
     } catch (error) {
         console.error('Error updating trigger:', error);
         showAlert(`Failed to update trigger: ${error.message}`, 'danger');
@@ -5584,23 +5626,17 @@ async function updateTriggerSink(boardId, channel, sinkName) {
 
 // Update trigger off delay (multi-board)
 async function updateTriggerDelay(boardId, channel, delay) {
-    const boardIdSafe = boardId.replace(/[^a-zA-Z0-9]/g, '_');
-    const sinkSelect = document.getElementById(`trigger-sink-${boardIdSafe}-${channel}`);
-    const sinkName = sinkSelect ? sinkSelect.value : null;
+    const t = getTrigger(boardId, channel);
+    const names = t ? (t.customSinkNames || []) : [];
 
     try {
-        // Use query params for board IDs that contain slashes (e.g., LCUS:/dev/ttyUSB0)
         const url = boardId.includes('/')
             ? `./api/triggers/boards/channel?boardId=${encodeURIComponent(boardId)}&channel=${channel}`
             : `./api/triggers/boards/${encodeURIComponent(boardId)}/${channel}`;
         const response = await fetch(url, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                channel,
-                customSinkName: sinkName || null,
-                offDelaySeconds: parseInt(delay, 10)
-            })
+            body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds: parseInt(delay, 10) })
         });
 
         if (!response.ok) {
@@ -5608,7 +5644,7 @@ async function updateTriggerDelay(boardId, channel, delay) {
             throw new Error(error.message || 'Failed to update trigger');
         }
 
-        showAlert(`Delay updated`, 'success', 2000);
+        showAlert('Delay updated', 'success', 2000);
     } catch (error) {
         console.error('Error updating trigger delay:', error);
         showAlert(`Failed to update trigger: ${error.message}`, 'danger');
@@ -5628,11 +5664,11 @@ function updateChannelState(boardId, channel, isOn) {
         }
     }
 
-    // Find the row for this channel by looking for the sink select element
-    const sinkSelect = document.getElementById(`trigger-sink-${boardIdSafe}-${channel}`);
-    if (!sinkSelect) return;
+    // Find the row for this channel by looking for the sink cell element
+    const sinkCell = document.getElementById(`trigger-sink-${boardIdSafe}-${channel}`);
+    if (!sinkCell) return;
 
-    const row = sinkSelect.closest('tr');
+    const row = sinkCell.closest('tr');
     if (!row) return;
 
     // Update the badge in the first cell

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -5549,14 +5549,14 @@ function renderSinkChips(boardId, channel, names, allSinks, disabled) {
         const remove = disabled ? '' :
             `<button type="button" class="btn-close btn-close-white ms-1" style="font-size:.5rem"
                      aria-label="Remove" title="Remove zone"
-                     onclick="removeTriggerSink('${escapeHtml(boardId)}', ${channel}, '${escapeHtml(name)}')"></button>`;
+                     onclick="removeTriggerSink(${escapeHtml(JSON.stringify(boardId))}, ${channel}, ${escapeHtml(JSON.stringify(name))})"></button>`;
         return `<span class="badge bg-primary d-inline-flex align-items-center me-1 mb-1">${escapeHtml(label)}${remove}</span>`;
     }).join('');
 
     const remaining = (allSinks || []).filter(s => !safeNames.includes(s.name));
     const addControl = (disabled || remaining.length === 0) ? '' : `
         <select class="form-select form-select-sm mt-1"
-                onchange="addTriggerSink('${escapeHtml(boardId)}', ${channel}, this.value); this.value='';">
+                onchange="addTriggerSink(${escapeHtml(JSON.stringify(boardId))}, ${channel}, this.value); this.value='';">
             <option value="">+ Add zone…</option>
             ${remaining.map(s => `<option value="${escapeHtml(s.name)}">${escapeHtml(s.description || s.name)}</option>`).join('')}
         </select>`;

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -353,6 +353,17 @@ function escapeJsString(str) {
     return str.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 }
 
+// Escape for a double-quoted HTML attribute value (encodes & < > and ").
+function escapeAttr(value) {
+    return escapeHtml(String(value)).replace(/"/g, '&quot;');
+}
+
+// Escape a value to sit inside a single-quoted JS string literal that is itself
+// inside a double-quoted HTML attribute (e.g. onclick="fn('...')").
+function escapeJsAttr(value) {
+    return escapeAttr(escapeJsString(String(value)));
+}
+
 // Extract simplified USB port identifier from full device path
 // e.g., "...AppleUSB20HubPort@02341200..." -> "Port 4.1.2"
 function extractUsbPort(usbPath) {
@@ -5549,16 +5560,16 @@ function renderSinkChips(boardId, channel, names, allSinks, disabled) {
         const remove = disabled ? '' :
             `<button type="button" class="btn-close btn-close-white ms-1" style="font-size:.5rem"
                      aria-label="Remove" title="Remove zone"
-                     onclick="removeTriggerSink(${escapeHtml(JSON.stringify(boardId))}, ${channel}, ${escapeHtml(JSON.stringify(name))})"></button>`;
+                     onclick="removeTriggerSink('${escapeJsAttr(boardId)}', ${channel}, '${escapeJsAttr(name)}')"></button>`;
         return `<span class="badge bg-primary d-inline-flex align-items-center me-1 mb-1">${escapeHtml(label)}${remove}</span>`;
     }).join('');
 
     const remaining = (allSinks || []).filter(s => !safeNames.includes(s.name));
     const addControl = (disabled || remaining.length === 0) ? '' : `
         <select class="form-select form-select-sm mt-1"
-                onchange="addTriggerSink(${escapeHtml(JSON.stringify(boardId))}, ${channel}, this.value); this.value='';">
+                onchange="addTriggerSink('${escapeJsAttr(boardId)}', ${channel}, this.value); this.value='';">
             <option value="">+ Add zone…</option>
-            ${remaining.map(s => `<option value="${escapeHtml(s.name)}">${escapeHtml(s.description || s.name)}</option>`).join('')}
+            ${remaining.map(s => `<option value="${escapeAttr(s.name)}">${escapeHtml(s.description || s.name)}</option>`).join('')}
         </select>`;
 
     const empty = safeNames.length === 0 ? '<span class="text-muted small">Not assigned</span>' : '';

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -5055,17 +5055,6 @@ function renderTriggers() {
 
     container.innerHTML = accordionHtml;
 
-    // Set selected values for sink dropdowns
-    triggersData.boards.forEach(board => {
-        const boardIdSafe = board.boardId.replace(/[^a-zA-Z0-9]/g, '_');
-        board.triggers.forEach(trigger => {
-            const select = document.getElementById(`trigger-sink-${boardIdSafe}-${trigger.channel}`);
-            if (select && trigger.customSinkName) {
-                select.value = trigger.customSinkName;
-            }
-        });
-    });
-
     // Restore scroll position after DOM update
     if (modalBody && scrollTop > 0) {
         requestAnimationFrame(() => {
@@ -5560,14 +5549,14 @@ function renderSinkChips(boardId, channel, names, allSinks, disabled) {
         const remove = disabled ? '' :
             `<button type="button" class="btn-close btn-close-white ms-1" style="font-size:.5rem"
                      aria-label="Remove" title="Remove zone"
-                     onclick="removeTriggerSink('${boardId}', ${channel}, '${escapeHtml(name)}')"></button>`;
+                     onclick="removeTriggerSink('${escapeHtml(boardId)}', ${channel}, '${escapeHtml(name)}')"></button>`;
         return `<span class="badge bg-primary d-inline-flex align-items-center me-1 mb-1">${escapeHtml(label)}${remove}</span>`;
     }).join('');
 
     const remaining = (allSinks || []).filter(s => !safeNames.includes(s.name));
     const addControl = (disabled || remaining.length === 0) ? '' : `
         <select class="form-select form-select-sm mt-1"
-                onchange="addTriggerSink('${boardId}', ${channel}, this.value); this.value='';">
+                onchange="addTriggerSink('${escapeHtml(boardId)}', ${channel}, this.value); this.value='';">
             <option value="">+ Add zone…</option>
             ${remaining.map(s => `<option value="${escapeHtml(s.name)}">${escapeHtml(s.description || s.name)}</option>`).join('')}
         </select>`;

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -5581,6 +5581,10 @@ async function removeTriggerSink(boardId, channel, sinkName) {
     await saveTriggerSinks(boardId, channel);
 }
 
+// Preserve references so the onboarding wizard can restore these after overriding.
+const appAddTriggerSink = addTriggerSink;
+const appRemoveTriggerSink = removeTriggerSink;
+
 // Persist the channel's full sink list (+ current delay) and re-render its chips.
 async function saveTriggerSinks(boardId, channel) {
     const boardIdSafe = boardId.replace(/[^a-zA-Z0-9]/g, '_');

--- a/src/MultiRoomAudio/wwwroot/js/wizard.js
+++ b/src/MultiRoomAudio/wwwroot/js/wizard.js
@@ -75,15 +75,19 @@ const Wizard = {
     customSinks: [],
     playersToCreate: [],
     modal: null,
+    triggerBoards: [],     // boards fetched from /api/triggers
+    triggersEnabled: false,
 
     // Step definitions
     // Note: 'cards' step is conditionally shown only if there are cards with multiple profiles
+    // Note: 'triggers' step is conditionally shown only if relay boards exist
     STEPS: [
         { id: 'welcome', title: 'Welcome' },
         { id: 'cards', title: 'Devices' },
         { id: 'identify', title: 'Identify' },
         { id: 'sinks', title: 'Sinks' },
         { id: 'players', title: 'Players' },
+        { id: 'triggers', title: 'Amp Triggers' },
         { id: 'complete', title: 'Done' }
     ],
 
@@ -166,6 +170,9 @@ const Wizard = {
 
     // Hide the wizard
     hide() {
+        // Restore main-app chip handlers (defined in app.js).
+        if (typeof appAddTriggerSink === 'function') window.addTriggerSink = appAddTriggerSink;
+        if (typeof appRemoveTriggerSink === 'function') window.removeTriggerSink = appRemoveTriggerSink;
         this.modal.hide();
     },
 
@@ -235,10 +242,12 @@ const Wizard = {
     renderProgress() {
         const container = document.getElementById('wizardProgress');
         const showCards = this.hasMultiProfileCards();
+        const showTriggers = this.triggerBoards.length > 0;
 
-        // Filter steps - hide cards step if no multi-profile cards
+        // Filter steps - hide cards step if no multi-profile cards; hide triggers step if no boards
         const visibleSteps = this.STEPS.filter(step =>
-            step.id !== 'cards' || showCards
+            (step.id !== 'cards' || showCards) &&
+            (step.id !== 'triggers' || showTriggers)
         );
 
         container.innerHTML = visibleSteps.map((step, displayIndex) => {
@@ -311,6 +320,17 @@ const Wizard = {
                 break;
             case 'players':
                 content.innerHTML = this.renderPlayers();
+                break;
+            case 'triggers':
+                await this.loadTriggerBoards();
+                if (this.triggerBoards.length === 0) {
+                    // No relay boards configured — skip this step entirely.
+                    this.currentStep++;
+                    this.renderProgress();
+                    await this.renderStep();
+                    return;
+                }
+                content.innerHTML = this.renderTriggers();
                 break;
             case 'complete':
                 content.innerHTML = this.renderComplete();
@@ -1536,6 +1556,100 @@ const Wizard = {
                 autostart: true
             });
         });
+    },
+
+    // Load configured relay boards for the triggers step.
+    async loadTriggerBoards() {
+        try {
+            const response = await fetch('./api/triggers');
+            if (!response.ok) { this.triggerBoards = []; return; }
+            const data = await response.json();
+            this.triggerBoards = data.boards || [];
+            this.triggersEnabled = !!data.enabled;
+        } catch (error) {
+            console.error('Failed to load trigger boards:', error);
+            this.triggerBoards = [];
+        }
+    },
+
+    // Step: assign zones/sinks to relay channels using the shared chip picker.
+    renderTriggers() {
+        // Route chip-picker callbacks to wizard-scoped handlers for this step.
+        window.addTriggerSink = (b, c, s) => this.wizardAddTriggerSink(b, c, s);
+        window.removeTriggerSink = (b, c, s) => this.wizardRemoveTriggerSink(b, c, s);
+
+        const sinkList = this.customSinks.map(s => ({ name: s.name, description: s.description || s.name }));
+        const boardsHtml = this.triggerBoards.map(board => {
+            const rows = (board.triggers || []).map(t => `
+                <tr>
+                    <td><span class="badge bg-primary">CH ${t.channel}</span></td>
+                    <td>
+                        <div id="wizard-trigger-sink-${board.boardId.replace(/[^a-zA-Z0-9]/g, '_')}-${t.channel}">
+                            ${renderSinkChips(board.boardId, t.channel, t.customSinkNames, sinkList, false)}
+                        </div>
+                    </td>
+                </tr>`).join('');
+            return `
+                <h6 class="mt-3">${escapeHtml(board.displayName || board.boardId)}</h6>
+                <table class="table table-sm align-middle">
+                    <thead><tr><th style="width:6rem">Channel</th><th>Zones</th></tr></thead>
+                    <tbody>${rows}</tbody>
+                </table>`;
+        }).join('');
+
+        return `
+            <div class="py-2">
+                <h4>Amplifier Triggers</h4>
+                <p class="text-muted">Assign one or more zones to each relay channel. The relay
+                   switches on when any assigned zone plays and off when all of them stop —
+                   ideal for powering a multi-zone amplifier from a single trigger.</p>
+                ${boardsHtml}
+            </div>`;
+    },
+
+    wizardGetTrigger(boardId, channel) {
+        const board = this.triggerBoards.find(b => b.boardId === boardId);
+        return board?.triggers?.find(t => t.channel === channel);
+    },
+
+    async wizardAddTriggerSink(boardId, channel, sinkName) {
+        if (!sinkName) return;
+        const t = this.wizardGetTrigger(boardId, channel);
+        if (!t) return;
+        t.customSinkNames = t.customSinkNames || [];
+        if (!t.customSinkNames.includes(sinkName)) t.customSinkNames.push(sinkName);
+        await this.wizardSaveTriggerSinks(boardId, channel);
+    },
+
+    async wizardRemoveTriggerSink(boardId, channel, sinkName) {
+        const t = this.wizardGetTrigger(boardId, channel);
+        if (!t) return;
+        t.customSinkNames = (t.customSinkNames || []).filter(n => n !== sinkName);
+        await this.wizardSaveTriggerSinks(boardId, channel);
+    },
+
+    async wizardSaveTriggerSinks(boardId, channel) {
+        const t = this.wizardGetTrigger(boardId, channel);
+        const names = t ? (t.customSinkNames || []) : [];
+        // Ensure the feature is enabled before the first assignment.
+        if (!this.triggersEnabled) {
+            await fetch('./api/triggers/enabled', {
+                method: 'PUT', headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ enabled: true })
+            });
+            this.triggersEnabled = true;
+        }
+        const url = boardId.includes('/')
+            ? `./api/triggers/boards/channel?boardId=${encodeURIComponent(boardId)}&channel=${channel}`
+            : `./api/triggers/boards/${encodeURIComponent(boardId)}/${channel}`;
+        await fetch(url, {
+            method: 'PUT', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds: 60 })
+        });
+        const safe = boardId.replace(/[^a-zA-Z0-9]/g, '_');
+        const container = document.getElementById(`wizard-trigger-sink-${safe}-${channel}`);
+        const sinkList = this.customSinks.map(s => ({ name: s.name, description: s.description || s.name }));
+        if (container) container.innerHTML = renderSinkChips(boardId, channel, names, sinkList, false);
     },
 
     // Complete the wizard

--- a/src/MultiRoomAudio/wwwroot/js/wizard.js
+++ b/src/MultiRoomAudio/wwwroot/js/wizard.js
@@ -1582,7 +1582,7 @@ const Wizard = {
         const boardsHtml = this.triggerBoards.map(board => {
             const rows = (board.triggers || []).map(t => `
                 <tr>
-                    <td><span class="badge bg-primary">CH ${t.channel}</span></td>
+                    <td><span class="badge bg-primary">CH ${parseInt(t.channel, 10)}</span></td>
                     <td>
                         <div id="wizard-trigger-sink-${board.boardId.replace(/[^a-zA-Z0-9]/g, '_')}-${t.channel}">
                             ${renderSinkChips(board.boardId, t.channel, t.customSinkNames, sinkList, false)}
@@ -1631,25 +1631,36 @@ const Wizard = {
     async wizardSaveTriggerSinks(boardId, channel) {
         const t = this.wizardGetTrigger(boardId, channel);
         const names = t ? (t.customSinkNames || []) : [];
-        // Ensure the feature is enabled before the first assignment.
-        if (!this.triggersEnabled) {
-            await fetch('./api/triggers/enabled', {
+
+        try {
+            // Ensure the feature is enabled before the first assignment.
+            if (!this.triggersEnabled) {
+                await fetch('./api/triggers/enabled', {
+                    method: 'PUT', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ enabled: true })
+                });
+                this.triggersEnabled = true;
+            }
+            const url = boardId.includes('/')
+                ? `./api/triggers/boards/channel?boardId=${encodeURIComponent(boardId)}&channel=${channel}`
+                : `./api/triggers/boards/${encodeURIComponent(boardId)}/${channel}`;
+            const response = await fetch(url, {
                 method: 'PUT', headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ enabled: true })
+                body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds: 60 })
             });
-            this.triggersEnabled = true;
+            if (!response.ok) {
+                const error = await response.json();
+                throw new Error(error.message || 'Failed to update trigger');
+            }
+            const safe = boardId.replace(/[^a-zA-Z0-9]/g, '_');
+            const container = document.getElementById(`wizard-trigger-sink-${safe}-${channel}`);
+            const sinkList = this.customSinks.map(s => ({ name: s.name, description: s.description || s.name }));
+            if (container) container.innerHTML = renderSinkChips(boardId, channel, names, sinkList, false);
+            showAlert('Trigger updated', 'success', 2000);
+        } catch (error) {
+            console.error('Failed to save trigger assignment:', error);
+            showAlert('Failed to update trigger: ' + error.message, 'danger');
         }
-        const url = boardId.includes('/')
-            ? `./api/triggers/boards/channel?boardId=${encodeURIComponent(boardId)}&channel=${channel}`
-            : `./api/triggers/boards/${encodeURIComponent(boardId)}/${channel}`;
-        await fetch(url, {
-            method: 'PUT', headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds: 60 })
-        });
-        const safe = boardId.replace(/[^a-zA-Z0-9]/g, '_');
-        const container = document.getElementById(`wizard-trigger-sink-${safe}-${channel}`);
-        const sinkList = this.customSinks.map(s => ({ name: s.name, description: s.description || s.name }));
-        if (container) container.innerHTML = renderSinkChips(boardId, channel, names, sinkList, false);
     },
 
     // Complete the wizard

--- a/tests/MultiRoomAudio.Tests/Mqtt/AmpDiscoveryTests.cs
+++ b/tests/MultiRoomAudio.Tests/Mqtt/AmpDiscoveryTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using MultiRoomAudio.Models;
@@ -11,7 +12,8 @@ public class AmpDiscoveryTests
     private readonly HaDiscovery _d = new(new MqttTopics("multiroom-audio", "homeassistant"), "1.2.3");
 
     private static TriggerResponse Zone() => new(
-        Channel: 1, CustomSinkName: "sink", CustomSinkDisplayName: "Sink",
+        Channel: 1, CustomSinkNames: new List<string> { "sink" },
+        CustomSinkDisplayNames: new List<string> { "Sink" },
         OffDelaySeconds: 30, ZoneName: "Living Room", RelayState: RelayState.On,
         IsActive: true, LastActivated: null, ScheduledOffTime: null, IsOverridden: false);
 

--- a/tests/MultiRoomAudio.Tests/Mqtt/AmpStatePayloadsTests.cs
+++ b/tests/MultiRoomAudio.Tests/Mqtt/AmpStatePayloadsTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json;
 using MultiRoomAudio.Models;
 using MultiRoomAudio.Mqtt;
@@ -8,7 +9,8 @@ namespace MultiRoomAudio.Tests.Mqtt;
 public class AmpStatePayloadsTests
 {
     private static TriggerResponse Zone(RelayState s, bool overridden) => new(
-        Channel: 1, CustomSinkName: "sink", CustomSinkDisplayName: "Sink",
+        Channel: 1, CustomSinkNames: new List<string> { "sink" },
+        CustomSinkDisplayNames: new List<string> { "Sink" },
         OffDelaySeconds: 30, ZoneName: "Living Room", RelayState: s,
         IsActive: s == RelayState.On, LastActivated: null, ScheduledOffTime: null,
         IsOverridden: overridden);

--- a/tests/MultiRoomAudio.Tests/Services/MultiSinkTriggerTests.cs
+++ b/tests/MultiRoomAudio.Tests/Services/MultiSinkTriggerTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MultiRoomAudio.Models;
+using MultiRoomAudio.Relay;
+using MultiRoomAudio.Services;
+using Xunit;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace MultiRoomAudio.Tests.Services;
+
+public class MultiSinkTriggerMigrationTests
+{
+    private static IDeserializer Deserializer() => new DeserializerBuilder()
+        .WithNamingConvention(UnderscoredNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    private static ISerializer Serializer() => new SerializerBuilder()
+        .WithNamingConvention(UnderscoredNamingConvention.Instance)
+        .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitDefaults)
+        .Build();
+
+    [Fact]
+    public void LegacySingleSink_MigratesIntoList()
+    {
+        var yaml = "channel: 1\ncustom_sink_name: sink1\noff_delay_seconds: 30\n";
+        var cfg = Deserializer().Deserialize<TriggerConfiguration>(yaml);
+        Assert.Equal(new[] { "sink1" }, cfg.CustomSinkNames);
+    }
+
+    [Fact]
+    public void Serialization_OmitsLegacyKey_EmitsPluralKey()
+    {
+        var cfg = new TriggerConfiguration { Channel = 1, CustomSinkNames = { "sink1" } };
+        var outYaml = Serializer().Serialize(cfg);
+        // Note: "custom_sink_name:" (singular + colon) is NOT a substring of "custom_sink_names:".
+        Assert.DoesNotContain("custom_sink_name:", outYaml);
+        Assert.Contains("custom_sink_names", outYaml);
+    }
+}
+
+public class MultiSinkTriggerEngineTests
+{
+    private static (TriggerService svc, string boardId) Setup()
+    {
+        var svc = TriggerTestHarness.CreateMockService();
+        svc.SetEnabled(true);
+        var boardId = "VIRTUAL:multi01";
+        svc.AddBoard(boardId, "Test", channelCount: 2, boardType: RelayBoardType.Virtual);
+        return (svc, boardId);
+    }
+
+    private static TriggerResponse Channel(TriggerService svc, string boardId, int channel)
+        => svc.GetBoardStatus(boardId)!.Triggers.Single(t => t.Channel == channel);
+
+    [Fact]
+    public void OneSinkOnTwoChannels_ActivatesBoth()
+    {
+        var (svc, boardId) = Setup();
+        svc.ConfigureTrigger(boardId, 1, new List<string> { "zoneA" }, 30, "Zone A");
+        svc.ConfigureTrigger(boardId, 2, new List<string> { "zoneA", "zoneB" }, 30, "Master");
+
+        svc.OnPlayerStarted("p1", "zoneA");
+
+        Assert.Equal(RelayState.On, Channel(svc, boardId, 1).RelayState);
+        Assert.Equal(RelayState.On, Channel(svc, boardId, 2).RelayState);
+    }
+
+    [Fact]
+    public void ChannelWithTwoSinks_StaysOnUntilLastStops()
+    {
+        var (svc, boardId) = Setup();
+        svc.ConfigureTrigger(boardId, 2, new List<string> { "zoneA", "zoneB" }, 0, "Master");
+
+        svc.OnPlayerStarted("p1", "zoneA");
+        svc.OnPlayerStarted("p2", "zoneB");
+        svc.OnPlayerStopped("p1", "zoneA");
+        Assert.Equal(RelayState.On, Channel(svc, boardId, 2).RelayState);   // zoneB still active
+
+        svc.OnPlayerStopped("p2", "zoneB");
+        Assert.Equal(RelayState.Off, Channel(svc, boardId, 2).RelayState);  // last sink stopped, delay 0 ⇒ immediate off
+    }
+
+    [Fact]
+    public void DeletingSink_RemovesItFromTriggerLists()
+    {
+        var (svc, boardId) = Setup();
+        svc.ConfigureTrigger(boardId, 2, new List<string> { "zoneA", "zoneB" }, 30, "Master");
+
+        svc.OnSinkDeleted("zoneA");
+
+        Assert.Equal(new[] { "zoneB" }, Channel(svc, boardId, 2).CustomSinkNames);
+    }
+}

--- a/tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs
+++ b/tests/MultiRoomAudio.Tests/Services/TriggerOverrideTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using MultiRoomAudio.Models;
@@ -16,7 +17,7 @@ public class TriggerOverrideBehaviorTests
         svc.SetEnabled(true);
         var boardId = "VIRTUAL:test01";
         svc.AddBoard(boardId, "Test Zone", channelCount: 2, boardType: RelayBoardType.Virtual);
-        svc.ConfigureTrigger(boardId, channel: 1, customSinkName: "sink1", offDelaySeconds: 30, zoneName: "Zone 1");
+        svc.ConfigureTrigger(boardId, channel: 1, customSinkNames: new List<string> { "sink1" }, offDelaySeconds: 30, zoneName: "Zone 1");
         await Task.CompletedTask;
         return (svc, boardId);
     }
@@ -88,7 +89,9 @@ public class TriggerModelsTests
     public void TriggerResponse_IsOverridden_DefaultsFalse()
     {
         var r = new TriggerResponse(
-            Channel: 1, CustomSinkName: null, CustomSinkDisplayName: null,
+            Channel: 1,
+            CustomSinkNames: new List<string>(),
+            CustomSinkDisplayNames: new List<string>(),
             OffDelaySeconds: 60, ZoneName: null, RelayState: RelayState.Off,
             IsActive: false, LastActivated: null, ScheduledOffTime: null);
         Assert.False(r.IsOverridden);


### PR DESCRIPTION
Closes #250.

## What

Lets a single relay trigger channel reference **multiple** sinks/zones, with full many-to-many mapping: a channel can list many sinks, and a sink can drive many channels. This enables whole-amp power control — one relay powers a multi-zone amp, turning ON when any assigned zone plays and OFF only after the last one stops.

## How

**Backend**
- `TriggerConfiguration.CustomSinkName` (single string) → `CustomSinkNames` (`List<string>`). The old field is retained as a write-only YAML migration shim (null getter + `OmitNull`), so existing `triggers` config migrates on load and the legacy `custom_sink_name:` key is dropped on next save — no data loss, no version flag.
- The player-event handlers now activate **every** channel containing a played sink (removed the early-return). The existing `ActivePlayerCount` reference counter is untouched, so a channel stays ON until its last contributing sink stops.
- `ConfigureTrigger`, `OnSinkDeleted` (prunes only the named sink), the status response, the save-cleanup filter, and the request/response models all move to the list shape. A legacy singular field on the request is still accepted and folded in for back-compat.

**Main app UI**
- The single-sink `<select>` is replaced by a tag/chip picker: selected zones render as removable chips plus an "+ Add zone…" dropdown. Inline-handler values are escaped for both the JS-string and HTML-attribute contexts.

**Onboarding wizard**
- New self-skipping "Amp Triggers" step (only shown when relay boards exist) reuses the same chip picker and persists via the existing trigger API.

## Tests

- 77 unit tests pass, including new coverage for: legacy YAML migration (load → list; serialize drops the singular key), one-sink-on-two-channels fan-out, two-sinks-on-one-channel ref-count hold, and sink-deletion pruning.

## Not yet verified

- **Browser testing of the chip picker and wizard step is still pending.** Automated checks (unit tests, `node --check`, code review) all pass, but the UI interactions should be clicked through in a running instance before merge.

## Notes

- Deferred (pre-existing): the player-event handlers enumerate the sink lists without taking `_configLock` while `OnSinkDeleted` mutates them under the lock — a pre-existing concurrency class, slightly widened. Not addressed here.