### PR TITLE
MQTT Improvements

### DIFF
--- a/src/MultiRoomAudio/Mqtt/HaDiscovery.cs
+++ b/src/MultiRoomAudio/Mqtt/HaDiscovery.cs
@@ -43,6 +43,7 @@ public class HaDiscovery
             {
                 w.WriteString("value_template", "{{ value_json.server_name }}");
                 w.WriteString("entity_category", "diagnostic");
+                w.WriteString("enabled_by_default", "false");
             }),
             Entity("binary_sensor", "clock_synced", $"{p.Name} Clock Synced", w =>
             {
@@ -50,6 +51,7 @@ public class HaDiscovery
                 w.WriteString("payload_on", "ON");
                 w.WriteString("payload_off", "OFF");
                 w.WriteString("entity_category", "diagnostic");
+                w.WriteString("enabled_by_default", "false");
             }),
             Entity("binary_sensor", "reconnect_pending", $"{p.Name} Reconnecting", w =>
             {
@@ -57,11 +59,13 @@ public class HaDiscovery
                 w.WriteString("payload_on", "ON");
                 w.WriteString("payload_off", "OFF");
                 w.WriteString("entity_category", "diagnostic");
+                w.WriteString("enabled_by_default", "false");
             }),
             Entity("sensor", "reconnect_attempts", $"{p.Name} Reconnect Attempts", w =>
             {
                 w.WriteString("value_template", "{{ value_json.reconnect_attempts }}");
                 w.WriteString("entity_category", "diagnostic");
+                w.WriteString("enabled_by_default", "false");
             }),
             Entity("number", "offset", $"{p.Name} Delay Offset", w =>
             {
@@ -78,6 +82,7 @@ public class HaDiscovery
                 w.WriteString("command_topic", _topics.PlayerCommandTopic(p.ClientId, "restart"));
                 w.WriteString("payload_press", "PRESS");
                 w.WriteString("entity_category", "config");
+                w.WriteString("enabled_by_default", "false");
             }),
         };
     }
@@ -109,6 +114,7 @@ public class HaDiscovery
             {
                 w.WriteString("value_template", "{{ value_json.version }}");
                 w.WriteString("entity_category", "diagnostic");
+                w.WriteString("enabled_by_default", "false");
             }),
             Entity("sensor", "player_count", "Multi-Room Audio Players", w =>
                 w.WriteString("value_template", "{{ value_json.player_count }}")),
@@ -116,11 +122,13 @@ public class HaDiscovery
             {
                 w.WriteString("value_template", "{{ value_json.audio_backend }}");
                 w.WriteString("entity_category", "diagnostic");
+                w.WriteString("enabled_by_default", "false");
             }),
             Entity("sensor", "environment", "Multi-Room Audio Environment", w =>
             {
                 w.WriteString("value_template", "{{ value_json.environment }}");
                 w.WriteString("entity_category", "diagnostic");
+                w.WriteString("enabled_by_default", "false");
             }),
         };
     }
@@ -155,6 +163,7 @@ public class HaDiscovery
                 w.WriteString("value_template", "{{ value_json.scheduled_off }}");
                 w.WriteString("device_class", "timestamp");
                 w.WriteString("entity_category", "diagnostic");
+                w.WriteString("enabled_by_default", "false");
             }),
             Entity("switch", "override", $"{label} Override", w =>
             {
@@ -172,6 +181,7 @@ public class HaDiscovery
                 w.WriteString("payload_off", "OFF");
                 w.WriteString("device_class", "connectivity");
                 w.WriteString("entity_category", "diagnostic");
+                w.WriteString("enabled_by_default", "false");
             }),
         };
     }

--- a/src/MultiRoomAudio/Mqtt/HaDiscovery.cs
+++ b/src/MultiRoomAudio/Mqtt/HaDiscovery.cs
@@ -21,7 +21,7 @@ public class HaDiscovery
 
     public record DiscoveryMessage(string Topic, string Payload);
 
-private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
+    private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
     {
         return new DiscoveryMessage(_topics.DiscoveryTopic(component, deviceId), "");
     }
@@ -41,8 +41,8 @@ private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
         using (var w = new Utf8JsonWriter(stream))
         {
             w.WriteStartObject();
-            w.WritePropertyName("dev"); 
-            w.WriteStartObject();       
+            w.WritePropertyName("dev");
+            w.WriteStartObject();
             w.WriteString("ids", deviceId); // Identifiers
             w.WriteString("name", "Multi-Room Audio");
             w.WriteString("mf", "Multi-Room Audio");// Manufacturer
@@ -61,16 +61,16 @@ private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
             w.WriteStartObject();
 
             // Ready Sensor
-            w.WritePropertyName($"{deviceId}_State"); 
+            w.WritePropertyName($"{deviceId}_State");
             w.WriteStartObject();
             w.WriteString("name", $"{p.Name} State");
             w.WriteString("unique_id", $"{deviceId}_State");
-            w.WriteString("p", "sensor");                
+            w.WriteString("p", "sensor");
             w.WriteString("value_template", "{{ value_json.state }}");
             w.WriteEndObject();
 
             // Player Server Sensor
-            w.WritePropertyName($"{deviceId}_server"); 
+            w.WritePropertyName($"{deviceId}_server");
             w.WriteStartObject();
             w.WriteString("name", $"{p.Name} Server");
             w.WriteString("unique_id", $"{deviceId}_server");
@@ -79,22 +79,22 @@ private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
             w.WriteString("entity_category", "diagnostic");
             w.WriteString("enabled_by_default", "false");
             w.WriteEndObject();
-            
+
             // Clock Synced Sensor
-            w.WritePropertyName($"{deviceId}_clock_synced"); 
+            w.WritePropertyName($"{deviceId}_clock_synced");
             w.WriteStartObject();
             w.WriteString("name", $"{p.Name} Clocke Synced");
             w.WriteString("unique_id", $"{deviceId}_clock_synced");
             w.WriteString("p", "binary_sensor");
             w.WriteString("value_template", "{{ value_json.clock_synced }}");
-            w.WriteString("payload_on", "ON");                
+            w.WriteString("payload_on", "ON");
             w.WriteString("payload_off", "OFF");
             w.WriteString("entity_category", "diagnostic");
             w.WriteString("enabled_by_default", "false");
             w.WriteEndObject();
-            
+
             // Reconnect Pending Sensor
-            w.WritePropertyName($"{deviceId}_reconnect_pending"); 
+            w.WritePropertyName($"{deviceId}_reconnect_pending");
             w.WriteStartObject();
             w.WriteString("name", $"{p.Name} Reconnecting");
             w.WriteString("unique_id", $"{deviceId}_reconnect_pending");
@@ -105,9 +105,9 @@ private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
             w.WriteString("entity_category", "diagnostic");
             w.WriteString("enabled_by_default", "false");
             w.WriteEndObject();
-            
+
             // Reconnect Attempts Sensor
-            w.WritePropertyName($"{deviceId}_reconnect_attempts"); 
+            w.WritePropertyName($"{deviceId}_reconnect_attempts");
             w.WriteStartObject();
             w.WriteString("name", $"{p.Name} Reconnect Attempts");
             w.WriteString("unique_id", $"{deviceId}_reconnect_attempts");
@@ -116,9 +116,9 @@ private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
             w.WriteString("entity_category", "diagnostic");
             w.WriteString("enabled_by_default", "false");
             w.WriteEndObject();
-            
+
             // Ready Sensor
-            w.WritePropertyName($"{deviceId}_offset"); 
+            w.WritePropertyName($"{deviceId}_offset");
             w.WriteStartObject();
             w.WriteString("name", $"{p.Name} Delay Offset");
             w.WriteString("unique_id", $"{deviceId}_offset");
@@ -131,9 +131,9 @@ private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
             w.WriteString("mode", "box");
             w.WriteString("entity_category", "config");
             w.WriteEndObject();
-            
+
             // Restart Sensor
-            w.WritePropertyName($"{deviceId}_restart"); 
+            w.WritePropertyName($"{deviceId}_restart");
             w.WriteStartObject();
             w.WriteString("name", $"{p.Name} Restart");
             w.WriteString("unique_id", $"{deviceId}_restart");
@@ -143,10 +143,10 @@ private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
             w.WriteString("entity_category", "config");
             w.WriteString("enabled_by_default", "false");
             w.WriteEndObject();
-                    
+
             //End Components
             w.WriteEndObject();
-            
+
             w.WriteString("state_topic", stateTopic);
             w.WriteString("availability_topic", _topics.BridgeAvailabilityTopic);
             w.WriteString("payload_available", "online");
@@ -154,13 +154,13 @@ private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
             w.WriteEndObject();
         }
         var payload = System.Text.Encoding.UTF8.GetString(stream.ToArray());
