### PR TITLE
Fix default.pa import losing sink descriptions that contain spaces

### DIFF
--- a/src/MultiRoomAudio/Utilities/DefaultPaParser.cs
+++ b/src/MultiRoomAudio/Utilities/DefaultPaParser.cs
@@ -22,10 +22,21 @@ public partial class DefaultPaParser
 
     /// <summary>
     /// Regex pattern to extract key=value pairs from module arguments.
-    /// Handles quoted values for properties like device.description="My Sink"
+    /// Handles both quote styles, because a value that itself contains quotes has to use the
+    /// other kind on the outside - PulseAudio only loads a description with spaces when it is
+    /// quoted twice, either sink_properties="device.description='My Sink'" or the reverse.
+    /// Captures: 1 = key, 2 = double-quoted value, 3 = single-quoted value, 4 = bare value.
     /// </summary>
-    [GeneratedRegex(@"(\w+)=(?:""([^""]*)""|([^\s]+))", RegexOptions.Compiled)]
+    [GeneratedRegex(@"(\w+)=(?:""([^""]*)""|'([^']*)'|([^\s]+))", RegexOptions.Compiled)]
     private static partial Regex KeyValuePattern();
+
+    /// <summary>
+    /// Regex pattern to pull device.description out of a sink_properties value, after the
+    /// outer quoting has already been stripped by <see cref="KeyValuePattern"/>.
+    /// Captures: 1 = single-quoted, 2 = double-quoted, 3 = unquoted or half-quoted remainder.
+    /// </summary>
+    [GeneratedRegex(@"device\.description=(?:'([^']*)'|""([^""]*)""|""?([^""]+)""?)", RegexOptions.Compiled)]
+    private static partial Regex DescriptionPattern();
 
     /// <summary>
     /// Marker comment added when we comment out a line.
@@ -115,19 +126,58 @@ public partial class DefaultPaParser
         return detected;
     }
 
