### PR TITLE
Standardize remap sink naming and disambiguate duplicate sound cards

### DIFF
--- a/docs/CUSTOM_SINKS.md
+++ b/docs/CUSTOM_SINKS.md
@@ -103,6 +103,31 @@ A remap sink extracts specific channels from a multi-channel device and presents
 4. Click **Create**
 5. Use the **Test** button to verify audio plays on the correct channels
 
+### Default Naming
+
+Picking a master device and channel mapping fills in the name and description for you, so
+remap sinks are named consistently instead of falling back to PulseAudio's own
+`Remapped <card>` label.
+
+| Field | Generated from | Example |
+|-------|----------------|---------|
+| **Name** | Device slug + abbreviated channels | `Creative_X_Fi_Analog_Surround_7_1_fl_fr` |
+| **Description** | Device name + channel labels | `Creative X-Fi Analog Surround 7.1 Front Left Front Right` |
+
+Channel abbreviations are `fl`, `fr`, `fc`, `lfe`, `rl`, `rr`, `sl`, `sr`. A second sink on
+the same device and channels gets a `_2` suffix so it does not collide.
+
+Both fields stay in sync with the form until you type in them - the first manual edit to a
+field stops it regenerating, and the other field keeps updating. Reopening the dialog for a
+new sink starts fresh. Editing an existing sink never rewrites its name or description.
+
+### Duplicate Devices
+
+Two identical sound cards report the same description, which used to make them
+indistinguishable in the device lists. Where names collide, the UI appends the ALSA card
+number - `Creative X-Fi Analog Surround 7.1 (card 1)` and `... (card 4)`. Devices with
+unique names are shown unchanged.
+
 ### Example: 4-Channel DAC Split
 
 A 4-channel USB DAC with channels:
@@ -165,13 +190,18 @@ Under the hood, this creates a PulseAudio `module-remap-sink`:
 ```
 pactl load-module module-remap-sink \
   sink_name=bedroom \
-  sink_properties=device.description="Bedroom" \
+  sink_properties="device.description='Bedroom Rear Speakers'" \
   master=alsa_output.usb-4ch_DAC \
   channels=2 \
   channel_map=front-left,front-right \
   master_channel_map=rear-left,rear-right \
   remix=no
 ```
+
+The description is quoted twice on purpose: pactl's module argument parser strips the outer
+double quotes, then PulseAudio's proplist parser strips the inner single quotes. A single
+level of quoting fails with "Module initialization failed", which is why descriptions used
+to reach Home Assistant with underscores in place of spaces.
 
 ---
 
@@ -231,8 +261,10 @@ This allows you to manage previously-created sinks through the web interface wit
 
 ### Naming Conventions
 
-- Use lowercase letters with underscores: `living_room`, `kitchen_dining`
-- Avoid spaces and special characters
+- For remap sinks, accept the generated name unless you have a reason not to - it already
+  encodes the device and channels
+- Otherwise use lowercase letters with underscores: `living_room`, `kitchen_dining`
+- Avoid spaces and special characters in names; descriptions may contain them
 - Keep names short but descriptive
 
 ### Order of Creation

--- a/docs/CUSTOM_SINKS.md
+++ b/docs/CUSTOM_SINKS.md
@@ -124,9 +124,14 @@ new sink starts fresh. Editing an existing sink never rewrites its name or descr
 ### Duplicate Devices
 
 Two identical sound cards report the same description, which used to make them
-indistinguishable in the device lists. Where names collide, the UI appends the ALSA card
-number - `Creative X-Fi Analog Surround 7.1 (card 1)` and `... (card 4)`. Devices with
-unique names are shown unchanged.
+indistinguishable in the device lists. Where names collide, the UI appends the card number -
+`Creative X-Fi Analog Surround 7.1 (card 1)` and `... (card 4)`. Devices with unique names
+are shown unchanged.
+
+The number is the ALSA card number, the one `aplay -l` shows. A card whose profile is off
+has no sink to read it from, so if any card in the list is in that state the whole list
+falls back to PulseAudio card indices instead - mixing the two numbering systems in one list
+could otherwise give two different cards the same number.
 
 ### Example: 4-Channel DAC Split
 
@@ -185,7 +190,9 @@ Standard PulseAudio channel names:
 
 ### Technical Details
 
-Under the hood, this creates a PulseAudio `module-remap-sink`:
+Under the hood, this creates a PulseAudio `module-remap-sink`. This is the command the app
+issues, not a line to paste into `default.pa` - the quoting below is specific to passing a
+description through `pactl`:
 
 ```
 pactl load-module module-remap-sink \

--- a/docs/CUSTOM_SINKS.md
+++ b/docs/CUSTOM_SINKS.md
@@ -190,9 +190,7 @@ Standard PulseAudio channel names:
 
 ### Technical Details
 
-Under the hood, this creates a PulseAudio `module-remap-sink`. This is the command the app
-issues, not a line to paste into `default.pa` - the quoting below is specific to passing a
-description through `pactl`:
+Under the hood, this creates a PulseAudio `module-remap-sink`:
 
 ```
 pactl load-module module-remap-sink \