-        
+
         DiscoveryMessage Entity(string component, string key)
             => BuildRemovalMessage(component, $"mra_{id}_{key}");
-        
+
         return new List<DiscoveryMessage>
         {
-            new DiscoveryMessage(_topics.DeviceDiscoveryTopic(deviceId), payload),        
+            new DiscoveryMessage(_topics.DeviceDiscoveryTopic(deviceId), payload),
             Entity("sensor", "state"),
             Entity("sensor", "server"),
             Entity("binary_sensor", "clock_synced"),
@@ -186,8 +186,8 @@ private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
         using (var w = new Utf8JsonWriter(stream))
         {
             w.WriteStartObject();
-            w.WritePropertyName("dev"); 
-            w.WriteStartObject();       
+            w.WritePropertyName("dev");
+            w.WriteStartObject();
             w.WriteString("ids", deviceId); // Identifiers
             w.WriteString("name", "Multi-Room Audio");
             w.WriteString("mf", "Multi-Room Audio");// Manufacturer
@@ -205,63 +205,63 @@ private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
             w.WritePropertyName("components"); // components
             w.WriteStartObject();
 
-                // Ready Sensor
-                w.WritePropertyName($"{deviceId}_ready"); 
-                w.WriteStartObject();
-                w.WriteString("name", $"{label} Ready");
-                w.WriteString("unique_id", $"{deviceId}_ready");
-                w.WriteString("p", "binary_sensor");
-                w.WriteString("value_template", "{{ value_json.ready }}");
-                w.WriteString("payload_on", "ON");
-                w.WriteString("payload_off", "OFF");
-                w.WriteString("device_class", "running");
-                w.WriteEndObject();
+            // Ready Sensor
+            w.WritePropertyName($"{deviceId}_ready");
+            w.WriteStartObject();
+            w.WriteString("name", $"{label} Ready");
+            w.WriteString("unique_id", $"{deviceId}_ready");
+            w.WriteString("p", "binary_sensor");
+            w.WriteString("value_template", "{{ value_json.ready }}");
+            w.WriteString("payload_on", "ON");
+            w.WriteString("payload_off", "OFF");
+            w.WriteString("device_class", "running");
+            w.WriteEndObject();
 
-                // Version Sensor
-                w.WritePropertyName($"{deviceId}_version"); 
-                w.WriteStartObject();
-                w.WriteString("name", $"{label} Version");
-                w.WriteString("unique_id", $"{deviceId}_version");
-                w.WriteString("p", "sensor");
-                w.WriteString("value_template", "{{ value_json.version }}");
-                w.WriteString("entity_category", "diagnostic");
-                w.WriteString("enabled_by_default", "false");
-                w.WriteEndObject();
+            // Version Sensor
+            w.WritePropertyName($"{deviceId}_version");
+            w.WriteStartObject();
+            w.WriteString("name", $"{label} Version");
+            w.WriteString("unique_id", $"{deviceId}_version");
+            w.WriteString("p", "sensor");
+            w.WriteString("value_template", "{{ value_json.version }}");
+            w.WriteString("entity_category", "diagnostic");
+            w.WriteString("enabled_by_default", "false");
+            w.WriteEndObject();
 
-                // player Count sensor
-                w.WritePropertyName($"{deviceId}_player_count"); 
-                w.WriteStartObject();
-                w.WriteString("name", $"{label} Players");
-                w.WriteString("unique_id", $"{deviceId}_player_count");
-                w.WriteString("p", "sensor");
-                w.WriteString("value_template", "{{ value_json.player_count }}");
-                w.WriteEndObject();
+            // player Count sensor
+            w.WritePropertyName($"{deviceId}_player_count");
+            w.WriteStartObject();
+            w.WriteString("name", $"{label} Players");
+            w.WriteString("unique_id", $"{deviceId}_player_count");
+            w.WriteString("p", "sensor");
+            w.WriteString("value_template", "{{ value_json.player_count }}");
+            w.WriteEndObject();
 
-                // Board Connected Sensor
-                w.WritePropertyName($"{label}_audio_backend"); 
-                w.WriteStartObject();
-                w.WriteString("name", $"{label} Audio Backend");
-                w.WriteString("unique_id", $"{label}_audio_backend");
-                w.WriteString("p", "sensor");
-                w.WriteString("value_template", "{{ value_json.audio_backend }}");
-                w.WriteString("entity_category", "diagnostic");
-                w.WriteString("enabled_by_default", "false");
-                w.WriteEndObject();
+            // Board Connected Sensor
+            w.WritePropertyName($"{label}_audio_backend");
+            w.WriteStartObject();
+            w.WriteString("name", $"{label} Audio Backend");
+            w.WriteString("unique_id", $"{label}_audio_backend");
+            w.WriteString("p", "sensor");
+            w.WriteString("value_template", "{{ value_json.audio_backend }}");
+            w.WriteString("entity_category", "diagnostic");
+            w.WriteString("enabled_by_default", "false");
+            w.WriteEndObject();
 
-                // Environment sensor
-                w.WritePropertyName($"{deviceId}_environment"); 
-                w.WriteStartObject();
-                w.WriteString("name", $"{label} Environment");
-                w.WriteString("unique_id", $"{deviceId}_environment");
-                w.WriteString("p", "sensor");
-                w.WriteString("value_template", "{{ value_json.environment }}");
-                w.WriteString("entity_category", "diagnostic");
-                w.WriteString("enabled_by_default", "false");
-                w.WriteEndObject();
-                
+            // Environment sensor
+            w.WritePropertyName($"{deviceId}_environment");
+            w.WriteStartObject();
+            w.WriteString("name", $"{label} Environment");
+            w.WriteString("unique_id", $"{deviceId}_environment");
+            w.WriteString("p", "sensor");
+            w.WriteString("value_template", "{{ value_json.environment }}");
+            w.WriteString("entity_category", "diagnostic");
+            w.WriteString("enabled_by_default", "false");
+            w.WriteEndObject();
+
             //End Components
             w.WriteEndObject();
-            
+
             w.WriteString("state_topic", stateTopic);
             w.WriteString("availability_topic", _topics.BridgeAvailabilityTopic);
             w.WriteString("payload_available", "online");
@@ -269,7 +269,7 @@ private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
             w.WriteEndObject();
         }
         var payload = System.Text.Encoding.UTF8.GetString(stream.ToArray());
-        
+
         DiscoveryMessage Entity(string component, string key)
             => BuildRemovalMessage(component, $"mra_bridge_{id}_{key}");
 
@@ -303,8 +303,8 @@ private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
         using (var w = new Utf8JsonWriter(stream))
         {
             w.WriteStartObject();
-            w.WritePropertyName("dev"); 
-            w.WriteStartObject();       
+            w.WritePropertyName("dev");
+            w.WriteStartObject();
             w.WriteString("ids", $"mra_amp_{zone}"); // Identifiers
             w.WriteString("name", label!);
             w.WriteString("mf", "Multi-Room Audio");// Manufacturer
@@ -321,61 +321,61 @@ private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
             // Start Components
             w.WritePropertyName("components"); // components
             w.WriteStartObject();
-                // Poser Sensor
-                w.WritePropertyName($"{deviceId}_power"); // start of power binary sensor
-                w.WriteStartObject();
-                w.WriteString("name", $"{label} Power");
-                w.WriteString("unique_id", $"{deviceId}_power");
-                w.WriteString("p", "binary_sensor");
-                w.WriteString("value_template", "{{ value_json.power }}");
-                w.WriteString("payload_on", "ON");
-                w.WriteString("payload_off", "OFF");
-                w.WriteString("device_class", "power");
-                w.WriteEndObject();
+            // Poser Sensor
+            w.WritePropertyName($"{deviceId}_power"); // start of power binary sensor
+            w.WriteStartObject();
+            w.WriteString("name", $"{label} Power");
+            w.WriteString("unique_id", $"{deviceId}_power");
+            w.WriteString("p", "binary_sensor");
+            w.WriteString("value_template", "{{ value_json.power }}");
+            w.WriteString("payload_on", "ON");
+            w.WriteString("payload_off", "OFF");
+            w.WriteString("device_class", "power");
+            w.WriteEndObject();
 
-                // Scheduled Off Sensor
-                w.WritePropertyName($"{deviceId}_scheduled_off"); // start of Scheduled Off sensor
-                w.WriteStartObject();
-                w.WriteString("name", $"{label} Scheduled Off");
-                w.WriteString("unique_id", $"{deviceId}_scheduled_off");
-                w.WriteString("p", "sensor");
-                w.WriteString("value_template", "{{ value_json.scheduled_off }}");
-                w.WriteString("device_class", "timestamp");
-                w.WriteString("entity_category", "diagnostic");
-                w.WriteString("enabled_by_default", "false");
-                w.WriteEndObject();
+            // Scheduled Off Sensor
+            w.WritePropertyName($"{deviceId}_scheduled_off"); // start of Scheduled Off sensor
+            w.WriteStartObject();
+            w.WriteString("name", $"{label} Scheduled Off");
+            w.WriteString("unique_id", $"{deviceId}_scheduled_off");
+            w.WriteString("p", "sensor");
+            w.WriteString("value_template", "{{ value_json.scheduled_off }}");
+            w.WriteString("device_class", "timestamp");
+            w.WriteString("entity_category", "diagnostic");
+            w.WriteString("enabled_by_default", "false");
+            w.WriteEndObject();
 
-                // Override Switch
-                w.WritePropertyName($"{deviceId}_override"); // start of Override Switch
-                w.WriteStartObject();
-                w.WriteString("name", $"{label} Override");
-                w.WriteString("unique_id", $"{deviceId}_override");
-                w.WriteString("p", "switch");
-                w.WriteString("command_topic", _topics.AmpCommandTopic(boardId, t.Channel, "override"));
-                w.WriteString("value_template", "{{ value_json.override }}");
-                w.WriteString("state_on", "ON");
-                w.WriteString("state_off", "OFF");
-                w.WriteString("payload_on", "ON");
-                w.WriteString("payload_off", "OFF");
-                w.WriteEndObject();
+            // Override Switch
+            w.WritePropertyName($"{deviceId}_override"); // start of Override Switch
+            w.WriteStartObject();
+            w.WriteString("name", $"{label} Override");
+            w.WriteString("unique_id", $"{deviceId}_override");
+            w.WriteString("p", "switch");
+            w.WriteString("command_topic", _topics.AmpCommandTopic(boardId, t.Channel, "override"));
+            w.WriteString("value_template", "{{ value_json.override }}");
+            w.WriteString("state_on", "ON");
+            w.WriteString("state_off", "OFF");
+            w.WriteString("payload_on", "ON");
+            w.WriteString("payload_off", "OFF");
+            w.WriteEndObject();
 
-                // Board Connected Sensor
-                w.WritePropertyName($"{deviceId}_board_connected"); // start of Board Connected Binary Sensor
-                w.WriteStartObject();
-                w.WriteString("name", $"{label} Board Connected");
-                w.WriteString("unique_id", $"{deviceId}_board_connected");
-                w.WriteString("p", "binary_sensor");
-                w.WriteString("value_template", "{{ value_json.board_connected }}");
-                w.WriteString("payload_on", "ON");
-                w.WriteString("payload_off", "OFF");
-                w.WriteString("device_class", "connectivity");
-                w.WriteString("entity_category", "diagnostic");
-                w.WriteString("enabled_by_default", "false");
-                w.WriteEndObject();
-            
+            // Board Connected Sensor
+            w.WritePropertyName($"{deviceId}_board_connected"); // start of Board Connected Binary Sensor
+            w.WriteStartObject();
+            w.WriteString("name", $"{label} Board Connected");
+            w.WriteString("unique_id", $"{deviceId}_board_connected");
+            w.WriteString("p", "binary_sensor");
+            w.WriteString("value_template", "{{ value_json.board_connected }}");
+            w.WriteString("payload_on", "ON");
+            w.WriteString("payload_off", "OFF");
+            w.WriteString("device_class", "connectivity");
+            w.WriteString("entity_category", "diagnostic");
+            w.WriteString("enabled_by_default", "false");
+            w.WriteEndObject();
+
             //End Components
             w.WriteEndObject();
-            
+
             w.WriteString("state_topic", stateTopic);
             w.WriteString("availability_topic", _topics.BridgeAvailabilityTopic);
             w.WriteString("payload_available", "online");

--- a/src/MultiRoomAudio/Mqtt/HaDiscovery.cs
+++ b/src/MultiRoomAudio/Mqtt/HaDiscovery.cs
@@ -21,206 +21,393 @@ public class HaDiscovery
 
     public record DiscoveryMessage(string Topic, string Payload);
 
+private DiscoveryMessage BuildRemovalMessage(string component, string deviceId)
+    {
+        return new DiscoveryMessage(_topics.DiscoveryTopic(component, deviceId), "");
+    }
+
     /// <summary>
-    /// Returns HA MQTT discovery config messages for all entities belonging to a single audio player device.
+    /// Returns HA MQTT discovery config messages for all entities belonging to the container-level bridge device.
     /// </summary>
-    public IReadOnlyList<DiscoveryMessage> ForPlayer(PlayerResponse p)
+    public IReadOnlyList<DiscoveryMessage> ForPlayerDevice(PlayerResponse p)
     {
         var id = MqttTopics.Sanitize(p.ClientId);
         var stateTopic = _topics.PlayerStateTopic(p.ClientId);
         var deviceId = $"mra_player_{id}";
-        var device = Device(deviceId, p.Name, "Audio Player");
+        var label = $"{p.Name}";
 
-        DiscoveryMessage Entity(string component, string key, string name,
-            Action<Utf8JsonWriter> extra)
-            => Build(component, $"mra_{id}_{key}", name, deviceId, stateTopic, device, extra);
+        using var stream = new MemoryStream();
+        // Build Device Messge
+        using (var w = new Utf8JsonWriter(stream))
+        {
+            w.WriteStartObject();
+            w.WritePropertyName("dev"); 
+            w.WriteStartObject();       
+            w.WriteString("ids", deviceId); // Identifiers
+            w.WriteString("name", "Multi-Room Audio");
+            w.WriteString("mf", "Multi-Room Audio");// Manufacturer
+            w.WriteString("model", "Audio Player");
+            w.WriteString("sw", _version); //sw_version
+            w.WriteEndObject();
 
+            w.WritePropertyName("o"); // origin
+            w.WriteStartObject();
+            w.WriteString("name", "Multiroom Audio Sendspin Container");
+            w.WriteString("sw", _version); // software Version
+            w.WriteEndObject();
+
+            // Start Components
+            w.WritePropertyName("components"); // components
+            w.WriteStartObject();
+
+            // Ready Sensor
+            w.WritePropertyName($"{deviceId}_State"); 
+            w.WriteStartObject();
+            w.WriteString("name", $"{p.Name} State");
+            w.WriteString("unique_id", $"{deviceId}_State");
+            w.WriteString("p", "sensor");                
+            w.WriteString("value_template", "{{ value_json.state }}");
+            w.WriteEndObject();
+
+            // Player Server Sensor
+            w.WritePropertyName($"{deviceId}_server"); 
+            w.WriteStartObject();
+            w.WriteString("name", $"{p.Name} Server");
+            w.WriteString("unique_id", $"{deviceId}_server");
+            w.WriteString("p", "sensor");
+            w.WriteString("value_template", "{{ value_json.server_name }}");
+            w.WriteString("entity_category", "diagnostic");
+            w.WriteString("enabled_by_default", "false");
+            w.WriteEndObject();
+            
+            // Clock Synced Sensor
+            w.WritePropertyName($"{deviceId}_clock_synced"); 
+            w.WriteStartObject();
+            w.WriteString("name", $"{p.Name} Clocke Synced");
+            w.WriteString("unique_id", $"{deviceId}_clock_synced");
+            w.WriteString("p", "binary_sensor");
+            w.WriteString("value_template", "{{ value_json.clock_synced }}");
+            w.WriteString("payload_on", "ON");                
+            w.WriteString("payload_off", "OFF");
+            w.WriteString("entity_category", "diagnostic");
+            w.WriteString("enabled_by_default", "false");
+            w.WriteEndObject();
+            
+            // Reconnect Pending Sensor
+            w.WritePropertyName($"{deviceId}_reconnect_pending"); 
+            w.WriteStartObject();
+            w.WriteString("name", $"{p.Name} Reconnecting");
+            w.WriteString("unique_id", $"{deviceId}_reconnect_pending");
+            w.WriteString("p", "binary_sensor");
+            w.WriteString("value_template", "{{ value_json.reconnect_pending }}");
+            w.WriteString("payload_on", "ON");
+            w.WriteString("payload_off", "OFF");
+            w.WriteString("entity_category", "diagnostic");
+            w.WriteString("enabled_by_default", "false");
+            w.WriteEndObject();
+            
+            // Reconnect Attempts Sensor
+            w.WritePropertyName($"{deviceId}_reconnect_attempts"); 
+            w.WriteStartObject();
+            w.WriteString("name", $"{p.Name} Reconnect Attempts");
+            w.WriteString("unique_id", $"{deviceId}_reconnect_attempts");
+            w.WriteString("p", "sensor");
+            w.WriteString("value_template", "{{ value_json.reconnect_attempts }}");
+            w.WriteString("entity_category", "diagnostic");
+            w.WriteString("enabled_by_default", "false");
+            w.WriteEndObject();
+            
+            // Ready Sensor
+            w.WritePropertyName($"{deviceId}_offset"); 
+            w.WriteStartObject();
+            w.WriteString("name", $"{p.Name} Delay Offset");
+            w.WriteString("unique_id", $"{deviceId}_offset");
+            w.WriteString("p", "number");
+            w.WriteString("command_topic", _topics.PlayerCommandTopic(p.ClientId, "offset"));
+            w.WriteString("value_template", "{{ value_json.delay_ms }}");
+            w.WriteNumber("min", -5000);
+            w.WriteNumber("max", 5000);
+            w.WriteString("unit_of_measurement", "ms");
+            w.WriteString("mode", "box");
+            w.WriteString("entity_category", "config");
+            w.WriteEndObject();
+            
+            // Restart Sensor
+            w.WritePropertyName($"{deviceId}_restart"); 
+            w.WriteStartObject();
+            w.WriteString("name", $"{p.Name} Restart");
+            w.WriteString("unique_id", $"{deviceId}_restart");
+            w.WriteString("p", "button");
+            w.WriteString("command_topic", _topics.PlayerCommandTopic(p.ClientId, "restart"));
+            w.WriteString("payload_press", "PRESS");
+            w.WriteString("entity_category", "config");
+            w.WriteString("enabled_by_default", "false");
+            w.WriteEndObject();
+                    
+            //End Components
+            w.WriteEndObject();
+            
+            w.WriteString("state_topic", stateTopic);
+            w.WriteString("availability_topic", _topics.BridgeAvailabilityTopic);
+            w.WriteString("payload_available", "online");
+            w.WriteString("payload_not_available", "offline");
+            w.WriteEndObject();
+        }
+        var payload = System.Text.Encoding.UTF8.GetString(stream.ToArray());
+        
+        DiscoveryMessage Entity(string component, string key)
+            => BuildRemovalMessage(component, $"mra_{id}_{key}");
+        
         return new List<DiscoveryMessage>
         {
-            Entity("sensor", "state", $"{p.Name} State", w =>
-                w.WriteString("value_template", "{{ value_json.state }}")),
-            Entity("sensor", "server", $"{p.Name} Server", w =>
-            {
-                w.WriteString("value_template", "{{ value_json.server_name }}");
-                w.WriteString("entity_category", "diagnostic");
-                w.WriteString("enabled_by_default", "false");
-            }),
-            Entity("binary_sensor", "clock_synced", $"{p.Name} Clock Synced", w =>
-            {
-                w.WriteString("value_template", "{{ value_json.clock_synced }}");
-                w.WriteString("payload_on", "ON");
-                w.WriteString("payload_off", "OFF");
-                w.WriteString("entity_category", "diagnostic");
-                w.WriteString("enabled_by_default", "false");
-            }),
-            Entity("binary_sensor", "reconnect_pending", $"{p.Name} Reconnecting", w =>
-            {
-                w.WriteString("value_template", "{{ value_json.reconnect_pending }}");
-                w.WriteString("payload_on", "ON");
-                w.WriteString("payload_off", "OFF");
-                w.WriteString("entity_category", "diagnostic");
-                w.WriteString("enabled_by_default", "false");
-            }),
-            Entity("sensor", "reconnect_attempts", $"{p.Name} Reconnect Attempts", w =>
-            {
-                w.WriteString("value_template", "{{ value_json.reconnect_attempts }}");
-                w.WriteString("entity_category", "diagnostic");
-                w.WriteString("enabled_by_default", "false");
-            }),
-            Entity("number", "offset", $"{p.Name} Delay Offset", w =>
-            {
-                w.WriteString("command_topic", _topics.PlayerCommandTopic(p.ClientId, "offset"));
-                w.WriteString("value_template", "{{ value_json.delay_ms }}");
-                w.WriteNumber("min", -5000);
-                w.WriteNumber("max", 5000);
-                w.WriteString("unit_of_measurement", "ms");
-                w.WriteString("mode", "box");
-                w.WriteString("entity_category", "config");
-            }),
-            Entity("button", "restart", $"{p.Name} Restart", w =>
-            {
-                w.WriteString("command_topic", _topics.PlayerCommandTopic(p.ClientId, "restart"));
-                w.WriteString("payload_press", "PRESS");
-                w.WriteString("entity_category", "config");
-                w.WriteString("enabled_by_default", "false");
-            }),
+            new DiscoveryMessage(_topics.DeviceDiscoveryTopic(deviceId), payload),        
+            Entity("sensor", "state"),
+            Entity("sensor", "server"),
+            Entity("binary_sensor", "clock_synced"),
+            Entity("binary_sensor", "reconnect_pending"),
+            Entity("sensor", "reconnect_attempts"),
+            Entity("number", "offset"),
+            Entity("button", "restart"),
         };
     }
 
     /// <summary>
     /// Returns HA MQTT discovery config messages for all entities belonging to the container-level bridge device.
     /// </summary>
-    public IReadOnlyList<DiscoveryMessage> ForContainer(string instanceId)
+    public IReadOnlyList<DiscoveryMessage> ForContainerDevice(string instanceId)
     {
         var id = MqttTopics.Sanitize(instanceId);
         var stateTopic = _topics.ContainerStateTopic;
         var deviceId = $"mra_bridge_{id}";
-        var device = Device(deviceId, "Multi-Room Audio", "Controller");
+        var label = $"MRA Bridge {id}";
 
-        DiscoveryMessage Entity(string component, string key, string name,
-            Action<Utf8JsonWriter> extra)
-            => Build(component, $"mra_bridge_{id}_{key}", name, deviceId, stateTopic, device, extra);
-
-        return new List<DiscoveryMessage>
+        using var stream = new MemoryStream();
+        // Build Device Messge
+        using (var w = new Utf8JsonWriter(stream))
         {
-            Entity("binary_sensor", "ready", "Multi-Room Audio Ready", w =>
-            {
+            w.WriteStartObject();
+            w.WritePropertyName("dev"); 
+            w.WriteStartObject();       
+            w.WriteString("ids", deviceId); // Identifiers
+            w.WriteString("name", "Multi-Room Audio");
+            w.WriteString("mf", "Multi-Room Audio");// Manufacturer
+            w.WriteString("model", "Controller");
+            w.WriteString("sw", _version); //sw_version
+            w.WriteEndObject();
+
+            w.WritePropertyName("o"); // origin
+            w.WriteStartObject();
+            w.WriteString("name", "Multiroom Audio Sendspin Container");
+            w.WriteString("sw", _version); // software Version
+            w.WriteEndObject();
+
+            // Start Components
+            w.WritePropertyName("components"); // components
+            w.WriteStartObject();
+
+                // Ready Sensor
+                w.WritePropertyName($"{deviceId}_ready"); 
+                w.WriteStartObject();
+                w.WriteString("name", $"{label} Ready");
+                w.WriteString("unique_id", $"{deviceId}_ready");
+                w.WriteString("p", "binary_sensor");
                 w.WriteString("value_template", "{{ value_json.ready }}");
                 w.WriteString("payload_on", "ON");
                 w.WriteString("payload_off", "OFF");
                 w.WriteString("device_class", "running");
-            }),
-            Entity("sensor", "version", "Multi-Room Audio Version", w =>
-            {
+                w.WriteEndObject();
+
+                // Version Sensor
+                w.WritePropertyName($"{deviceId}_version"); 
+                w.WriteStartObject();
+                w.WriteString("name", $"{label} Version");
+                w.WriteString("unique_id", $"{deviceId}_version");
+                w.WriteString("p", "sensor");
                 w.WriteString("value_template", "{{ value_json.version }}");
                 w.WriteString("entity_category", "diagnostic");
                 w.WriteString("enabled_by_default", "false");
-            }),
-            Entity("sensor", "player_count", "Multi-Room Audio Players", w =>
-                w.WriteString("value_template", "{{ value_json.player_count }}")),
-            Entity("sensor", "audio_backend", "Multi-Room Audio Backend", w =>
-            {
+                w.WriteEndObject();
+
+                // player Count sensor
+                w.WritePropertyName($"{deviceId}_player_count"); 
+                w.WriteStartObject();
+                w.WriteString("name", $"{label} Players");
+                w.WriteString("unique_id", $"{deviceId}_player_count");
+                w.WriteString("p", "sensor");
+                w.WriteString("value_template", "{{ value_json.player_count }}");
+                w.WriteEndObject();
+
+                // Board Connected Sensor
+                w.WritePropertyName($"{label}_audio_backend"); 
+                w.WriteStartObject();
+                w.WriteString("name", $"{label} Audio Backend");
+                w.WriteString("unique_id", $"{label}_audio_backend");
+                w.WriteString("p", "sensor");
                 w.WriteString("value_template", "{{ value_json.audio_backend }}");
                 w.WriteString("entity_category", "diagnostic");
                 w.WriteString("enabled_by_default", "false");
-            }),
-            Entity("sensor", "environment", "Multi-Room Audio Environment", w =>
-            {
+                w.WriteEndObject();
+
+                // Environment sensor
+                w.WritePropertyName($"{deviceId}_environment"); 
+                w.WriteStartObject();
+                w.WriteString("name", $"{label} Environment");
+                w.WriteString("unique_id", $"{deviceId}_environment");
+                w.WriteString("p", "sensor");
                 w.WriteString("value_template", "{{ value_json.environment }}");
                 w.WriteString("entity_category", "diagnostic");
                 w.WriteString("enabled_by_default", "false");
-            }),
+                w.WriteEndObject();
+                
+            //End Components
+            w.WriteEndObject();
+            
+            w.WriteString("state_topic", stateTopic);
+            w.WriteString("availability_topic", _topics.BridgeAvailabilityTopic);
+            w.WriteString("payload_available", "online");
+            w.WriteString("payload_not_available", "offline");
+            w.WriteEndObject();
+        }
+        var payload = System.Text.Encoding.UTF8.GetString(stream.ToArray());
+        
+        DiscoveryMessage Entity(string component, string key)
+            => BuildRemovalMessage(component, $"mra_bridge_{id}_{key}");
+
+        return new List<DiscoveryMessage>
+        {
+            new DiscoveryMessage(_topics.DeviceDiscoveryTopic(deviceId), payload),
+
+            Entity("binary_sensor", "ready"),
+            Entity("sensor", "version"),
+            Entity("sensor", "player_count"),
+            Entity("sensor", "audio_backend"),
+            Entity("sensor", "environment"),
         };
     }
 
     /// <summary>
     /// Returns HA MQTT discovery config messages for all entities belonging to a single amplifier zone (relay channel).
     /// </summary>
-    public IReadOnlyList<DiscoveryMessage> ForAmp(string boardId, string? boardDisplayName, TriggerResponse t)
+    public IReadOnlyList<DiscoveryMessage> ForAmpDevice(string boardId, string? boardDisplayName, TriggerResponse t)
     {
+
         var zone = $"{MqttTopics.Sanitize(boardId)}_{t.Channel}";
         var stateTopic = _topics.AmpStateTopic(boardId, t.Channel);
         var deviceId = $"mra_amp_{zone}";
         var label = !string.IsNullOrWhiteSpace(t.ZoneName) ? t.ZoneName
                   : !string.IsNullOrWhiteSpace(boardDisplayName) ? $"{boardDisplayName} CH{t.Channel}"
                   : $"{boardId} CH{t.Channel}";
-        var device = Device(deviceId, label!, "Amplifier Zone");
 
-        DiscoveryMessage Entity(string component, string key, string name, Action<Utf8JsonWriter> extra)
-            => Build(component, $"mra_amp_{zone}_{key}", name, deviceId, stateTopic, device, extra);
-
-        return new List<DiscoveryMessage>
+        using var stream = new MemoryStream();
+        // Build Device Messge
+        using (var w = new Utf8JsonWriter(stream))
         {
-            Entity("binary_sensor", "power", $"{label} Power", w =>
-            {
+            w.WriteStartObject();
+            w.WritePropertyName("dev"); 
+            w.WriteStartObject();       
+            w.WriteString("ids", $"mra_amp_{zone}"); // Identifiers
+            w.WriteString("name", label!);
+            w.WriteString("mf", "Multi-Room Audio");// Manufacturer
+            w.WriteString("model", "Amplifier Zone");
+            w.WriteString("sw", _version); //sw_version
+            w.WriteEndObject();
+
+            w.WritePropertyName("o"); // origin
+            w.WriteStartObject();
+            w.WriteString("name", "Multiroom Audio Sendspin Container");
+            w.WriteString("sw", _version); // software Version
+            w.WriteEndObject();
+
+            // Start Components
+            w.WritePropertyName("components"); // components
+            w.WriteStartObject();
+                // Poser Sensor
+                w.WritePropertyName($"{deviceId}_power"); // start of power binary sensor
+                w.WriteStartObject();
+                w.WriteString("name", $"{label} Power");
+                w.WriteString("unique_id", $"{deviceId}_power");
+                w.WriteString("p", "binary_sensor");
                 w.WriteString("value_template", "{{ value_json.power }}");
                 w.WriteString("payload_on", "ON");
                 w.WriteString("payload_off", "OFF");
                 w.WriteString("device_class", "power");
-            }),
-            Entity("sensor", "scheduled_off", $"{label} Scheduled Off", w =>
-            {
+                w.WriteEndObject();
+
+                // Scheduled Off Sensor
+                w.WritePropertyName($"{deviceId}_scheduled_off"); // start of Scheduled Off sensor
+                w.WriteStartObject();
+                w.WriteString("name", $"{label} Scheduled Off");
+                w.WriteString("unique_id", $"{deviceId}_scheduled_off");
+                w.WriteString("p", "sensor");
                 w.WriteString("value_template", "{{ value_json.scheduled_off }}");
                 w.WriteString("device_class", "timestamp");
                 w.WriteString("entity_category", "diagnostic");
                 w.WriteString("enabled_by_default", "false");
-            }),
-            Entity("switch", "override", $"{label} Override", w =>
-            {
+                w.WriteEndObject();
+
+                // Override Switch
+                w.WritePropertyName($"{deviceId}_override"); // start of Override Switch
+                w.WriteStartObject();
+                w.WriteString("name", $"{label} Override");
+                w.WriteString("unique_id", $"{deviceId}_override");
+                w.WriteString("p", "switch");
                 w.WriteString("command_topic", _topics.AmpCommandTopic(boardId, t.Channel, "override"));
                 w.WriteString("value_template", "{{ value_json.override }}");
                 w.WriteString("state_on", "ON");
                 w.WriteString("state_off", "OFF");
                 w.WriteString("payload_on", "ON");
                 w.WriteString("payload_off", "OFF");
-            }),
-            Entity("binary_sensor", "board_connected", $"{label} Board Connected", w =>
-            {
+                w.WriteEndObject();
+
+                // Board Connected Sensor
+                w.WritePropertyName($"{deviceId}_board_connected"); // start of Board Connected Binary Sensor
+                w.WriteStartObject();
+                w.WriteString("name", $"{label} Board Connected");
+                w.WriteString("unique_id", $"{deviceId}_board_connected");
+                w.WriteString("p", "binary_sensor");
                 w.WriteString("value_template", "{{ value_json.board_connected }}");
                 w.WriteString("payload_on", "ON");
                 w.WriteString("payload_off", "OFF");
                 w.WriteString("device_class", "connectivity");
                 w.WriteString("entity_category", "diagnostic");
                 w.WriteString("enabled_by_default", "false");
-            }),
-        };
-    }
-
-    private DiscoveryMessage Build(string component, string uniqueId, string name,
-        string deviceId, string stateTopic, Action<Utf8JsonWriter> deviceBlock,
-        Action<Utf8JsonWriter> extra)
-    {
-        using var stream = new MemoryStream();
-        using (var w = new Utf8JsonWriter(stream))
-        {
-            w.WriteStartObject();
-            w.WriteString("name", name);
-            w.WriteString("unique_id", uniqueId);
-            w.WriteString("object_id", uniqueId);
+                w.WriteEndObject();
+            
+            //End Components
+            w.WriteEndObject();
+            
             w.WriteString("state_topic", stateTopic);
             w.WriteString("availability_topic", _topics.BridgeAvailabilityTopic);
             w.WriteString("payload_available", "online");
             w.WriteString("payload_not_available", "offline");
-            extra(w);
-            w.WritePropertyName("device");
-            deviceBlock(w);
             w.WriteEndObject();
         }
         var payload = System.Text.Encoding.UTF8.GetString(stream.ToArray());
-        return new DiscoveryMessage(_topics.DiscoveryTopic(component, uniqueId), payload);
+
+        DiscoveryMessage Entity(string component, string key)
+            => BuildRemovalMessage(component, $"mra_amp_{zone}_{key}");
+        return new List<DiscoveryMessage>
+        {
+            new DiscoveryMessage(_topics.DeviceDiscoveryTopic(deviceId), payload),
+            Entity("binary_sensor", "power"),
+            Entity("sensor", "scheduled_off"),
+            Entity("switch", "override"),
+            Entity("binary_sensor", "board_connected")
+        };
     }
 
     private Action<Utf8JsonWriter> Device(string identifier, string name, string model) => w =>
     {
         w.WriteStartObject();
-        w.WritePropertyName("identifiers");
-        w.WriteStartArray();
-        w.WriteStringValue(identifier);
-        w.WriteEndArray();
+        //w.WritePropertyName("dev");        
+        w.WriteString("ids", identifier); // Identifiers
         w.WriteString("name", name);
-        w.WriteString("manufacturer", "Multi-Room Audio");
+        w.WriteString("mf", "Multi-Room Audio");// Manufacturer
         w.WriteString("model", model);
-        w.WriteString("sw_version", _version);
+        w.WriteString("sw", _version); //sw_version
         w.WriteEndObject();
+        //w.WriteStartArray();
+        //w.WriteStringValue(identifier);
+        //w.WriteEndArray();
     };
 }

--- a/src/MultiRoomAudio/Mqtt/MqttTopics.cs
+++ b/src/MultiRoomAudio/Mqtt/MqttTopics.cs
@@ -49,6 +49,9 @@ public class MqttTopics
     public string DiscoveryTopic(string component, string objectId) =>
         $"{_prefix}/{component}/{objectId}/config";
 
+    public string DeviceDiscoveryTopic(string deviceId) =>
+        $"{_prefix}/device/{deviceId}/config";
+
     /// <summary>Lowercase and replace any character outside [a-z0-9_-] with '_'. Collapse consecutive underscores.</summary>
     public static string Sanitize(string raw)
     {

--- a/src/MultiRoomAudio/Services/MqttService.cs
+++ b/src/MultiRoomAudio/Services/MqttService.cs
@@ -133,16 +133,16 @@ public class MqttService
     private async Task PublishDiscoveryAsync(CancellationToken ct)
     {
         foreach (var p in _players.GetAllPlayers().Players)
-            foreach (var m in _discovery!.ForPlayer(p))
+            foreach (var m in _discovery!.ForPlayerDevice(p))
                 await PublishAsync(m.Topic, m.Payload, retain: true, ct);
 
-        foreach (var m in _discovery!.ForContainer(_env.EnvironmentName))
+        foreach (var m in _discovery!.ForContainerDevice(_env.EnvironmentName))
             await PublishAsync(m.Topic, m.Payload, retain: true, ct);
 
         var trig = _triggers.GetStatus();
         foreach (var board in trig.Boards)
             foreach (var t in board.Triggers)
-                foreach (var m in _discovery!.ForAmp(board.BoardId, board.DisplayName, t))
+                foreach (var m in _discovery!.ForAmpDevice(board.BoardId, board.DisplayName, t))
                     await PublishAsync(m.Topic, m.Payload, retain: true, ct);
     }
 
@@ -173,7 +173,7 @@ public class MqttService
             {
                 if (!IsConnected)
                     return;
-                await PublishDiscoveryAsync(CancellationToken.None);
+                //await PublishDiscoveryAsync(CancellationToken.None);
                 await PublishAllStateAsync(CancellationToken.None);
             }
             catch (Exception ex)
@@ -312,6 +312,7 @@ public class MqttService
         {
             if (!IsConnected)
                 return;
+            await PublishDiscoveryAsync(ct);
             await PublishAllStateAsync(ct);
         }
         catch (Exception ex)

--- a/tests/MultiRoomAudio.Tests/Mqtt/AmpDiscoveryTests.cs
+++ b/tests/MultiRoomAudio.Tests/Mqtt/AmpDiscoveryTests.cs
@@ -39,5 +39,5 @@ public class AmpDiscoveryTests
 
     [Fact]
     public void Amp_EmitsPowerBinarySensor()
-        => Assert.Contains(_d.ForAmp("VIRTUAL:x", null, Zone()), m => m.Topic.Contains("/binary_sensor/") && m.Payload.Contains("value_json.power"));
+        => Assert.Contains(_d.ForAmp("VIRTUAL:x", null, Zone()),  m.Payload.Contains("value_json.power"));
 }

--- a/tests/MultiRoomAudio.Tests/Mqtt/AmpDiscoveryTests.cs
+++ b/tests/MultiRoomAudio.Tests/Mqtt/AmpDiscoveryTests.cs
@@ -15,29 +15,35 @@ public class AmpDiscoveryTests
         OffDelaySeconds: 30, ZoneName: "Living Room", RelayState: RelayState.On,
         IsActive: true, LastActivated: null, ScheduledOffTime: null, IsOverridden: false);
 
