### PR TITLE
fix: stop a cleared off-delay box from failing trigger sink saves (#250)

### DIFF
--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -5596,13 +5596,25 @@ async function removeTriggerSink(boardId, channel, sinkName) {
 const appAddTriggerSink = addTriggerSink;
 const appRemoveTriggerSink = removeTriggerSink;
 
+// Resolve an off-delay to a value the API will accept. An empty or non-numeric input
+// parses to NaN, which JSON.stringify writes as null - the API then rejects the whole
+// request because offDelaySeconds is a non-nullable int, so the sink assignment is lost
+// too. Fall back to the last saved delay instead of failing the save.
+function coerceOffDelay(rawValue, fallback) {
+    const parsed = parseInt(rawValue, 10);
+    if (Number.isFinite(parsed)) {
+        return Math.min(3600, Math.max(0, parsed));
+    }
+    return Number.isFinite(fallback) ? fallback : 60;
+}
+
 // Persist the channel's full sink list (+ current delay) and re-render its chips.
 async function saveTriggerSinks(boardId, channel) {
     const boardIdSafe = boardId.replace(/[^a-zA-Z0-9]/g, '_');
     const t = getTrigger(boardId, channel);
     const names = t ? (t.customSinkNames || []) : [];
     const delayInput = document.getElementById(`trigger-delay-${boardIdSafe}-${channel}`);
-    const delay = delayInput ? parseInt(delayInput.value, 10) : 60;
+    const delay = coerceOffDelay(delayInput ? delayInput.value : null, t ? t.offDelaySeconds : 60);
 
     try {
         const url = boardId.includes('/')
@@ -5617,6 +5629,7 @@ async function saveTriggerSinks(boardId, channel) {
             const error = await response.json();
             throw new Error(error.message || 'Failed to update trigger');
         }
+        if (t) t.offDelaySeconds = delay;
         const container = document.getElementById(`trigger-sink-${boardIdSafe}-${channel}`);
         if (container) {
             container.innerHTML = renderSinkChips(boardId, channel, names, triggerSinksList, false);
@@ -5632,6 +5645,7 @@ async function saveTriggerSinks(boardId, channel) {
 async function updateTriggerDelay(boardId, channel, delay) {
     const t = getTrigger(boardId, channel);
     const names = t ? (t.customSinkNames || []) : [];
+    const offDelaySeconds = coerceOffDelay(delay, t ? t.offDelaySeconds : 60);
 
     try {
         const url = boardId.includes('/')
@@ -5640,7 +5654,7 @@ async function updateTriggerDelay(boardId, channel, delay) {
         const response = await fetch(url, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds: parseInt(delay, 10) })
+            body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds })
         });
 
         if (!response.ok) {
@@ -5648,6 +5662,7 @@ async function updateTriggerDelay(boardId, channel, delay) {
             throw new Error(error.message || 'Failed to update trigger');
         }
 
+        if (t) t.offDelaySeconds = offDelaySeconds;
         showAlert('Delay updated', 'success', 2000);
     } catch (error) {
         console.error('Error updating trigger delay:', error);


### PR DESCRIPTION
Follow-up to #255 (multi-sink triggers), addressing the "appears fail to save correctly" report on #250.

## Problem

`saveTriggerSinks()` and `updateTriggerDelay()` both build the request body with:

```js
parseInt(delayInput.value, 10)
```

If the off-delay number box is empty or non-numeric, `parseInt` returns `NaN`, and `JSON.stringify` serialises `NaN` as **`null`**. `TriggerConfigureRequest.OffDelaySeconds` is a non-nullable `int`, so model binding rejects the entire request with a 400 — which means **the sink assignment is discarded along with the delay**. From the user's side the chip appears to add, then disappears on the next refresh, with only a generic "Failed to update trigger" toast.

The 82 existing C# tests can't catch this: the defect is in JS number coercion, before the request is ever formed.

## Fix

- Add `coerceOffDelay(rawValue, fallback)` — returns the parsed value clamped to the API's validated `0-3600` range, or falls back to the trigger's last saved delay (then `60`) when the input isn't a finite number.
- Route both call sites through it.
- Mirror the accepted value back onto the local `triggersData` trigger so a subsequent chip add doesn't re-read the same bad DOM value.

## Verification

- `node --check src/MultiRoomAudio/wwwroot/js/app.js` — passes
- `dotnet test tests/MultiRoomAudio.Tests` — 82/82 passing (unchanged; no C# touched)

Not yet manually exercised in a browser — @chrisuthe worth confirming on a dev build that clearing the delay box and adding a zone chip now saves instead of erroring.

## Not addressed here

While reading this path I noticed `TriggerService.ConfigureTrigger` unconditionally assigns `trigger.ZoneName = zoneName`, and neither `app.js` nor `wizard.js` sends `zoneName` — so any UI save silently clears a zone name set through the API or MQTT. Pre-existing (not introduced by #255) and left alone here to keep this diff surgical; happy to split it into its own PR.