@@ -205,10 +203,16 @@ pactl load-module module-remap-sink \
   remix=no
 ```
 
-The description is quoted twice on purpose: pactl's module argument parser strips the outer
-double quotes, then PulseAudio's proplist parser strips the inner single quotes. A single
-level of quoting fails with "Module initialization failed", which is why descriptions used
-to reach Home Assistant with underscores in place of spaces.
+The description is quoted twice on purpose: PulseAudio's module argument parser strips the
+outer double quotes, then its proplist parser strips the inner single quotes. A single level
+of quoting fails with "Module initialization failed", which is why descriptions used to
+reach Home Assistant with underscores in place of spaces.
+
+The same applies to a hand-written `default.pa` - `pactl` and `default.pa` go through the
+same argument parser, so a description with spaces needs both levels there too. The inner
+and outer quote styles can be swapped (`sink_properties='device.description="Bedroom Rear"'`
+works equally well), but one level of either, or a backslash-escaped space, silently fails
+to load the module.
 
 ---
 

--- a/multiroom-audio/CHANGELOG.md
+++ b/multiroom-audio/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Identical sound cards are now tellable apart. Where two cards or devices share a description, the Sound Cards list, the player device dropdowns, the remap master picker and the wizard's device lists append the ALSA card number - "Creative X-Fi Analog Surround 7.1 (card 1)" vs "... (card 4)". Devices with unique names are unchanged (#282)
 
 ### Fixed
+- The onboarding wizard sees pre-existing custom sinks again. It read `/api/sinks` as a bare array when the endpoint returns `{ sinks, count }`, so the list silently came back empty. Step 4 now offers sinks created before the wizard ran as player targets, and stops offering the hardware devices those sinks already consume as master or slave
 - Custom sink descriptions keep their spaces. They used to reach Home Assistant with underscores ("Front_Left_Front_Right") because PulseAudio's proplist parser rejected the unquoted value; quoting it twice gets it through intact. A description of only quote characters also no longer fails sink creation outright (#282)
 
 ### Changed

--- a/multiroom-audio/CHANGELOG.md
+++ b/multiroom-audio/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Remap sinks name themselves. Picking a master device and channel mapping prefills both the sink name and the description - `Creative_X_Fi_Analog_Surround_7_1_fl_fr` / "Creative X-Fi Analog Surround 7.1 Front Left Front Right" - instead of leaving PulseAudio to invent "Remapped <card>". Both fields keep regenerating until you type in them, in the main UI and the onboarding wizard alike (#282)
+- Identical sound cards are now tellable apart. Where two cards or devices share a description, the Sound Cards list, the player device dropdowns, the remap master picker and the wizard's device lists append the ALSA card number - "Creative X-Fi Analog Surround 7.1 (card 1)" vs "... (card 4)". Devices with unique names are unchanged (#282)
+
+### Fixed
+- Custom sink descriptions keep their spaces. They used to reach Home Assistant with underscores ("Front_Left_Front_Right") because PulseAudio's proplist parser rejected the unquoted value; quoting it twice gets it through intact. A description of only quote characters also no longer fails sink creation outright (#282)
+
+### Changed
+- **After upgrading, existing custom sinks are renamed in Home Assistant and Music Assistant.** Sinks reload from `custom-sinks.yaml` on restart and now register their stored description verbatim, so underscores become spaces and `_and_` becomes `&`. Sink names, players and configuration are untouched - only the display name changes, and you may need to fix up entity names on the Home Assistant side
+
 ## [5.2.2] - Volume Curve, MQTT Volume & Trigger Fixes
 
 Rolls up everything since 5.2.0 (the 5.2.1 combine-sink fix was never tagged).

--- a/src/MultiRoomAudio/Utilities/PaModuleRunner.cs
+++ b/src/MultiRoomAudio/Utilities/PaModuleRunner.cs
@@ -70,31 +70,41 @@ public partial class PaModuleRunner : IPaModuleRunner
     }
 
     /// <summary>
-    /// Sanitizes a description string for use in device.description property.
-    /// PulseAudio has a known bug where property values with spaces fail to parse
-    /// (see https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/issues/615).
-    /// We replace spaces with underscores as the standard workaround.
-    /// The original description with spaces is preserved in YAML/UI.
+    /// Strips characters that would break out of the quoting applied by
+    /// <see cref="BuildDescriptionArg"/>, or that PulseAudio cannot carry in a
+    /// property value at all.
     /// </summary>
-    private static string SanitizeDescription(string description)
+    internal static string SanitizeDescription(string description)
     {
         if (string.IsNullOrWhiteSpace(description))
             return description;
 
-        // Sanitize for PulseAudio property values
-        // PulseAudio has a bug where spaces in property values cause "Failed to parse proplist"
-        // See: https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/issues/615
-        // Replace spaces with underscores as the workaround
         return description
-            .Replace("\\", "")      // Remove backslashes (escape character)
-            .Replace("\"", "")      // Remove double quotes
-            .Replace("'", "")       // Remove single quotes
-            .Replace(" ", "_")      // Replace spaces with underscores (PulseAudio bug workaround)
-            .Replace("&", "_and_")  // Replace & with _and_ for readability
-            .Replace("\n", "_")     // Replace newlines with underscores
+            .Replace("\\", "")      // Escape character - would consume the following char
+            .Replace("\"", "")      // Would terminate the outer (modargs) quoting
+            .Replace("'", "")       // Would terminate the inner (proplist) quoting
+            .Replace("\n", " ")     // Proplist values are single-line
             .Replace("\r", "")      // Remove carriage returns
             .Replace("\0", "")      // Remove null chars
             .Trim();
+    }
+
+    /// <summary>
+    /// Builds the <c>sink_properties</c> argument that sets <c>device.description</c>.
+    /// </summary>
+    /// <remarks>
+    /// The value needs two levels of quoting to survive with spaces intact: pactl's module
+    /// argument parser strips the outer double quotes, then PulseAudio's proplist parser
+    /// strips the inner single quotes. A single level of either quote, or backslash-escaped
+    /// spaces, fails with "Module initialization failed" - which is what the old
+    /// space-to-underscore substitution was working around
+    /// (https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/issues/615).
+    /// Verified against PulseAudio 16.1, the version shipped in the container image.
+    /// </remarks>
+    internal static string BuildDescriptionArg(string description)
+    {
+        var safeDesc = SanitizeDescription(description);
+        return $"sink_properties=\"device.description='{safeDesc}'\"";
     }
 
     /// <summary>
@@ -145,9 +155,7 @@ public partial class PaModuleRunner : IPaModuleRunner
         // Add description if provided
         if (!string.IsNullOrWhiteSpace(description))
         {
-            var safeDesc = SanitizeDescription(description);
-            // No quotes needed - spaces are replaced with underscores due to PulseAudio bug
-            args.Add($"sink_properties=device.description={safeDesc}");
+            args.Add(BuildDescriptionArg(description));
         }
 
         _logger.LogInformation("Loading combine-sink '{SinkName}' with {SlaveCount} slaves. Args: {Args}",
@@ -242,9 +250,7 @@ public partial class PaModuleRunner : IPaModuleRunner
         // Add description if provided
         if (!string.IsNullOrWhiteSpace(description))
         {
-            var safeDesc = SanitizeDescription(description);
-            // No quotes needed - spaces are replaced with underscores due to PulseAudio bug
-            args.Add($"sink_properties=device.description={safeDesc}");
+            args.Add(BuildDescriptionArg(description));
         }
 
         _logger.LogInformation("Loading remap-sink '{SinkName}' from master '{Master}' with {Channels} channels. Args: {Args}",

--- a/src/MultiRoomAudio/wwwroot/index.html
+++ b/src/MultiRoomAudio/wwwroot/index.html
@@ -383,13 +383,15 @@
                                 <div class="mb-3">
                                     <label for="remapSinkName" class="form-label">Sink Name</label>
                                     <input type="text" class="form-control" id="remapSinkName"
-                                           required placeholder="zone1_stereo">
+                                           required placeholder="zone1_stereo"
+                                           oninput="markRemapFieldEdited('name')">
                                     <small class="text-muted">Letters, numbers, underscores, hyphens only</small>
                                 </div>
                                 <div class="mb-3">
                                     <label for="remapSinkDesc" class="form-label">Description (optional)</label>
                                     <input type="text" class="form-control" id="remapSinkDesc"
-                                           placeholder="Surround Card - Front Speakers">
+                                           placeholder="Surround Card - Front Speakers"
+                                           oninput="markRemapFieldEdited('desc')">
                                 </div>
                                 <div class="mb-3">
                                     <label for="remapMasterDevice" class="form-label">Master Device</label>

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -3683,11 +3683,15 @@ function renderSoundCards(savedScrollTop = 0) {
         return soundCardDevices.find(d => d.id && d.id.includes(cardBase));
     };
 
-    // Two identical cards share a description, so fall back to the card number
+    // Two identical cards share a description, so fall back to the card number. device.cardIndex
+    // is the ALSA card number and card.index the PulseAudio one; numbering them from both at once
+    // can hand two cards the same "(card N)", so use ALSA only when every card has one. An
+    // off-profile card matches a placeholder device that carries no cardIndex.
+    const useAlsaCardNumbers = soundCards.every(c => findCardDevice(c)?.cardIndex != null);
     const cardLabel = makeCardDisambiguator(
         soundCards,
         c => c.description || c.name,
-        c => findCardDevice(c)?.cardIndex ?? c.index
+        c => useAlsaCardNumbers ? findCardDevice(c).cardIndex : c.index
     );
 
     const accordionHtml = soundCards.map((card, index) => {

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -1025,6 +1025,13 @@ async function refreshDevices(currentDeviceId = null) {
             return true;
         });
 
+        // Identically-described cards are only tellable apart by their card number
+        const hardwareLabel = makeCardDisambiguator(
+            visibleDevices.filter(d => !d.sinkType),
+            d => d.name,
+            d => d.cardIndex
+        );
+
         // Update device selects
         const selects = document.querySelectorAll('#audioDevice, #editAudioDevice');
         selects.forEach(select => {
@@ -1039,9 +1046,9 @@ async function refreshDevices(currentDeviceId = null) {
                     // Custom sink: show "Sink: name (description)" if description exists
                     displayName = device.alias ? `Sink: ${device.name} (${device.alias})` : `Sink: ${device.name}`;
                 } else {
-                    // Hardware device: use device.name directly (already correct from PulseAudio)
-                    // (cardDescriptions map uses PulseAudio index but device.cardIndex is ALSA card number)
-                    const cardName = device.name;
+                    // Hardware device: device.name is already correct from PulseAudio, but
+                    // duplicate cards share it, so add the card number when it repeats.
+                    const cardName = hardwareLabel(device);
                     displayName = device.alias ? `Device: ${cardName} (${device.alias})` : `Device: ${cardName}`;
                 }
                 if (device.isDefault) displayName += ' (default)';
@@ -2750,6 +2757,54 @@ function getSinkStateBadgeClass(state) {
 let editingCombineSink = null;
 let editingRemapSink = null;
 
+// Autofill stops for a field once the user types in it, until the modal is reopened
+let remapNameEdited = false;
+let remapDescEdited = false;
+
+// Labels the master-device dropdown's entries; rebuilt whenever the dropdown is populated
+// so generated names carry the same "(card N)" suffix the user sees.
+let remapMasterLabel = (device) => device.alias || device.name;
+
+// Called from the name/description inputs' oninput handlers
+function markRemapFieldEdited(field) {
+    if (field === 'name') remapNameEdited = true;
+    else if (field === 'desc') remapDescEdited = true;
+}
+
+// Currently selected master channels, in output order (one entry in mono mode)
+function getSelectedRemapChannels() {
+    if (document.getElementById('outputModeMono')?.checked) {
+        return [document.getElementById('monoChannel')?.value];
+    }
+    return [
+        document.getElementById('leftChannel')?.value,
+        document.getElementById('rightChannel')?.value
+    ];
+}
+
+// Regenerate the default name/description from the current master device and channels,
+// leaving alone whichever fields the user has already typed in.
+function autofillRemapSinkNaming() {
+    if (editingRemapSink) return;
+    if (remapNameEdited && remapDescEdited) return;
+
+    const masterSelect = document.getElementById('remapMasterDevice');
+    const master = devices.find(d => d.id === masterSelect?.value);
+    if (!master) return;
+
+    // Sink names share one PulseAudio namespace with hardware sinks
+    const taken = [...Object.keys(customSinks), ...devices.map(d => d.id)];
+    const defaults = buildRemapSinkDefaults(
+        remapMasterLabel(master),
+        getSelectedRemapChannels(),
+        taken
+    );
+    if (!defaults.name) return;
+
+    if (!remapNameEdited) document.getElementById('remapSinkName').value = defaults.name;
+    if (!remapDescEdited) document.getElementById('remapSinkDesc').value = defaults.description;
+}
+
 // Cached modal instances to avoid creating duplicates
 let combineSinkModalInstance = null;
 let remapSinkModalInstance = null;
@@ -2829,6 +2884,10 @@ function openRemapSinkModal(editData = null) {
     // Track if editing
     editingRemapSink = editData;
 
+    // A fresh create starts with both fields eligible for autofill again
+    remapNameEdited = false;
+    remapDescEdited = false;
+
     // Update modal title based on mode
     const modalTitle = document.querySelector('#remapSinkModal .modal-title');
     if (modalTitle) {
@@ -2858,10 +2917,15 @@ function openRemapSinkModal(editData = null) {
         if (d.hidden && d.id !== currentMaster) return false;
         return true;
     });
+    remapMasterLabel = makeCardDisambiguator(
+        eligibleDevices,
+        d => d.alias || d.name,
+        d => d.cardIndex
+    );
     masterSelect.innerHTML = '<option value="">Select a device...</option>' +
         eligibleDevices.map(d => {
             const hiddenNote = d.hidden ? ' (hidden)' : '';
-            return `<option value="${escapeHtml(d.id)}">${escapeHtml(d.alias || d.name)} (${d.maxChannels}ch)${hiddenNote}</option>`;
+            return `<option value="${escapeHtml(d.id)}">${escapeHtml(remapMasterLabel(d))} (${d.maxChannels}ch)${hiddenNote}</option>`;
         }).join('');
 
     // Set master device if editing
@@ -2962,7 +3026,8 @@ function updateChannelPicker() {
             <div class="channel-pair mb-2 d-flex align-items-center">
                 <span class="output-label">Output</span>
                 <i class="fas fa-arrow-left mx-2 text-muted"></i>
-                <select class="form-select form-select-sm channel-select" id="monoChannel">
+                <select class="form-select form-select-sm channel-select" id="monoChannel"
+                        onchange="autofillRemapSinkNaming()">
                     ${optionsHtml}
                 </select>
                 <button class="btn btn-outline-primary btn-sm ms-2"
@@ -2980,7 +3045,8 @@ function updateChannelPicker() {
             <div class="channel-pair mb-2 d-flex align-items-center">
                 <span class="output-label">Left Output</span>
                 <i class="fas fa-arrow-left mx-2 text-muted"></i>
-                <select class="form-select form-select-sm channel-select" id="leftChannel">
+                <select class="form-select form-select-sm channel-select" id="leftChannel"
+                        onchange="autofillRemapSinkNaming()">
                     ${optionsHtml}
                 </select>
                 <button class="btn btn-outline-primary btn-sm ms-2"
@@ -2993,7 +3059,8 @@ function updateChannelPicker() {
             <div class="channel-pair mb-2 d-flex align-items-center">
                 <span class="output-label">Right Output</span>
                 <i class="fas fa-arrow-left mx-2 text-muted"></i>
-                <select class="form-select form-select-sm channel-select" id="rightChannel">
+                <select class="form-select form-select-sm channel-select" id="rightChannel"
+                        onchange="autofillRemapSinkNaming()">
                     ${optionsHtml}
                 </select>
                 <button class="btn btn-outline-primary btn-sm ms-2"
@@ -3007,6 +3074,8 @@ function updateChannelPicker() {
         document.getElementById('leftChannel').value = 'front-left';
         document.getElementById('rightChannel').value = 'front-right';
     }
+
+    autofillRemapSinkNaming();
 }
 
 // Create or update combine sink
@@ -3606,6 +3675,21 @@ function renderSoundCards(savedScrollTop = 0) {
     // Only auto-expand if exactly 1 device AND no saved state
     const shouldAutoExpand = soundCards.length === 1 && !expandedDeviceState;
 
+    // Match a card to its device by name pattern:
+    // For ALSA cards: alsa_card.pci-0000_00_1f.3 -> alsa_output.pci-0000_00_1f.3.analog-stereo
+    // For Bluetooth: bluez_card.00_1A_7D_DA_71_13 -> bluez_sink.00_1A_7D_DA_71_13.a2dp_sink
+    const findCardDevice = (card) => {
+        const cardBase = card.name.replace('alsa_card.', '').replace('bluez_card.', '');
+        return soundCardDevices.find(d => d.id && d.id.includes(cardBase));
+    };
+
+    // Two identical cards share a description, so fall back to the card number
+    const cardLabel = makeCardDisambiguator(
+        soundCards,
+        c => c.description || c.name,
+        c => findCardDevice(c)?.cardIndex ?? c.index
+    );
+
     const accordionHtml = soundCards.map((card, index) => {
         const cardKey = card.index.toString();
         const isExpanded = expandedDeviceState === cardKey || (shouldAutoExpand && index === 0);
@@ -3637,14 +3721,10 @@ function renderSoundCards(savedScrollTop = 0) {
         const busIcon = getBusTypeIcon(busType);
         const busLabel = getBusTypeLabel(busType);
 
-        // Find the device associated with this card by matching name patterns
-        // For ALSA cards: alsa_card.pci-0000_00_1f.3 -> alsa_output.pci-0000_00_1f.3.analog-stereo
-        // For Bluetooth: bluez_card.00_1A_7D_DA_71_13 -> bluez_sink.00_1A_7D_DA_71_13.a2dp_sink
-        const cardBase = card.name.replace('alsa_card.', '').replace('bluez_card.', '');
-        const device = soundCardDevices.find(d => d.id && d.id.includes(cardBase));
+        const device = findCardDevice(card);
         const deviceAlias = device?.alias || '';
         const deviceId = device?.id || '';
-        const deviceName = card.description || card.name;
+        const deviceName = cardLabel(card);
         const maxVolumeDisplay = card.maxVolume !== null && card.maxVolume !== undefined ? card.maxVolume : 100;
         const isHidden = device?.hidden || false;
 

--- a/src/MultiRoomAudio/wwwroot/js/utils.js
+++ b/src/MultiRoomAudio/wwwroot/js/utils.js
@@ -96,3 +96,87 @@ function showPrompt(title, label, defaultValue = '', placeholder = '') {
         });
     });
 }
+
+// ========== Remap Sink Naming ==========
+// Shared by the main app's Create Remap Sink modal and the onboarding wizard so both
+// generate identical defaults.
+
+// PulseAudio channel value -> friendly label / short name-suffix abbreviation
+const REMAP_CHANNEL_INFO = {
+    'front-left': { label: 'Front Left', abbrev: 'fl' },
+    'front-right': { label: 'Front Right', abbrev: 'fr' },
+    'front-center': { label: 'Front Center', abbrev: 'fc' },
+    'lfe': { label: 'LFE', abbrev: 'lfe' },
+    'rear-left': { label: 'Rear Left', abbrev: 'rl' },
+    'rear-right': { label: 'Rear Right', abbrev: 'rr' },
+    'side-left': { label: 'Side Left', abbrev: 'sl' },
+    'side-right': { label: 'Side Right', abbrev: 'sr' }
+};
+
+// Longest name and description RemapSinkCreateRequest will accept
+const REMAP_SINK_NAME_MAX = 100;
+const REMAP_SINK_DESC_MAX = 200;
+
+// Reduce a device description to the character set a sink name allows.
+function slugifySinkName(text) {
+    return (text || '')
+        .replace(/[^a-zA-Z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '');
+}
+
+// Build the name/description a remap sink gets by default.
+// masterLabel: the master device's display name (e.g. "Creative X-Fi Analog Surround 7.1")
+// channels:    selected master channel values, in output order (one entry for mono)
+// existingNames: names already taken, used to pick a non-colliding suffix
+function buildRemapSinkDefaults(masterLabel, channels, existingNames = []) {
+    const picked = (channels || []).filter(Boolean);
+    if (!masterLabel || picked.length === 0) {
+        return { name: '', description: '' };
+    }
+
+    const labels = picked.map(ch => REMAP_CHANNEL_INFO[ch]?.label || ch);
+    const description = `${masterLabel} ${labels.join(' ')}`.slice(0, REMAP_SINK_DESC_MAX).trim();
+
+    const channelSuffix = picked.map(ch => REMAP_CHANNEL_INFO[ch]?.abbrev || slugifySinkName(ch)).join('_');
+    const taken = new Set(existingNames);
+
+    // The channel suffix is what makes the name meaningful, so the device slug is what
+    // gives way when the 100-char cap bites.
+    const compose = (ordinal) => {
+        const tail = ordinal > 1 ? `_${channelSuffix}_${ordinal}` : `_${channelSuffix}`;
+        let slug = slugifySinkName(masterLabel) || 'remap';
+        if (slug.length + tail.length > REMAP_SINK_NAME_MAX) {
+            slug = slug.slice(0, Math.max(1, REMAP_SINK_NAME_MAX - tail.length)).replace(/_+$/, '') || 'remap';
+        }
+        return `${slug}${tail}`.slice(0, REMAP_SINK_NAME_MAX);
+    };
+
+    let ordinal = 1;
+    let name = compose(ordinal);
+    while (taken.has(name) && ordinal < 100) {
+        name = compose(++ordinal);
+    }
+
+    return { name, description };
+}
+
+// ========== Duplicate Device Disambiguation ==========
+
+// Build a label function that appends "(card N)" only to labels shared by more than one
+// entry, so identical sound cards stay tellable apart without noise on unique ones.
+// getCardNumber should prefer the ALSA card number and fall back to the PulseAudio index.
+function makeCardDisambiguator(items, getLabel, getCardNumber) {
+    const counts = new Map();
+    (items || []).forEach(item => {
+        const label = getLabel(item);
+        counts.set(label, (counts.get(label) || 0) + 1);
+    });
+
+    return (item) => {
+        const label = getLabel(item);
+        if ((counts.get(label) || 0) < 2) return label;
+        const cardNumber = getCardNumber(item);
+        if (cardNumber === null || cardNumber === undefined || cardNumber === '') return label;
+        return `${label} (card ${cardNumber})`;
+    };
+}

--- a/src/MultiRoomAudio/wwwroot/js/utils.js
+++ b/src/MultiRoomAudio/wwwroot/js/utils.js
@@ -151,9 +151,12 @@ function buildRemapSinkDefaults(masterLabel, channels, existingNames = []) {
         return `${slug}${tail}`.slice(0, REMAP_SINK_NAME_MAX);
     };
 
+    // Trying one more ordinal than there are taken names guarantees a free one, so the
+    // bound can never make us hand back a name we know collides.
+    const limit = taken.size + 2;
     let ordinal = 1;
     let name = compose(ordinal);
-    while (taken.has(name) && ordinal < 100) {
+    while (taken.has(name) && ordinal < limit) {
         name = compose(++ordinal);
     }
 

--- a/src/MultiRoomAudio/wwwroot/js/wizard.js
+++ b/src/MultiRoomAudio/wwwroot/js/wizard.js
@@ -141,7 +141,10 @@ const Wizard = {
         try {
             const response = await fetch('./api/sinks');
             if (response.ok) {
-                const sinks = await response.json();
+                // The endpoint returns { sinks, count }, not a bare array - calling map on
+                // the envelope threw into the catch below and left customSinks empty
+                const data = await response.json();
+                const sinks = data.sinks || [];
                 // Store sinks with their slaves/masterSink info for filtering
                 this.customSinks = sinks.map(s => ({
                     id: s.sinkName || s.name,

--- a/src/MultiRoomAudio/wwwroot/js/wizard.js
+++ b/src/MultiRoomAudio/wwwroot/js/wizard.js
@@ -548,15 +548,17 @@ const Wizard = {
             `;
         }
 