+    private static JsonElement DeviceMessage(System.Collections.Generic.IReadOnlyList<HaDiscovery.DiscoveryMessage> msgs)
+    {
+        var device = msgs.Single(m => !string.IsNullOrEmpty(m.Payload));
+        return JsonDocument.Parse(device.Payload).RootElement.Clone();
+    }
+
     [Fact]
     public void Amp_EmitsOverrideSwitchWithCommandTopic()
     {
-        var sw = _d.ForAmp("VIRTUAL:x", "Living Room Amp", Zone()).Single(m => m.Topic.Contains("/switch/"));
-        using var doc = JsonDocument.Parse(sw.Payload);
-        var root = doc.RootElement;
-        Assert.Equal("multiroom-audio/amp/virtual_x_1/override/set", root.GetProperty("command_topic").GetString());
+        var root = DeviceMessage(_d.ForAmpDevice("VIRTUAL:x", "Living Room Amp", Zone()));
+        var components = root.GetProperty("components");
+        var sw = components.EnumerateObject().Single(e => e.Value.GetProperty("p").GetString() == "switch");
+
+        Assert.Equal("multiroom-audio/amp/virtual_x_1/override/set", sw.Value.GetProperty("command_topic").GetString());
         Assert.Equal("multiroom-audio/amp/virtual_x_1/state", root.GetProperty("state_topic").GetString());
     }
 
     [Fact]
     public void Amp_AllEntitiesShareDeviceIdentifier()
     {
-        var ids = _d.ForAmp("VIRTUAL:x", "Living Room Amp", Zone()).Select(m =>
-        {
-            using var doc = JsonDocument.Parse(m.Payload);
-            return doc.RootElement.GetProperty("device").GetProperty("identifiers")[0].GetString();
-        }).Distinct().ToList();
-        Assert.Single(ids);
-        Assert.Equal("mra_amp_virtual_x_1", ids[0]);
+        var root = DeviceMessage(_d.ForAmpDevice("VIRTUAL:x", "Living Room Amp", Zone()));
+        Assert.Equal("mra_amp_virtual_x_1", root.GetProperty("dev").GetProperty("ids").GetString());
+
+        var components = root.GetProperty("components");
+        Assert.All(components.EnumerateObject(), e =>
+            Assert.StartsWith("mra_amp_virtual_x_1_", e.Value.GetProperty("unique_id").GetString()));
     }
 
     [Fact]
     public void Amp_EmitsPowerBinarySensor()
