### PR TITLE
fix: apply a cubic volume taper instead of linear amplitude (#263)

### DIFF
--- a/src/MultiRoomAudio/Audio/VolumeCurve.cs
+++ b/src/MultiRoomAudio/Audio/VolumeCurve.cs
@@ -1,0 +1,36 @@
+namespace MultiRoomAudio.Audio;
+
+/// <summary>
+/// Maps a 0-100 user-facing volume onto the linear amplitude gain the SDK multiplies
+/// samples by.
+/// </summary>
+/// <remarks>
+/// Feeding the percentage straight through as <c>percent / 100f</c> makes the slider
+/// linear in amplitude, which does not match how loudness is heard (#263). Perceived
+/// loudness roughly doubles per +10 dB, so a linear amplitude taper is louder than the
+/// number suggests everywhere and crams the audible range into the bottom of the slider:
+///
+/// <code>
+///   slider  linear gain     dB   ~perceived
+///       50         0.50   -6.0         66%
+///       10         0.10  -20.0         25%
+///        2         0.02  -34.0          9%
+/// </code>
+///
+/// A cubic taper is the convention the rest of the audio stack already uses -
+/// PulseAudio's <c>pa_sw_volume_to_linear</c> is literally <c>(v/PA_VOLUME_NORM)^3</c>,
+/// and ALSA's mixers behave the same way - so it also keeps a player's software volume
+/// consistent with the hardware volume applied through <c>pactl</c>.
+/// </remarks>
+internal static class VolumeCurve
+{
+    /// <summary>
+    /// Converts a 0-100 volume percentage to the amplitude gain to apply. Values outside
+    /// 0-100 are clamped. 0 returns silence and 100 returns unity gain.
+    /// </summary>
+    public static float ToGain(int percent)
+    {
+        var normalized = Math.Clamp(percent, 0, 100) / 100.0;
+        return (float)(normalized * normalized * normalized);
+    }
+}

--- a/src/MultiRoomAudio/Services/PlayerManagerService.cs
+++ b/src/MultiRoomAudio/Services/PlayerManagerService.cs
@@ -1098,7 +1098,7 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
     {
         // Apply startup volume locally - player is authoritative for its own volume
         // Hardware volume is set to 80% on container startup to avoid clipping
-        context.Player.Volume = context.Config.Volume / 100.0f;
+        context.Player.Volume = VolumeCurve.ToGain(context.Config.Volume);
         _logger.LogInformation("VOLUME [Create] Player '{Name}': startup volume {Volume}% applied locally",
             name, context.Config.Volume);
 
@@ -1444,7 +1444,7 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
         context.Config.Volume = volume;
 
         // 2. Apply volume locally - player is authoritative for its own volume
-        context.Player.Volume = volume / 100.0f;
+        context.Player.Volume = VolumeCurve.ToGain(volume);
 
         // 3. Inform MA of our volume (command + state echo)
         if (IsPlayerInActiveState(context.State))
@@ -1553,7 +1553,7 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
         context.Config.Volume = volume;
 
         // 2. Apply volume locally - player is authoritative for its own volume
-        context.Player.Volume = volume / 100.0f;
+        context.Player.Volume = VolumeCurve.ToGain(volume);
 
         // 3. Inform MA of our volume
         if (IsPlayerInActiveState(context.State))
@@ -3031,7 +3031,7 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
                 context.Config.Volume = serverVolume;
 
                 // Apply volume locally - player is authoritative for its own volume
-                context.Player.Volume = serverVolume / 100.0f;
+                context.Player.Volume = VolumeCurve.ToGain(serverVolume);
 
                 // Note: SDK 5.4.0 auto-acknowledges by sending client/state,
                 // so we don't need to call SendPlayerStateAsync manually

--- a/tests/MultiRoomAudio.Tests/VolumeCurveTests.cs
+++ b/tests/MultiRoomAudio.Tests/VolumeCurveTests.cs
@@ -1,0 +1,62 @@
+using MultiRoomAudio.Audio;
+using Xunit;
+
+namespace MultiRoomAudio.Tests;
+
+public class VolumeCurveTests
+{
+    [Fact]
+    public void Zero_IsSilent() => Assert.Equal(0f, VolumeCurve.ToGain(0));
+
+    [Fact]
+    public void OneHundred_IsUnityGain() => Assert.Equal(1f, VolumeCurve.ToGain(100));
+
+    [Theory]
+    [InlineData(-10)]
+    [InlineData(150)]
+    public void OutOfRangeInputs_AreClamped(int percent)
+    {
+        var gain = VolumeCurve.ToGain(percent);
+
+        Assert.InRange(gain, 0f, 1f);
+    }
+
+    [Theory]
+    [InlineData(50, 0.125)]
+    [InlineData(25, 0.015625)]
+    [InlineData(10, 0.001)]
+    public void FollowsACubicTaper(int percent, double expected)
+    {
+        // Matches PulseAudio's pa_sw_volume_to_linear, so software volume and the hardware
+        // volume applied via pactl behave the same way.
+        Assert.Equal(expected, VolumeCurve.ToGain(percent), precision: 6);
+    }
+
+    [Fact]
+    public void IsMonotonic()
+    {
+        for (var percent = 1; percent <= 100; percent++)
+            Assert.True(VolumeCurve.ToGain(percent) > VolumeCurve.ToGain(percent - 1),
+                $"gain at {percent} should exceed gain at {percent - 1}");
+    }
+
+    [Fact]
+    public void LowSettingsAreQuieterThanTheOldLinearTaper()
+    {
+        // The #263 report: level 2 was "already quite loud" because the old taper applied
+        // 0.02 amplitude (-34 dB) there rather than something proportionate.
+        Assert.True(VolumeCurve.ToGain(2) < 2 / 100.0f);
+        Assert.True(VolumeCurve.ToGain(20) < 20 / 100.0f);
+    }
+
+    [Fact]
+    public void SpreadsMoreRangeAcrossTheUpperHalfOfTheSlider()
+    {
+        // A linear taper puts only 6 dB between 50 and 100, which is why increments felt
+        // wrong. Cubic gives the top half a far wider span.
+        var linearSpan = 1.0f - 0.5f;
+        var cubicSpan = VolumeCurve.ToGain(100) - VolumeCurve.ToGain(50);
+
+        Assert.True(cubicSpan > linearSpan);
+    }
+}


### PR DESCRIPTION
Fixes #263.

## Problem

`PlayerManagerService` sets the SDK player's gain as a raw amplitude multiplier in four places:

```csharp
context.Player.Volume = volume / 100.0f;
```

Amplitude is linear in pressure, but loudness is perceived roughly logarithmically (≈ doubles per +10 dB). A linear taper is therefore **louder than the number suggests at every setting**, and compresses the useful range into the bottom of the slider:

| Slider | Linear gain | dB | ≈ Perceived |
|---:|---:|---:|---:|
| 50 | 0.50 | −6.0 | 66% |
| 25 | 0.25 | −12.0 | 43% |
| 10 | 0.10 | −20.0 | 25% |
| 2 | 0.02 | −34.0 | 9% |

That is exactly the report — "already quite loud at level 2" — and it also explains "the volume increments aren't correct": the entire top half of the slider spans only **6 dB**.

## Fix

Add `VolumeCurve.ToGain(int percent)` (`src/MultiRoomAudio/Audio/`) applying a **cubic** taper, and route all four assignment sites through it:

- `InitializeAndConnectPlayer` (startup volume)
- `SetVolumeAsync` (UI/API)
- `ApplyHardwareVolumeChangeAsync` (HID buttons)
- the server-initiated volume handler (Music Assistant)

Cubic is what the rest of the stack already uses — PulseAudio's `pa_sw_volume_to_linear` is literally `(v/PA_VOLUME_NORM)³`, and ALSA's mixers behave the same. So this also makes a player's software volume consistent with the hardware volume the add-on applies through `pactl`, rather than the two using different tapers.

## ⚠️ Behaviour change — needs your call

**Any given percentage is now quieter than before.** Existing users will open the UI after upgrading and find their players quieter, and will need to raise the volume once. There's no way to fix the taper without that, but it should be called out in the changelog and probably the release notes.

Two alternatives if you'd rather not take the full change:

1. **Gentler exponent** — `^1.67` is the closer perceptual match (loudness ∝ amplitude^0.6); cubic is more aggressive but is the established convention. One-line change.
2. **Migrate stored volumes** — on first run under the new curve, rewrite each player's saved `volume` to the value that reproduces its current gain (`round(100 · ∛(old/100))`, so 50 → 79). Preserves existing loudness across the upgrade at the cost of a one-shot migration in `ConfigurationService`.

I did **not** add a config toggle for the curve — that seemed like unrequested configurability for something there's one right answer to, but say the word.

## Verification

`dotnet test tests/MultiRoomAudio.Tests` — **92/92 passing** (90 before, plus `VolumeCurveTests`: endpoints, clamping, cubic values, monotonicity, and the two properties from the issue).

Not verified by ear — @chrisuthe this one really wants a listening check on real hardware before it leaves draft.