### PR TITLE
fix: stop republishing unchanged retained MQTT topics (#256)

### DIFF
--- a/src/MultiRoomAudio/Mqtt/RetainedPublishCache.cs
+++ b/src/MultiRoomAudio/Mqtt/RetainedPublishCache.cs
@@ -1,0 +1,46 @@
+namespace MultiRoomAudio.Mqtt;
+
+/// <summary>
+/// Remembers the last payload published to each retained topic so a byte-identical
+/// republish can be skipped.
+/// </summary>
+/// <remarks>
+/// The bridge republishes every discovery config and every state topic whenever any
+/// player or trigger changes, because <c>PlayersChanged</c>/<c>TriggersChanged</c> don't
+/// say which entity changed. That turned a single player state change into ~40 broker
+/// messages (#256). For a retained topic the broker already holds the last value, so
+/// re-sending the same bytes tells subscribers nothing — suppressing it leaves only the
+/// entities that genuinely changed on the wire.
+///
+/// Not thread-safe by itself; callers must serialize access (MqttService does so under
+/// its publish lock).
+/// </remarks>
+internal sealed class RetainedPublishCache
+{
+    private readonly Dictionary<string, string> _lastPayloads = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Returns whether <paramref name="payload"/> needs to go on the wire. Non-retained
+    /// messages always do; a retained message only does when its payload differs from the
+    /// last one recorded for <paramref name="topic"/>.
+    /// </summary>
+    public bool ShouldPublish(string topic, string payload, bool retain)
+        => !retain || !_lastPayloads.TryGetValue(topic, out var previous) || previous != payload;
+
+    /// <summary>
+    /// Records a payload that was successfully published, so an identical follow-up is
+    /// suppressed. Called only after the publish succeeds — a failed publish leaves the
+    /// previous entry in place so the value is retried rather than assumed delivered.
+    /// </summary>
+    public void Record(string topic, string payload, bool retain)
+    {
+        if (retain)
+            _lastPayloads[topic] = payload;
+    }
+
+    /// <summary>
+    /// Drops all remembered payloads. Called on every (re)connect: a broker that restarted
+    /// may have lost its retained set, so the next announce must re-prime it in full.
+    /// </summary>
+    public void Clear() => _lastPayloads.Clear();
+}

--- a/src/MultiRoomAudio/Services/MqttService.cs
+++ b/src/MultiRoomAudio/Services/MqttService.cs
@@ -25,6 +25,7 @@ public class MqttService
     private HaDiscovery? _discovery;
     private string _baseTopic = "multiroom-audio";
     private readonly SemaphoreSlim _publishLock = new(1, 1);
+    private readonly RetainedPublishCache _retained = new();
     private CancellationTokenSource? _reconnectCts;
     private volatile bool _shuttingDown;
 
@@ -119,6 +120,12 @@ public class MqttService
         await _client!.ConnectAsync(_options!, ct);
         LastError = null;
         _logger.LogInformation("MQTT bridge connected to broker");
+
+        // A broker that restarted may have lost its retained set, so forget what we think it
+        // holds and let the announce below re-prime every topic in full.
+        await _publishLock.WaitAsync(ct);
+        try { _retained.Clear(); }
+        finally { _publishLock.Release(); }
 
         await _client.SubscribeAsync(_topics!.PlayerCommandSubscription, MqttQualityOfServiceLevel.AtLeastOnce, ct);
         await _client.SubscribeAsync(_topics!.AmpCommandSubscription, MqttQualityOfServiceLevel.AtLeastOnce, ct);
@@ -282,6 +289,10 @@ public class MqttService
         await _publishLock.WaitAsync(ct);
         try
         {
+            // The broker already retains the last value, so re-sending identical bytes is
+            // pure noise for subscribers (#256).
+            if (!_retained.ShouldPublish(topic, payload, retain)) return;
+
             var message = new MqttApplicationMessageBuilder()
                 .WithTopic(topic)
                 .WithPayload(payload)
@@ -289,6 +300,7 @@ public class MqttService
                 .WithQualityOfServiceLevel(MqttQualityOfServiceLevel.AtLeastOnce)
                 .Build();
             await _client.PublishAsync(message, ct);
+            _retained.Record(topic, payload, retain);
         }
         finally
         {

--- a/tests/MultiRoomAudio.Tests/Mqtt/RetainedPublishCacheTests.cs
+++ b/tests/MultiRoomAudio.Tests/Mqtt/RetainedPublishCacheTests.cs
@@ -1,0 +1,99 @@
+using MultiRoomAudio.Mqtt;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Mqtt;
+
+public class RetainedPublishCacheTests
+{
+    private const string Topic = "multiroom-audio/player/sendspin-kitchen-33fa00a6/state";
+    private const string Payload = """{"state":"connected","delay_ms":0}""";
+
+    [Fact]
+    public void FirstRetainedPublish_GoesOnTheWire()
+    {
+        var cache = new RetainedPublishCache();
+
+        Assert.True(cache.ShouldPublish(Topic, Payload, retain: true));
+    }
+
+    [Fact]
+    public void IdenticalRetainedPayload_IsSuppressed()
+    {
+        var cache = new RetainedPublishCache();
+        cache.ShouldPublish(Topic, Payload, retain: true);
+        cache.Record(Topic, Payload, retain: true);
+
+        Assert.False(cache.ShouldPublish(Topic, Payload, retain: true));
+    }
+
+    [Fact]
+    public void ChangedRetainedPayload_GoesOnTheWire()
+    {
+        var cache = new RetainedPublishCache();
+        cache.Record(Topic, Payload, retain: true);
+
+        Assert.True(cache.ShouldPublish(Topic, """{"state":"buffering","delay_ms":0}""", retain: true));
+    }
+
+    [Fact]
+    public void UnrecordedPublish_IsRetried()
+    {
+        // A publish that threw is never recorded, so the value must still be sent next time
+        // rather than being assumed delivered.
+        var cache = new RetainedPublishCache();
+        cache.ShouldPublish(Topic, Payload, retain: true);
+
+        Assert.True(cache.ShouldPublish(Topic, Payload, retain: true));
+    }
+
+    [Fact]
+    public void NonRetainedPayload_IsNeverSuppressed()
+    {
+        var cache = new RetainedPublishCache();
+        cache.Record(Topic, Payload, retain: false);
+
+        Assert.True(cache.ShouldPublish(Topic, Payload, retain: false));
+    }
+
+    [Fact]
+    public void Clear_ReprimesEveryTopic()
+    {
+        // Models a broker restart: the retained set may be gone, so the next announce has to
+        // publish everything again.
+        var cache = new RetainedPublishCache();
+        cache.Record(Topic, Payload, retain: true);
+        Assert.False(cache.ShouldPublish(Topic, Payload, retain: true));
+
+        cache.Clear();
+
+        Assert.True(cache.ShouldPublish(Topic, Payload, retain: true));
+    }
+
+    [Fact]
+    public void TopicsAreTrackedIndependently()
+    {
+        var cache = new RetainedPublishCache();
+        cache.Record(Topic, Payload, retain: true);
+
+        Assert.True(cache.ShouldPublish("multiroom-audio/amp/virtual_da1a7d94_1/state", Payload, retain: true));
+    }
+
+    [Fact]
+    public void UnchangedFanOut_CollapsesToOnlyTheChangedTopic()
+    {
+        // The #256 scenario: one player changes state, but the bridge republishes every
+        // player and amp topic because the change event doesn't say what changed.
+        var cache = new RetainedPublishCache();
+        var topics = Enumerable.Range(0, 40).Select(i => $"multiroom-audio/entity/{i}/state").ToArray();
+
+        foreach (var t in topics)
+        {
+            cache.ShouldPublish(t, "unchanged", retain: true);
+            cache.Record(t, "unchanged", retain: true);
+        }
+
+        var wouldPublish = topics.Count(t => cache.ShouldPublish(t, t == topics[7] ? "changed" : "unchanged", retain: true));
+
+        Assert.Equal(1, wouldPublish);
+    }
+}


### PR DESCRIPTION
Addresses the remaining half of #256.

## Problem

`PlayersChanged` and `TriggersChanged` carry no indication of *which* entity changed, so `OnPlayersChanged`/`OnTriggersChanged` call `PublishDiscoveryAsync()` + `PublishAllStateAsync()`, which walk every player, every amp zone and the bridge. With the reporter's 4 players / 8 amp zones that is ~40 broker messages per player state change, and 287 on startup. Home Assistant sees a full discovery **and** state refresh on every tick.

The issue asks for "one message per updated entity (~5 for a player state change) relying on the retained state messages for entities that have not changed."

## Approach

Rather than re-plumbing the change events to carry an entity identity (invasive, and easy to get subtly wrong), suppress the redundancy at the wire: **for a retained topic the broker already holds the last value, so re-sending identical bytes tells subscribers nothing.**

- New `RetainedPublishCache` (`src/MultiRoomAudio/Mqtt/`) remembers the last payload per retained topic.
- `PublishAsync` consults it under the existing `_publishLock`, so no new synchronisation.
- Records **only after a successful publish** — a publish that throws is retried next time rather than assumed delivered.
- Cleared on every (re)connect, because a restarted broker may have lost its retained set and the announce must re-prime it in full.

Net effect: a player state change puts only the topics that actually changed on the wire. Discovery configs are stable payloads, so after the first announce they cost nothing — which means the discovery republish can **stay** (a newly added player still gets announced) instead of being removed.

## Verification

`dotnet test tests/MultiRoomAudio.Tests` — **90/90 passing** (82 before, 8 new). New `RetainedPublishCacheTests` covers first publish, suppression, change detection, retry-after-failure, non-retained passthrough, clear-on-reconnect, per-topic independence, and a 40-topic fan-out that collapses to 1.

Not yet exercised against a live broker — @chrisuthe worth confirming with `subscribe multiroom-audio/#` that a player state change now yields a handful of messages rather than ~40.

## ⚠️ Branch divergence — needs a decision

This is based on `dev`, per the usual flow. But `main` and `dev` have **diverged on the MQTT code** and this needs reconciling before either ships:

| | `main` | `dev` |
|---|---|---|
| #257 "MQTT Improvements" (device-based discovery, `ForPlayerDevice`/`ForAmpDevice`, diagnostics off by default) | ✅ | ❌ |
| #254 (#249) enum `device_class` on player State, container diagnostics off by default | ❌ | ✅ |

`HaDiscovery.cs` differs by ~479 lines between the two. Separately, #257 addressed part of #256 by **commenting out** the discovery republish in `OnPlayersChanged` (`//await PublishDiscoveryAsync(...)`) — with this cache that workaround is no longer needed and the commented line should be restored/removed during the merge.

Happy to rebase this onto `main` instead if you'd rather land it there.

## What #257 already covered

The reporter also asked for device-based discovery ([HA device discovery payload](https://www.home-assistant.io/integrations/mqtt/#device-discovery-payload)). #257 did that on `main`. This PR is only the message-volume half.