-        => Assert.Contains(_d.ForAmp("VIRTUAL:x", null, Zone()),  m.Payload.Contains("value_json.power"));
+        => Assert.Contains(_d.ForAmpDevice("VIRTUAL:x", null, Zone()), m => m.Payload.Contains("value_json.power"));
 }

--- a/tests/MultiRoomAudio.Tests/Mqtt/HaDiscoveryTests.cs
+++ b/tests/MultiRoomAudio.Tests/Mqtt/HaDiscoveryTests.cs
@@ -16,51 +16,55 @@ public class HaDiscoveryTests
         DateTime.UnixEpoch, DateTime.UnixEpoch, null, true, null,
         IsPendingReconnection: false, ReconnectionAttempts: 0);
 
+    private static JsonElement DeviceMessage(System.Collections.Generic.IReadOnlyList<HaDiscovery.DiscoveryMessage> msgs)
+    {
+        var device = msgs.Single(m => !string.IsNullOrEmpty(m.Payload));
+        return JsonDocument.Parse(device.Payload).RootElement.Clone();
+    }
+
     [Fact]
     public void Player_EmitsRestartButtonWithCommandTopic()
     {
-        var msgs = _d.ForPlayer(Player());
-        var button = msgs.Single(m => m.Topic.Contains("/button/"));
+        var root = DeviceMessage(_d.ForPlayerDevice(Player()));
+        var components = root.GetProperty("components");
+        var restart = components.EnumerateObject().Single(e => e.Value.GetProperty("p").GetString() == "button");
 
-        using var doc = JsonDocument.Parse(button.Payload);
-        var root = doc.RootElement;
-        Assert.Equal("multiroom-audio/player/abc123/restart/set", root.GetProperty("command_topic").GetString());
+        Assert.Equal("multiroom-audio/player/abc123/restart/set", restart.Value.GetProperty("command_topic").GetString());
         Assert.Equal("multiroom-audio/bridge/availability", root.GetProperty("availability_topic").GetString());
-        Assert.StartsWith("mra_abc123_", root.GetProperty("unique_id").GetString());
+        Assert.StartsWith("mra_player_abc123_", restart.Value.GetProperty("unique_id").GetString());
     }
 
     [Fact]
     public void Player_OffsetNumberHasCommandTopicAndRange()
     {
-        var number = _d.ForPlayer(Player()).Single(m => m.Topic.Contains("/number/"));
-        using var doc = JsonDocument.Parse(number.Payload);
-        var root = doc.RootElement;
-        Assert.Equal("multiroom-audio/player/abc123/offset/set", root.GetProperty("command_topic").GetString());
-        Assert.Equal(-5000, root.GetProperty("min").GetInt32());
-        Assert.Equal(5000, root.GetProperty("max").GetInt32());
+        var root = DeviceMessage(_d.ForPlayerDevice(Player()));
+        var components = root.GetProperty("components");
+        var offset = components.EnumerateObject().Single(e => e.Value.GetProperty("p").GetString() == "number");
+
+        Assert.Equal("multiroom-audio/player/abc123/offset/set", offset.Value.GetProperty("command_topic").GetString());
+        Assert.Equal(-5000, offset.Value.GetProperty("min").GetInt32());
+        Assert.Equal(5000, offset.Value.GetProperty("max").GetInt32());
     }
 
     [Fact]
     public void Player_AllEntitiesShareDeviceIdentifier()
     {
-        var ids = _d.ForPlayer(Player()).Select(m =>
-        {
-            using var doc = JsonDocument.Parse(m.Payload);
-            return doc.RootElement.GetProperty("device").GetProperty("identifiers")[0].GetString();
-        }).Distinct().ToList();
-        Assert.Single(ids);
-        Assert.Equal("mra_player_abc123", ids[0]);
+        var root = DeviceMessage(_d.ForPlayerDevice(Player()));
+        Assert.Equal("mra_player_abc123", root.GetProperty("dev").GetProperty("ids").GetString());
+
+        var components = root.GetProperty("components");
+        Assert.All(components.EnumerateObject(), e =>
+            Assert.StartsWith("mra_player_abc123_", e.Value.GetProperty("unique_id").GetString()));
     }
 
     [Fact]
     public void Container_EmitsReadyBinarySensor()
     {
-        var msgs = _d.ForContainer("instance1");
-        Assert.Contains(msgs, m =>
-        {
-            if (!m.Topic.Contains("/binary_sensor/")) return false;
-            using var doc = System.Text.Json.JsonDocument.Parse(m.Payload);
-            return doc.RootElement.GetProperty("value_template").GetString()!.Contains("value_json.ready");
-        });
+        var root = DeviceMessage(_d.ForContainerDevice("instance1"));
+        var components = root.GetProperty("components");
+
+        Assert.Contains(components.EnumerateObject(), e =>
+            e.Value.GetProperty("p").GetString() == "binary_sensor" &&
+            e.Value.GetProperty("value_template").GetString()!.Contains("value_json.ready"));
     }
 }


### PR DESCRIPTION
Consolidate HA MQTT Discovery into Device method
Disable diagnostic entities by default

Diagnostic entities are rarely used and should not be added by default, this helps keep recorder workload down, particularly with this project pushing all discovery and entity data on every state change.