+        // device.name already carries the correct name from the PulseAudio sink description,
+        // but two identical cards share it, so add the card number when it repeats.
+        // (card.index is the PulseAudio card index, a different numbering system from
+        // device.cardIndex - don't look one up by the other.)
+        const deviceLabel = makeCardDisambiguator(this.devices, d => d.name, d => d.cardIndex);
+
         const deviceHtml = this.devices.map(device => {
             const isHidden = this.deviceState[device.id]?.hidden || device.hidden || false;
             const alias = this.deviceState[device.id]?.alias || device.alias || '';
             const portHint = parseUsbPortHint(device.identifiers?.busPath);
-
-            // Use device.name directly - it already contains the correct name from PulseAudio sink description
-            // (Previous code tried to look up card by cardIndex, but cardIndex is ALSA card number
-            // while card.index is PulseAudio card index - different numbering systems!)
-            const displayName = device.name;
+            const displayName = deviceLabel(device);
 
             return `
                 <div class="list-group-item position-relative ${isHidden ? 'device-hidden' : ''}" id="device-row-${escapeHtml(device.id)}">
@@ -626,12 +628,60 @@ const Wizard = {
         `;
     },
 
+    // Autofill stops for a field once the user types in it
+    remapNameEdited: false,
+    remapDescEdited: false,
+
+    // Called from the remap name/description inputs' oninput handlers
+    markRemapFieldEdited(field) {
+        if (field === 'name') this.remapNameEdited = true;
+        else if (field === 'desc') this.remapDescEdited = true;
+    },
+
+    // Regenerate the default remap name/description from the current master device and
+    // channels, leaving alone whichever fields the user has already typed in.
+    autofillRemapNaming() {
+        if (this.remapNameEdited && this.remapDescEdited) return;
+
+        const masterSelect = document.getElementById('wizardRemapMaster');
+        const masterLabel = masterSelect?.selectedOptions[0]?.dataset?.label;
+        if (!masterLabel) return;
+
+        const isMono = document.getElementById('wizardOutputModeMono')?.checked;
+        const channels = isMono
+            ? [document.getElementById('wizardRemapMono')?.value]
+            : [
+                document.getElementById('wizardRemapLeft')?.value,
+                document.getElementById('wizardRemapRight')?.value
+            ];
+
+        // Sink names share one PulseAudio namespace with hardware sinks
+        const taken = [
+            ...this.customSinks.map(sink => sink.name),
+            ...this.devices.map(d => d.id)
+        ];
+        const defaults = buildRemapSinkDefaults(masterLabel, channels, taken);
+        if (!defaults.name) return;
+
+        if (!this.remapNameEdited) document.getElementById('wizardRemapName').value = defaults.name;
+        if (!this.remapDescEdited) document.getElementById('wizardRemapDesc').value = defaults.description;
+    },
+
     // Step 3: Custom Sinks (Optional)
     renderSinks() {
+        // A freshly rendered form starts with both fields eligible for autofill again
+        this.remapNameEdited = false;
+        this.remapDescEdited = false;
+
         // Build device checkboxes for combine sink (exclude hidden devices)
         const visibleDevices = this.devices.filter(d =>
             !d.id.includes('.monitor') &&
             !(this.deviceState[d.id]?.hidden || d.hidden)
+        );
+        const sinkDeviceLabel = makeCardDisambiguator(
+            visibleDevices,
+            d => this.deviceState[d.id]?.alias || d.alias || d.name,
+            d => d.cardIndex
         );
         const deviceCheckboxes = visibleDevices
             .map(d => `
@@ -640,7 +690,7 @@ const Wizard = {
                            value="${escapeHtml(d.id)}"
                            id="wizard-combine-${escapeHtml(d.id)}">
                     <label class="form-check-label" for="wizard-combine-${escapeHtml(d.id)}">
-                        ${escapeHtml(this.deviceState[d.id]?.alias || d.alias || d.name)}
+                        ${escapeHtml(sinkDeviceLabel(d))}
                     </label>
                 </div>
             `).join('');
@@ -648,8 +698,9 @@ const Wizard = {
         // Build device options for remap sink (exclude hidden and remap sinks)
         const multiChannelDevices = visibleDevices.filter(d => d.maxChannels >= 4 && d.sinkType !== 'Remap');
         const deviceOptions = multiChannelDevices.map(d => `
-            <option value="${escapeHtml(d.id)}" data-channels="${d.maxChannels}">
-                ${escapeHtml(this.deviceState[d.id]?.alias || d.alias || d.name)} (${d.maxChannels}ch)
+            <option value="${escapeHtml(d.id)}" data-channels="${d.maxChannels}"
+                    data-label="${escapeHtml(sinkDeviceLabel(d))}">
+                ${escapeHtml(sinkDeviceLabel(d))} (${d.maxChannels}ch)
             </option>
         `).join('');
 
@@ -769,13 +820,15 @@ const Wizard = {
                                         <div class="mb-3">
                                             <label class="form-label">Sink Name <span class="text-danger">*</span></label>
                                             <input type="text" class="form-control" id="wizardRemapName"
-                                                   placeholder="surround_rear">
+                                                   placeholder="surround_rear"
+                                                   oninput="Wizard.markRemapFieldEdited('name')">
                                             <small class="text-muted">Letters, numbers, underscores, hyphens only</small>
                                         </div>
                                         <div class="mb-3">
                                             <label class="form-label">Description</label>
                                             <input type="text" class="form-control" id="wizardRemapDesc"
-                                                   placeholder="Surround Card - Rear Speakers">
+                                                   placeholder="Surround Card - Rear Speakers"
+                                                   oninput="Wizard.markRemapFieldEdited('desc')">
                                         </div>
                                         <div class="mb-3">
                                             <label class="form-label">Master Device <span class="text-danger">*</span></label>
@@ -872,7 +925,8 @@ const Wizard = {
                 <div class="mb-3">
                     <label class="form-label">Source Channel</label>
                     <div class="d-flex align-items-center">
-                        <select class="form-select" id="wizardRemapMono">
+                        <select class="form-select" id="wizardRemapMono"
+                                onchange="Wizard.autofillRemapNaming()">
                             ${optionsHtml}
                         </select>
                         <button class="btn btn-outline-primary btn-sm ms-2"
@@ -890,7 +944,8 @@ const Wizard = {
                 <div class="mb-3">
                     <label class="form-label">Left Channel</label>
                     <div class="d-flex align-items-center">
-                        <select class="form-select" id="wizardRemapLeft">
+                        <select class="form-select" id="wizardRemapLeft"
+                                onchange="Wizard.autofillRemapNaming()">
                             ${optionsHtml}
                         </select>
                         <button class="btn btn-outline-primary btn-sm ms-2"
@@ -904,7 +959,8 @@ const Wizard = {
                 <div class="mb-3">
                     <label class="form-label">Right Channel</label>
                     <div class="d-flex align-items-center">
-                        <select class="form-select" id="wizardRemapRight">
+                        <select class="form-select" id="wizardRemapRight"
+                                onchange="Wizard.autofillRemapNaming()">
                             ${optionsHtml}
                         </select>
                         <button class="btn btn-outline-primary btn-sm ms-2"
@@ -919,6 +975,8 @@ const Wizard = {
             document.getElementById('wizardRemapLeft').value = 'front-left';
             document.getElementById('wizardRemapRight').value = 'front-right';
         }
+
+        this.autofillRemapNaming();
     },
 
     // Create a combine sink
@@ -1094,6 +1152,8 @@ const Wizard = {
             nameInput.value = '';
             descInput.value = '';
             masterSelect.value = '';
+            this.remapNameEdited = false;
+            this.remapDescEdited = false;
 
             // Update the sinks list
             this.updateSinksList();

--- a/src/MultiRoomAudio/wwwroot/js/wizard.js
+++ b/src/MultiRoomAudio/wwwroot/js/wizard.js
@@ -1225,12 +1225,20 @@ const Wizard = {
     // Step 4: Create Players
     renderPlayers() {
         // Combine devices and custom sinks, excluding:
+        // - Duplicates: /api/devices already carries every loaded custom sink under the same
+        //   id, so without this a loaded sink renders twice - two checkboxes sharing one DOM
+        //   id, and collectPlayersToCreate() submitting the player twice. Sinks created in
+        //   this session have not reached /api/devices yet, so they still come through
+        //   customSinks.
         // - Hidden devices
         // - Devices used as master/slave by custom sinks (use the sink instead)
-        const allDevices = [...this.devices, ...this.customSinks].filter(d =>
-            !(this.deviceState[d.id]?.hidden || d.hidden) &&
-            !this.isDeviceUsedBySink(d.id)
-        );
+        const seen = new Set();
+        const allDevices = [...this.devices, ...this.customSinks].filter(d => {
+            if (seen.has(d.id)) return false;
+            seen.add(d.id);
+            return !(this.deviceState[d.id]?.hidden || d.hidden) &&
+                   !this.isDeviceUsedBySink(d.id);
+        });
 
         const playerHtml = allDevices.map(device => {
             const alias = this.deviceState[device.id]?.alias || device.alias || this.suggestName(device);

--- a/tests/MultiRoomAudio.Tests/Utilities/PaModuleRunnerDescriptionTests.cs
+++ b/tests/MultiRoomAudio.Tests/Utilities/PaModuleRunnerDescriptionTests.cs
@@ -1,0 +1,57 @@
+using MultiRoomAudio.Utilities;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Utilities;
+
+/// <summary>
+/// Tests for the <c>sink_properties=device.description=...</c> argument built by
+/// <see cref="PaModuleRunner"/>. Descriptions used to have their spaces replaced with
+/// underscores to work around PulseAudio's proplist parser; they are now carried through
+/// intact by quoting the value twice, so the escaping is what needs guarding.
+/// </summary>
+public class PaModuleRunnerDescriptionTests
+{
+    [Fact]
+    public void BuildDescriptionArg_QuotesTwiceAndKeepsSpaces()
+    {
+        // Outer double quotes are stripped by pactl's module argument parser, inner single
+        // quotes by pa_proplist_from_string. One level of either fails module init.
+        Assert.Equal(
+            "sink_properties=\"device.description='Creative X-Fi Front Left Front Right'\"",
+            PaModuleRunner.BuildDescriptionArg("Creative X-Fi Front Left Front Right"));
+    }
+
+    [Theory]
+    [InlineData("Bang & Olufsen", "Bang & Olufsen")]                 // no longer mangled to _and_
+    [InlineData("Zone 1 | back", "Zone 1 | back")]
+    [InlineData("Living Room  50% #2", "Living Room  50% #2")]
+    [InlineData("  padded  ", "padded")]
+    public void SanitizeDescription_LeavesHarmlessCharactersAlone(string input, string expected)
+    {
+        Assert.Equal(expected, PaModuleRunner.SanitizeDescription(input));
+    }
+
+    [Theory]
+    [InlineData("say \"hi\"", "say hi")]
+    [InlineData("it's mine", "its mine")]
+    [InlineData("back\\slash", "backslash")]
+    [InlineData("two\nlines", "two lines")]
+    [InlineData("carriage\rreturn", "carriagereturn")]
+    [InlineData("null\0char", "nullchar")]
+    public void SanitizeDescription_StripsCharactersThatWouldBreakQuoting(string input, string expected)
+    {
+        Assert.Equal(expected, PaModuleRunner.SanitizeDescription(input));
+    }
+
+    [Fact]
+    public void BuildDescriptionArg_CannotBeEscapedByQuotesInTheDescription()
+    {
+        // A description crafted to close the quoting and append another property must not
+        // produce anything outside the single quoted value.
+        var arg = PaModuleRunner.BuildDescriptionArg("evil' device.class='sound");
+
+        Assert.Equal("sink_properties=\"device.description='evil device.class=sound'\"", arg);
+        Assert.Equal(2, arg.Count(c => c == '\''));
+        Assert.Equal(2, arg.Count(c => c == '"'));
+    }
+}


### PR DESCRIPTION
Implements all three items from #282, plus the space-escaping spike that gated item 1.

Closes #282

## Default naming for remap sinks

Picking a master device and a channel mapping now prefills both fields:

| Field | Example |
|-------|---------|
| Name | `Creative_X_Fi_Analog_Surround_7_1_fl_fr` |
| Description | `Creative X-Fi Analog Surround 7.1 Front Left Front Right` |

Both keep regenerating while untouched; the first manual edit to a field stops autofill
for that field only, and reopening the form resets it. Editing an existing sink never
regenerates. A second sink on the same device and channels gets a `_2` suffix so the POST
does not hit `EntityAlreadyExistsException`. The generator lives in `utils.js` and drives
both the main modal and the onboarding wizard, so there is one implementation, not two.
Combine sinks keep manual naming - there is no sensible default from N slaves.

## Space handling: the spike answered yes

Descriptions no longer reach Home Assistant underscored. The value needs **two** levels of
quoting to survive:

```
sink_properties="device.description='Front Left Front Right'"
```

pactl's module argument parser strips the outer double quotes, then
`pa_proplist_from_string` strips the inner single quotes. Single-level quoting (either
kind), backslash-escaped spaces, and escaped quotes all fail with "Module initialization
failed" - which is what the space-to-underscore substitution was working around. `pactl`
has no `update-sink-proplist` subcommand in PA 16, so the post-load approach was not
available. Verified against PulseAudio 16.1, the version in the container image, including
`&`, `|`, `;`, backticks and `$`.

`SanitizeDescription` therefore drops the space and `&` substitutions and keeps stripping
backslashes, quotes, newlines and nulls - that part is what makes the quoting safe, not a
bug workaround. It also fixes a latent failure: the old unquoted form failed module init
outright when a description sanitized to empty.

## Duplicate card disambiguation

Where a card or device description collides, the lists append the ALSA card number -
`Creative X-Fi Analog Surround 7.1 (card 1)` vs `... (card 4)`. Unique names render
exactly as before. Applied to the Sound Cards accordion, the player device dropdowns, the
remap master picker, and the wizard's device lists. Display-only: `GET /api/cards` and
`GET /api/devices` are unchanged, and aliases, hidden flags, max-volume and mute still key
off the real `device.id` / `card.name`.

## Upgrade note

Existing sinks reload from `custom-sinks.yaml` through the same load path, so after
upgrading their stored description registers verbatim - underscores become spaces, `_and_`
becomes `&`. That renames those media players in Home Assistant and Music Assistant on the
first restart. Sink names, players and configuration are untouched. Called out under
`Changed` in the changelog.

## Verification

- `dotnet build -c Release`: 0 errors, 0 warnings; `dotnet format --verify-no-changes`: clean
- `dotnet test tests/MultiRoomAudio.Tests`: 121 passed, 12 of them new for the description quoting and sanitization
- `tests/MultiRoomAudio.E2ETests` could not be run - it has no `.csproj` and is in neither the solution nor CI (pre-existing)
- JS behaviour was checked with a throwaway node+jsdom harness against the real `index.html` markup and the real `app.js`/`wizard.js` functions: 25 checks across both forms (prefill, per-field sticky-until-edited, reset on reopen, collision suffix, mono, edit-mode no-rewrite, the 100-char cap, and disambiguation in the dropdowns, combine checkboxes and identify list). The repo has no JS test infrastructure, so nothing was committed for it - worth a follow-up if we want that logic guarded in CI.