-    private DetectedSink? ParseModuleArguments(string moduleType, string arguments, int startLine, int endLine, string rawLine)
+    /// <summary>
+    /// Split a load-module argument string into its key=value pairs, stripping one level of
+    /// quoting from each value. Pure - exposed for testing without a default.pa on disk.
+    /// </summary>
+    internal static Dictionary<string, string> ParseKeyValues(string arguments)
     {
         var keyValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (Match match in KeyValuePattern().Matches(arguments))
         {
             var key = match.Groups[1].Value;
-            // Use quoted value if present, otherwise use unquoted
-            var value = !string.IsNullOrEmpty(match.Groups[2].Value)
-                ? match.Groups[2].Value
-                : match.Groups[3].Value;
-            keyValues[key] = value;
+            // Whichever alternation matched wins; a bare value is the last resort.
+            var group = match.Groups[2].Success ? match.Groups[2]
+                : match.Groups[3].Success ? match.Groups[3]
+                : match.Groups[4];
+            keyValues[key] = group.Value;
         }
+
+        return keyValues;
+    }
+
+    /// <summary>
+    /// Extract the device.description value from a full argument string. Pure - exposed for
+    /// testing without a default.pa on disk.
+    /// </summary>
+    /// <returns>The description, or null if the arguments carry none.</returns>
+    internal static string? ParseDescriptionFromArguments(string arguments)
+    {
+        return ParseKeyValues(arguments).TryGetValue("sink_properties", out var properties)
+            ? ParseDescription(properties)
+            : null;
+    }
+
+    /// <summary>
+    /// Extract device.description from a sink_properties value whose outer quoting has
+    /// already been stripped.
+    /// </summary>
+    private static string? ParseDescription(string sinkProperties)
+    {
+        var match = DescriptionPattern().Match(sinkProperties);
+        if (!match.Success)
+            return null;
+
+        var group = match.Groups[1].Success ? match.Groups[1]
+            : match.Groups[2].Success ? match.Groups[2]
+            : match.Groups[3];
+        return group.Value;
+    }
+
+    private DetectedSink? ParseModuleArguments(string moduleType, string arguments, int startLine, int endLine, string rawLine)
+    {
+        var keyValues = ParseKeyValues(arguments);
 
         // Extract sink name (required)
         if (!keyValues.TryGetValue("sink_name", out var sinkName) || string.IsNullOrWhiteSpace(sinkName))
@@ -140,11 +190,7 @@ public partial class DefaultPaParser
         string? description = null;
         if (keyValues.TryGetValue("sink_properties", out var properties))
         {
-            var descMatch = Regex.Match(properties, @"device\.description=""?([^""]+)""?");
-            if (descMatch.Success)
-            {
-                description = descMatch.Groups[1].Value;
-            }
+            description = ParseDescription(properties);
         }
 
         var type = moduleType == "combine" ? CustomSinkType.Combine : CustomSinkType.Remap;

--- a/tests/MultiRoomAudio.Tests/Utilities/DefaultPaParserDescriptionTests.cs
+++ b/tests/MultiRoomAudio.Tests/Utilities/DefaultPaParserDescriptionTests.cs
@@ -1,0 +1,79 @@
+using MultiRoomAudio.Utilities;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Utilities;
+
+/// <summary>
+/// Tests for the reading half of the <c>sink_properties=device.description=...</c> contract:
+/// what <see cref="DefaultPaParser"/> pulls back out of a default.pa line.
+/// <see cref="PaModuleRunnerDescriptionTests"/> pins the writing half.
+/// </summary>
+public class DefaultPaParserDescriptionTests
+{
+    /// <summary>
+    /// The quoting matrix. Only the two doubly-quoted forms actually load in PulseAudio, so
+    /// those are the ones that have to come back whole; the rest are pinned to keep the parser
+    /// a mirror of what PulseAudio itself accepts.
+    /// </summary>
+    [Theory]
+    // Outer double / inner single - what PaModuleRunner.BuildDescriptionArg emits.
+    [InlineData("sink_properties=\"device.description='Bedroom Rear'\"", "Bedroom Rear")]
+    // Outer single / inner double - the other form PulseAudio loads.
+    [InlineData("sink_properties='device.description=\"Bedroom Rear\"'", "Bedroom Rear")]
+    // One level of quoting: PulseAudio rejects the line, so parsing stops at the space.
+    [InlineData("sink_properties=device.description=\"Bedroom Rear\"", "Bedroom")]
+    // No spaces, no quoting needed.
+    [InlineData("sink_properties=device.description=BedroomRear", "BedroomRear")]
+    public void ParseDescriptionFromArguments_HandlesEveryQuotingForm(string arguments, string expected)
+    {
+        Assert.Equal(expected, DefaultPaParser.ParseDescriptionFromArguments(
+            "sink_name=mra_bedroom master=alsa_output.usb " + arguments));
+    }
+
+    [Theory]
+    [InlineData("Bedroom Rear")]
+    [InlineData("Bang & Olufsen | 50%")]
+    [InlineData("Creative X-Fi Front Left Front Right")]
+    public void ParseDescriptionFromArguments_RoundTripsWhatPaModuleRunnerWrites(string description)
+    {
+        var arguments = "sink_name=mra_zone " + PaModuleRunner.BuildDescriptionArg(description);
+
+        Assert.Equal(description, DefaultPaParser.ParseDescriptionFromArguments(arguments));
+    }
+
+    [Fact]
+    public void ParseDescriptionFromArguments_ReturnsNullWhenThereIsNoDescription()
+    {
+        Assert.Null(DefaultPaParser.ParseDescriptionFromArguments("sink_name=mra_zone master=alsa_output.usb"));
+        Assert.Null(DefaultPaParser.ParseDescriptionFromArguments("sink_name=mra_zone sink_properties=device.class=sound"));
+    }
+
+    [Fact]
+    public void ParseKeyValues_ReadsRemapArgumentsAlongsideAQuotedDescription()
+    {
+        var keyValues = DefaultPaParser.ParseKeyValues(
+            "sink_name=mra_bedroom master=alsa_output.usb-0d8c_USB_Sound-00.analog-stereo " +
+            "channels=2 channel_map=front-left,front-right master_channel_map=front-left,front-right " +
+            "remix=no sink_properties=\"device.description='Bedroom Rear'\"");
+
+        Assert.Equal("mra_bedroom", keyValues["sink_name"]);
+        Assert.Equal("alsa_output.usb-0d8c_USB_Sound-00.analog-stereo", keyValues["master"]);
+        Assert.Equal("2", keyValues["channels"]);
+        Assert.Equal("front-left,front-right", keyValues["channel_map"]);
+        Assert.Equal("front-left,front-right", keyValues["master_channel_map"]);
+        Assert.Equal("no", keyValues["remix"]);
+        Assert.Equal("device.description='Bedroom Rear'", keyValues["sink_properties"]);
+    }
+
+    [Fact]
+    public void ParseKeyValues_ReadsCombineArguments()
+    {
+        var keyValues = DefaultPaParser.ParseKeyValues(
+            "sink_name=mra_whole_house slaves=sink_a,sink_b,sink_c " +
+            "sink_properties='device.description=\"Whole House\"'");
+
+        Assert.Equal("mra_whole_house", keyValues["sink_name"]);
+        Assert.Equal("sink_a,sink_b,sink_c", keyValues["slaves"]);
+        Assert.Equal("device.description=\"Whole House\"", keyValues["sink_properties"]);
+    }
+}


### PR DESCRIPTION
Fixes the sink-import path mis-parsing `default.pa` descriptions with spaces.

A `device.description` with spaces needs **two** levels of quoting to survive PulseAudio — the module-argument parser strips the outer pair, then `pa_proplist_from_string` strips the inner one — so one of the pairs is always single quotes. `DefaultPaParser` only knew double quotes, which meant:

- an outer-single-quoted `sink_properties` fell through to the bare `[^\s]+` branch and stopped at the first space;
- an inner-single-quoted value kept its literal `'` characters.

Between them, the app could not re-import the sinks `PaModuleRunner.BuildDescriptionArg` writes itself.

## What changed

- `KeyValuePattern()` gains a single-quote alternation. The capture-group indices this shifts now live in a new `ParseKeyValues` seam, which picks the branch by `Group.Success` rather than by emptiness — that also stops an unmatched group being confused with a matched-but-empty one.
- The inline `device.description` regex is promoted to a `[GeneratedRegex]` that knows both quote styles, keeping the old half-quoted tolerance as its last branch so non-loading forms don't regress.
- Two `internal static` parse seams (`ParseKeyValues`, `ParseDescriptionFromArguments`) make the quoting matrix testable without a `default.pa` on disk.
- The `KeyValuePattern()` doc comment no longer cites `device.description="My Sink"` — a form PulseAudio rejects outright, so it can't appear in a working `default.pa`.

## Parsing behaviour

| `sink_properties=` argument | PA loads? | Parsed description |
|---|---|---|
| `"device.description='Bedroom Rear'"` | yes | `Bedroom Rear` — **fixed** (was `'Bedroom Rear'`) |
| `'device.description="Bedroom Rear"'` | yes | `Bedroom Rear` — **fixed** (was `Bedroom`) |
| `device.description="Bedroom Rear"` | no | `Bedroom` — unchanged |
| `device.description=BedroomRear` | yes | `BedroomRear` — unchanged |

Strict on purpose: forms PulseAudio rejects keep their current output, so the parser stays a mirror of what actually loads rather than guessing at intent behind a line that never ran.

## Testing

`tests/MultiRoomAudio.Tests/Utilities/DefaultPaParserDescriptionTests.cs` covers all four rows as a table-driven `[Theory]`, round-trips `BuildDescriptionArg` output back through the parser (including `&`, `|`, `%`), and pins the other key/value pairs. 131/131 green; `dotnet format --verify-no-changes` clean.

Read-only import path — no change to the `default.pa` write path, `PaModuleRunner`, or any public API.

Closes #285