### PR TITLE
fix: stop UI trigger saves from clearing the zone name

### DIFF
--- a/src/MultiRoomAudio/Controllers/TriggersEndpoint.cs
+++ b/src/MultiRoomAudio/Controllers/TriggersEndpoint.cs
@@ -478,7 +478,8 @@ public static class TriggersEndpoint
 
             try
             {
-                service.ConfigureTrigger(boardId, channel, new List<string>(), 60, null);
+                // Empty (not null) zone name: unassigning must clear the name, not preserve it.
+                service.ConfigureTrigger(boardId, channel, new List<string>(), 60, "");
                 logger.LogInformation("Trigger channel {BoardId}/{Channel} unassigned", boardId, channel);
                 return Results.Ok(new SuccessResponse(true, $"Trigger channel {boardId}/{channel} unassigned"));
             }
@@ -741,7 +742,8 @@ public static class TriggersEndpoint
 
             try
             {
-                service.ConfigureTrigger(firstBoard.BoardId, channel, new List<string>(), 60, null);
+                // Empty (not null) zone name: unassigning must clear the name, not preserve it.
+                service.ConfigureTrigger(firstBoard.BoardId, channel, new List<string>(), 60, "");
                 logger.LogInformation("Trigger channel {Channel} unassigned on board {BoardId}",
                     channel, firstBoard.BoardId);
                 return Results.Ok(new SuccessResponse(true, $"Trigger channel {channel} unassigned"));

--- a/src/MultiRoomAudio/Models/TriggerModels.cs
+++ b/src/MultiRoomAudio/Models/TriggerModels.cs
@@ -457,7 +457,8 @@ public class TriggerConfigureRequest
     public int OffDelaySeconds { get; set; } = 60;
 
     /// <summary>
-    /// Optional friendly name for this zone.
+    /// Optional friendly name for this zone. Omit (or send null) to leave the current
+    /// name unchanged; send an empty string to clear it.
     /// </summary>
     [StringLength(100, ErrorMessage = "Zone name must be 100 characters or less.")]
     public string? ZoneName { get; set; }

--- a/src/MultiRoomAudio/Services/TriggerService.cs
+++ b/src/MultiRoomAudio/Services/TriggerService.cs
@@ -509,6 +509,10 @@ public class TriggerService : IAsyncDisposable
     /// <summary>
     /// Configure a trigger channel on a specific board.
     /// </summary>
+    /// <param name="zoneName">
+    /// Null leaves the existing zone name unchanged; an empty/whitespace string clears it.
+    /// Callers that omit the field (the web UI does) must not wipe a name set via the API.
+    /// </param>
     public bool ConfigureTrigger(string boardId, int channel, List<string> customSinkNames, int offDelaySeconds, string? zoneName)
     {
         var boardConfig = _config.Boards.FirstOrDefault(b => b.BoardId == boardId);
@@ -541,7 +545,13 @@ public class TriggerService : IAsyncDisposable
 
             trigger.CustomSinkNames = sinks;
             trigger.OffDelaySeconds = offDelaySeconds;
-            trigger.ZoneName = zoneName;
+
+            // Null means "not supplied" — preserve whatever is stored. Only an explicit
+            // empty string clears the name.
+            if (zoneName != null)
+            {
+                trigger.ZoneName = string.IsNullOrWhiteSpace(zoneName) ? null : zoneName;
+            }
 
             // If unassigning (no sinks), turn off the relay and cancel timer.
             if (sinks.Count == 0)
@@ -560,7 +570,7 @@ public class TriggerService : IAsyncDisposable
 
             SaveConfiguration();
             _logger.LogInformation("Trigger {BoardId}/{Channel} configured: sinks=[{Sinks}], delay={Delay}s, zone={Zone}",
-                boardId, channel, string.Join(", ", sinks), offDelaySeconds, zoneName ?? "(none)");
+                boardId, channel, string.Join(", ", sinks), offDelaySeconds, trigger.ZoneName ?? "(none)");
 
             return true;
         }

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -5615,6 +5615,8 @@ async function saveTriggerSinks(boardId, channel) {
     const names = t ? (t.customSinkNames || []) : [];
     const delayInput = document.getElementById(`trigger-delay-${boardIdSafe}-${channel}`);
     const delay = coerceOffDelay(delayInput ? delayInput.value : null, t ? t.offDelaySeconds : 60);
+    // Round-trip the zone name (set via API/MQTT, no UI field) so this save doesn't drop it.
+    const zoneName = t ? (t.zoneName ?? null) : null;
 
     try {
         const url = boardId.includes('/')
@@ -5623,7 +5625,7 @@ async function saveTriggerSinks(boardId, channel) {
         const response = await fetch(url, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds: delay })
+            body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds: delay, zoneName })
         });
         if (!response.ok) {
             const error = await response.json();
@@ -5646,6 +5648,8 @@ async function updateTriggerDelay(boardId, channel, delay) {
     const t = getTrigger(boardId, channel);
     const names = t ? (t.customSinkNames || []) : [];
     const offDelaySeconds = coerceOffDelay(delay, t ? t.offDelaySeconds : 60);
+    // Round-trip the zone name (set via API/MQTT, no UI field) so this save doesn't drop it.
+    const zoneName = t ? (t.zoneName ?? null) : null;
 
     try {
         const url = boardId.includes('/')
@@ -5654,7 +5658,7 @@ async function updateTriggerDelay(boardId, channel, delay) {
         const response = await fetch(url, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds })
+            body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds, zoneName })
         });
 
         if (!response.ok) {

--- a/src/MultiRoomAudio/wwwroot/js/wizard.js
+++ b/src/MultiRoomAudio/wwwroot/js/wizard.js
@@ -1631,6 +1631,8 @@ const Wizard = {
     async wizardSaveTriggerSinks(boardId, channel) {
         const t = this.wizardGetTrigger(boardId, channel);
         const names = t ? (t.customSinkNames || []) : [];
+        // Round-trip the zone name (set via API/MQTT, no UI field) so this save doesn't drop it.
+        const zoneName = t ? (t.zoneName ?? null) : null;
 
         try {
             // Ensure the feature is enabled before the first assignment.
@@ -1646,7 +1648,7 @@ const Wizard = {
                 : `./api/triggers/boards/${encodeURIComponent(boardId)}/${channel}`;
             const response = await fetch(url, {
                 method: 'PUT', headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds: 60 })
+                body: JSON.stringify({ channel, customSinkNames: names, offDelaySeconds: 60, zoneName })
             });
             if (!response.ok) {
                 const error = await response.json();

--- a/tests/MultiRoomAudio.Tests/Services/TriggerZoneNameTests.cs
+++ b/tests/MultiRoomAudio.Tests/Services/TriggerZoneNameTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using MultiRoomAudio.Models;
+using MultiRoomAudio.Relay;
+using MultiRoomAudio.Services;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Services;
+
+/// <summary>
+/// ZoneName is set only through the API and read only by HA MQTT discovery (it names the
+/// amplifier-zone device and its entities). The web UI never sends it, so ConfigureTrigger
+/// must treat an absent zoneName as "leave unchanged" rather than "clear".
+/// </summary>
+public class TriggerZoneNameTests
+{
+    private static (TriggerService svc, string boardId) Setup()
+    {
+        var svc = TriggerTestHarness.CreateMockService();
+        svc.SetEnabled(true);
+        var boardId = "VIRTUAL:zone01";
+        svc.AddBoard(boardId, "Test", channelCount: 2, boardType: RelayBoardType.Virtual);
+        return (svc, boardId);
+    }
+
+    private static TriggerResponse Channel(TriggerService svc, string boardId, int channel)
+        => svc.GetBoardStatus(boardId)!.Triggers.Single(t => t.Channel == channel);
+
+    [Fact]
+    public void NullZoneName_PreservesExistingName()
+    {
+        var (svc, boardId) = Setup();
+        svc.ConfigureTrigger(boardId, 1, new List<string> { "zoneA" }, 30, "Living Room");
+
+        // Mimics a UI save: sinks and delay only, no zoneName key in the JSON body.
+        svc.ConfigureTrigger(boardId, 1, new List<string> { "zoneA", "zoneB" }, 45, null);
+
+        Assert.Equal("Living Room", Channel(svc, boardId, 1).ZoneName);
+    }
+
+    [Fact]
+    public void EmptyZoneName_ClearsExistingName()
+    {
+        var (svc, boardId) = Setup();
+        svc.ConfigureTrigger(boardId, 1, new List<string> { "zoneA" }, 30, "Living Room");
+
+        svc.ConfigureTrigger(boardId, 1, new List<string> { "zoneA" }, 30, "");
+
+        Assert.Null(Channel(svc, boardId, 1).ZoneName);
+    }
+
+    [Fact]
+    public void NonEmptyZoneName_OverwritesExistingName()
+    {
+        var (svc, boardId) = Setup();
+        svc.ConfigureTrigger(boardId, 1, new List<string> { "zoneA" }, 30, "Living Room");
+
+        svc.ConfigureTrigger(boardId, 1, new List<string> { "zoneA" }, 30, "Kitchen");
+
+        Assert.Equal("Kitchen", Channel(svc, boardId, 1).ZoneName);
+    }
+}


### PR DESCRIPTION
## Problem

`TriggerService.ConfigureTrigger` assigned `trigger.ZoneName = zoneName` unconditionally, but neither `app.js` nor `wizard.js` includes `zoneName` in its PUT body. An absent JSON key deserializes to `null`, so **any** UI save — adding a sink chip, removing one, or nudging the off delay — silently wiped a zone name that had been set through the API.

That is the only way a zone name gets set: nothing in the UI exposes the field.

The damage shows up in Home Assistant. `HaDiscovery.ForAmp` builds the amplifier-zone device name and every entity name under it from `ZoneName`, falling back to `"{boardId} CH{n}"`. So a routine sink tweak renamed a user's entities from `Living Room Power` to `HID:CA88BCAC CH3 Power`.

Pre-existing; not introduced by #255.

## Fix

Two halves, deliberately belt-and-braces:

1. **Service-side (protects every caller).** `ConfigureTrigger` now treats `null` as "not supplied" and leaves the stored name alone; an empty/whitespace string clears it. `System.Text.Json` cannot distinguish an omitted key from an explicit `null`, so the empty string is the escape hatch for callers that genuinely want to clear. This covers curl, HA REST commands, and any future partial-update client — not just the two frontends this repo ships.
2. **UI-side (keeps the payload honest).** `app.js` and `wizard.js` round-trip the current value, so a reader of those fetch bodies can see the field exists rather than inferring it from a service-layer convention.

Both unassign paths (`DELETE /boards/{boardId}/{channel}` and the legacy `DELETE /{channel}`) now pass `""` instead of `null`, since they relied on `null` clearing the name.

The `zone=` log line now reports `trigger.ZoneName` rather than the argument — with the new semantics the argument no longer reflects what was stored.

## Tests

New `TriggerZoneNameTests` covering the three cases: `null` preserves, `""` clears, a non-empty value overwrites. The first two fail on `dev` and pass here.

```
Passed!  -  Failed: 0, Passed: 85, Skipped: 0, Total: 85
```