### PR TITLE
Advertise real DAC sample rates and bit depths to Music Assistant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,7 @@ new ErrorResponse(false, "Error message")
 | `PA_SAMPLE_FORMAT` | `float32le` | PulseAudio sample format (Docker mode only) |
 | `SUPERVISOR_TOKEN` | (HAOS only) | Auto-set by Home Assistant supervisor |
 | `MOCK_HARDWARE` | `false` | Enable mock relay boards for testing without hardware |
-| `ENABLE_ADVANCED_FORMATS` | `false` | Show format selection UI (dev-only). All players default to flac-48000 regardless. |
+| `ENABLE_ADVANCED_FORMATS` | `false` | Deprecated no-op. The Advertised Format selector is always visible and always device-derived; this flag no longer gates it or `GET /api/players/formats`. |
 | `BUFFER_SECONDS` | `30` | Audio buffer size in seconds (5-30, step 5). Lower values reduce RAM on constrained hardware. |
 | `RESET_SINKS` | `true` | Suspend/resume hardware sinks (`module-alsa-card.c` only, skipping `SUSPENDED` ones) once, in the `sinkreset` startup phase. Works around the ALSA mmap+timer kernel regression that leaves cards silent (#281). Startup is the only trigger — a device re-opened on the bad path later needs an add-on restart. Set to `false`/`0`/`no` to disable. Surfaced as the `reset_sinks` add-on option. |
 | `USE_AUDIO_CLOCK` | `false` | Opt in to the PulseAudio DAC clock for sync timing. Default uses the SDK `MonotonicTimer` (VM-resilient, no output-prefill offset, better multi-room sync). Enable only for genuinely divergent DAC clocks. |
@@ -236,11 +236,32 @@ new ErrorResponse(false, "Error message")
 
 **Audio Format Selection:**
 
-- All players default to advertising "flac-48000" for maximum Music Assistant compatibility
-- This default applies regardless of `ENABLE_ADVANCED_FORMATS` setting
-- When `ENABLE_ADVANCED_FORMATS=true`, UI shows dropdown to select specific formats or "All Formats"
-- Format preference is persisted in players.yaml and survives restarts
-- Changing format triggers automatic player restart to re-announce with new format
+`AudioFormatCatalog` (`src/MultiRoomAudio/Audio/AudioFormatCatalog.cs`) builds the
+`supported_formats` list from the player device's probed `DeviceCapabilities`.
+
+- A player advertises the **whole** list its DAC can do — flac entries, then pcm, then opus,
+  best quality first. Music Assistant builds its per-player `preferred_sendspin_format`
+  dropdown from this list, so advertising one entry left it with one option (#280).
+- **Entry 0 is the contract.** The aiosendspin server takes `compatible[0]` and holds it for
+  the whole session; it does not scan the list for a track's native rate. The preference only
+  moves an entry to the front — it never truncates the list.
+- **Every flac and pcm entry carries an explicit `bit_depth`.** The SDK maps a null depth to
+  16 (`BitDepth = (f.BitDepth ?? 16)`), which is what silently truncated hi-res streams.
+  Opus has no depth — the spec ignores it for that codec.
+- **Default anchor: `flac / 48000 / min(device best depth, 24) / 2ch`.** The rate stays at
+  48kHz because buffer RAM scales with it (~11.5MB per player at 48kHz, ~23MB at 96kHz,
+  ~46MB at 192kHz at `BUFFER_SECONDS=30`); depth costs LAN bandwidth but no RAM, so 24-bit
+  is safe by default. A DAC with no 48kHz mode anchors on its nearest rate.
+- **Preference strings** persisted in `players.yaml`: `codec-rate` (`"flac-48000"` — depth
+  resolved from the device), `codec-rate-depth` (`"pcm-96000-24"`), `"auto"` (device native
+  best), `"all"` (legacy; same as the default anchor), or null. All legacy values keep working.
+- Devices whose capabilities cannot be probed fall back to a static list that still carries
+  explicit bit depths.
+- Changing format triggers an automatic player restart to re-announce.
+
+Advertising a rate does not guarantee the DAC receives it — PulseAudio may resample,
+especially under HAOS where the daemon belongs to the supervisor. Stats-for-Nerds
+`hardwareSampleRate` / `hardwareBitDepth` (and `pactl list sinks`) are the truth.
 
 ---
 
@@ -307,7 +328,7 @@ squeezelite-docker/
 | PUT | `/api/players/{name}/mute` | Mute/unmute player |
 | PUT | `/api/players/{name}/offset` | Set delay offset |
 | PUT | `/api/players/{name}/auto-resume` | Enable/disable auto-resume on device reconnect |
-| GET | `/api/players/formats` | Get available audio formats (only when ENABLE_ADVANCED_FORMATS=true) |
+| GET | `/api/players/formats?device={id}` | Get the audio formats a device can be advertised as supporting |
 
 ### Audio Devices
 

--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -80,34 +80,19 @@ AUDIO_BACKEND=pulse
 
 ### ENABLE_ADVANCED_FORMATS
 
-Enable per-player audio format selection UI (dev-only).
+Deprecated. Has no effect.
 
 - **Type:** Boolean
 - **Default:** `false`
 - **Valid Values:** `true`, `false`, `1`, `0`, `yes`, `no`
-- **Description:** Controls whether the advanced format selection UI is displayed. **Important:** All players default to advertising "flac-48000" for maximum Music Assistant compatibility regardless of this setting.
+- **Description:** This flag used to gate the per-player Advertised Format dropdown and
+  `GET /api/players/formats`. Both are now always available, and the offered formats are
+  derived from the selected device's real capabilities. Setting it changes nothing; it is
+  kept only so existing compose files and dev scripts do not break.
 
-**Behavior:**
-
-| Setting           | Default Format | UI Behavior                 | Use Case                                                                      |
-|-------------------|----------------|-----------------------------|-------------------------------------------------------------------------------|
-| `false` (default) | flac-48000     | No format dropdown shown    | Production - maximum MA compatibility                                         |
-| `true`            | flac-48000     | Format dropdown shown in UI | Development/testing - allows selecting specific formats or "All Formats"      |
-
-When enabled, the UI provides options to:
-
-- Keep the default "flac-48000" (recommended)
-- Select specific formats (e.g., "PCM 192kHz 32-bit", "FLAC 96kHz")
-- Choose "All Formats" to advertise all supported formats
-
-**Examples:**
-```bash
-# Production (default) - flac-48000, no UI dropdown
-ENABLE_ADVANCED_FORMATS=false
-
-# Development - flac-48000 default, but UI allows format selection
-ENABLE_ADVANCED_FORMATS=true
-```
+Per-player format selection now lives in the player's settings dialog. See the
+"Audio Format Selection" section of `CLAUDE.md` for how the advertised list is built and
+what the default anchor is.
 
 ### CONFIG_PATH
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,7 +21,6 @@ services:
       #
       # - MOCK_HARDWARE=true        # Simulate audio devices and relay boards without hardware
       # - LOG_LEVEL=debug           # Verbose logging
-      # - ENABLE_ADVANCED_FORMATS=true  # Show format selection UI
       #
       # PulseAudio sample rate/format (applied at container startup):
       # - PA_SAMPLE_RATE=192000     # Default: 48000

--- a/docs/DOCKER_DEV.md
+++ b/docs/DOCKER_DEV.md
@@ -53,7 +53,6 @@ These options are available in dev builds for testing and debugging:
 |----------|---------|-------------|
 | `MOCK_HARDWARE` | `false` | Simulate audio devices and relay boards without hardware |
 | `LOG_LEVEL` | `info` | Logging verbosity: `debug`, `info`, `warning`, `error` |
-| `ENABLE_ADVANCED_FORMATS` | `false` | Show format selection UI (players default to flac-48000 regardless) |
 | `PA_SAMPLE_RATE` | `48000` | PulseAudio sample rate (applied at container startup) |
 | `PA_SAMPLE_FORMAT` | `float32le` | PulseAudio format: `s16le`, `s24le`, `s32le`, `float32le` |
 
@@ -66,7 +65,6 @@ services:
     environment:
       - MOCK_HARDWARE=true
       - LOG_LEVEL=debug
-      - ENABLE_ADVANCED_FORMATS=true
     # ... rest of config
 ```
 

--- a/src/MultiRoomAudio/Audio/AudioFormatCatalog.cs
+++ b/src/MultiRoomAudio/Audio/AudioFormatCatalog.cs
@@ -47,6 +47,22 @@ public static class AudioFormatCatalog
     private static readonly int[] FlacBitDepths = [24, 16];
 
     /// <summary>
+    /// Picks the capabilities to build a device's advertised formats from.
+    /// </summary>
+    /// <param name="device">The enriched device, whose <c>Capabilities</c> carry ALSA-probed hardware data.</param>
+    /// <param name="backendProbe">The backend's own probe, used only when the device has none.</param>
+    /// <returns>The best available capabilities, or null when neither source has any.</returns>
+    /// <remarks>
+    /// The enriched device is the only source that is actually per-device:
+    /// <see cref="PulseAudio.PulseAudioBackend.GetDeviceCapabilities"/> returns one fixed
+    /// hi-res table for every sink, so building formats from it would advertise 192kHz on a
+    /// 48kHz-only DAC. ALSA capabilities are attached during enrichment
+    /// (<see cref="Services.DeviceMatchingService"/>), which is why they win here.
+    /// </remarks>
+    public static DeviceCapabilities? CapabilitiesFor(AudioDevice? device, DeviceCapabilities? backendProbe) =>
+        device?.Capabilities ?? backendProbe;
+
+    /// <summary>
     /// Builds the full advertisable format list for a device, best quality first.
     /// </summary>
     /// <param name="capabilities">Probed device capabilities, or null when unavailable.</param>

--- a/src/MultiRoomAudio/Audio/AudioFormatCatalog.cs
+++ b/src/MultiRoomAudio/Audio/AudioFormatCatalog.cs
@@ -1,0 +1,299 @@
+using MultiRoomAudio.Models;
+using Sendspin.SDK.Models;
+
+namespace MultiRoomAudio.Audio;
+
+/// <summary>
+/// Builds the <c>supported_formats</c> list a player advertises in <c>client/hello</c>,
+/// derived from the real capabilities of the DAC it plays to.
+/// </summary>
+/// <remarks>
+/// Pure and static so the wire contract can be unit tested without the SDK service graph.
+/// Two rules drive everything here:
+/// <list type="bullet">
+/// <item>Every flac/pcm entry carries an explicit bit depth — the SDK silently maps a null
+/// depth to 16, which is what truncated hi-res streams before (#280).</item>
+/// <item>Entry 0 is the whole contract — the Music Assistant server picks
+/// <c>compatible[0]</c> and holds it for the session, so ordering is the preference.</item>
+/// </list>
+/// </remarks>
+public static class AudioFormatCatalog
+{
+    /// <summary>Preference string meaning "the device's highest rate and depth".</summary>
+    public const string AutoFormatId = "auto";
+
+    /// <summary>Legacy preference string; now resolves to the same anchor as no preference at all.</summary>
+    public const string AllFormatsId = "all";
+
+    /// <summary>Sample rate the default anchor prefers — hi-res stays opt-in because buffer RAM scales with it.</summary>
+    private const int DefaultSampleRate = 48000;
+
+    /// <summary>Depth cap for the default anchor. 24-bit costs bandwidth but no RAM, so it is safe by default.</summary>
+    private const int DefaultMaxBitDepth = 24;
+
+    /// <summary>Rates below this are capture/telephony modes we never want to advertise for music.</summary>
+    private const int MinAdvertisedSampleRate = 44100;
+
+    private const int AdvertisedChannels = 2;
+    private const int OpusBitrateKbps = 256;
+
+    /// <summary>Used when a device reports no usable capabilities (probe failed, or a virtual sink).</summary>
+    private static readonly int[] FallbackSampleRates = [192000, 96000, 48000, 44100];
+    private static readonly int[] FallbackBitDepths = [32, 24, 16];
+
+    private static readonly int[] PcmBitDepths = [32, 24, 16];
+
+    /// <summary>FLAC carries 16- or 24-bit samples; a 32-bit-only device is advertised at 24.</summary>
+    private static readonly int[] FlacBitDepths = [24, 16];
+
+    /// <summary>
+    /// Builds the full advertisable format list for a device, best quality first.
+    /// </summary>
+    /// <param name="capabilities">Probed device capabilities, or null when unavailable.</param>
+    /// <returns>flac entries, then pcm entries, then opus — each with an explicit bit depth where the codec has one.</returns>
+    public static List<AudioFormat> BuildFormats(DeviceCapabilities? capabilities)
+    {
+        var rates = ResolveSampleRates(capabilities);
+        var depths = ResolveBitDepths(capabilities);
+
+        var formats = new List<AudioFormat>();
+
+        foreach (var rate in rates)
+        {
+            foreach (var depth in FlacDepthsFor(depths))
+            {
+                formats.Add(new AudioFormat
+                {
+                    Codec = "flac",
+                    SampleRate = rate,
+                    Channels = AdvertisedChannels,
+                    BitDepth = depth
+                });
+            }
+        }
+
+        foreach (var rate in rates)
+        {
+            foreach (var depth in PcmBitDepths.Where(depths.Contains))
+            {
+                formats.Add(new AudioFormat
+                {
+                    Codec = "pcm",
+                    SampleRate = rate,
+                    Channels = AdvertisedChannels,
+                    BitDepth = depth
+                });
+            }
+        }
+
+        // Opus is decoded in software and is fixed at 48kHz; bit depth is ignored for it by spec.
+        formats.Add(new AudioFormat
+        {
+            Codec = "opus",
+            SampleRate = 48000,
+            Channels = AdvertisedChannels,
+            Bitrate = OpusBitrateKbps
+        });
+
+        return formats;
+    }
+
+    /// <summary>
+    /// Picks the entry a player with no explicit preference should advertise first:
+    /// FLAC at 48kHz (or the nearest rate the device supports) and the device's best depth, capped at 24-bit.
+    /// </summary>
+    /// <param name="formats">The list from <see cref="BuildFormats"/>.</param>
+    /// <param name="capabilities">Probed device capabilities, or null when unavailable.</param>
+    /// <returns>The default anchor, never null for a non-empty list.</returns>
+    public static AudioFormat ResolveDefault(IReadOnlyList<AudioFormat> formats, DeviceCapabilities? capabilities)
+    {
+        var rate = NearestSampleRate(ResolveSampleRates(capabilities), DefaultSampleRate);
+        var depth = Math.Min(FlacDepthsFor(ResolveBitDepths(capabilities)).Max(), DefaultMaxBitDepth);
+
+        return Match(formats, "flac", rate, depth)
+            ?? formats.FirstOrDefault(f => f.Codec == "flac")
+            ?? formats[0];
+    }
+
+    /// <summary>
+    /// Resolves a persisted preference string to one entry of <paramref name="formats"/>.
+    /// </summary>
+    /// <param name="formats">The list from <see cref="BuildFormats"/>.</param>
+    /// <param name="preference">
+    /// <c>null</c>/empty or <c>"all"</c> for the default anchor, <c>"auto"</c> for the device's
+    /// native best, or <c>codec-rate</c> / <c>codec-rate-depth</c> (e.g. <c>"flac-48000"</c>,
+    /// <c>"pcm-96000-24"</c>). A missing depth is resolved from the device.
+    /// </param>
+    /// <param name="capabilities">Probed device capabilities, or null when unavailable.</param>
+    /// <returns>The matching entry, or null when an explicit preference matches nothing the device can do.</returns>
+    public static AudioFormat? ResolvePreferred(
+        IReadOnlyList<AudioFormat> formats,
+        string? preference,
+        DeviceCapabilities? capabilities)
+    {
+        if (formats.Count == 0)
+            return null;
+
+        if (string.IsNullOrWhiteSpace(preference) ||
+            preference.Equals(AllFormatsId, StringComparison.OrdinalIgnoreCase))
+        {
+            return ResolveDefault(formats, capabilities);
+        }
+
+        if (preference.Equals(AutoFormatId, StringComparison.OrdinalIgnoreCase))
+        {
+            // Device native: highest rate the device does, at the best depth flac can carry.
+            var nativeRate = ResolveSampleRates(capabilities)[0];
+            return Match(formats, "flac", nativeRate, FlacDepthsFor(ResolveBitDepths(capabilities)).Max())
+                ?? formats.FirstOrDefault(f => f.Codec == "flac");
+        }
+
+        var parts = preference.Split('-');
+        if (parts.Length < 2 || !int.TryParse(parts[1], out var sampleRate))
+            return null;
+
+        var codec = parts[0].ToLowerInvariant();
+
+        if (parts.Length >= 3 && int.TryParse(parts[2], out var bitDepth))
+            return Match(formats, codec, sampleRate, bitDepth);
+
+        // Legacy two-part form ("flac-48000"): the depth comes from the device, best first.
+        return formats
+            .Where(f => f.Codec.Equals(codec, StringComparison.OrdinalIgnoreCase) && f.SampleRate == sampleRate)
+            .OrderByDescending(f => f.BitDepth ?? 0)
+            .FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Returns the full list with <paramref name="preferred"/> moved to index 0,
+    /// the remainder keeping its descending-quality order.
+    /// </summary>
+    /// <param name="formats">The list from <see cref="BuildFormats"/>.</param>
+    /// <param name="preferred">The entry to advertise first.</param>
+    /// <returns>A new, reordered list.</returns>
+    public static List<AudioFormat> WithPreferredFirst(IReadOnlyList<AudioFormat> formats, AudioFormat preferred)
+    {
+        var ordered = new List<AudioFormat>(formats.Count) { preferred };
+        ordered.AddRange(formats.Where(f => !ReferenceEquals(f, preferred)));
+        return ordered;
+    }
+
+    /// <summary>
+    /// Renders a format as the preference string persisted in players.yaml.
+    /// </summary>
+    /// <param name="format">The format to render.</param>
+    /// <returns>e.g. <c>"flac-48000-24"</c>, or <c>"opus-48000"</c> for depthless codecs.</returns>
+    public static string ToFormatId(AudioFormat format) =>
+        format.BitDepth.HasValue
+            ? $"{format.Codec}-{format.SampleRate}-{format.BitDepth}"
+            : $"{format.Codec}-{format.SampleRate}";
+
+    /// <summary>
+    /// Builds the selectable format options for a device, for the player settings dropdown.
+    /// </summary>
+    /// <param name="capabilities">Probed device capabilities, or null when unavailable.</param>
+    /// <returns>"Auto (device native)" first, then every advertisable format, best quality first.</returns>
+    public static List<AudioFormatOption> BuildOptions(DeviceCapabilities? capabilities)
+    {
+        var formats = BuildFormats(capabilities);
+        var defaultFormat = ResolveDefault(formats, capabilities);
+        var nativeRate = ResolveSampleRates(capabilities)[0];
+        var nativeDepth = FlacDepthsFor(ResolveBitDepths(capabilities)).Max();
+
+        var options = new List<AudioFormatOption>
+        {
+            new(AutoFormatId,
+                "Auto (device native)",
+                $"Follow the device: FLAC {DescribeRate(nativeRate)} {nativeDepth}-bit")
+        };
+
+        foreach (var format in formats)
+        {
+            var label = format.BitDepth.HasValue
+                ? $"{format.Codec.ToUpperInvariant()} {DescribeRate(format.SampleRate)} {format.BitDepth}-bit"
+                : $"{format.Codec.ToUpperInvariant()} {DescribeRate(format.SampleRate)}";
+
+            options.Add(new AudioFormatOption(ToFormatId(format), label, DescribeFormat(format, defaultFormat)));
+        }
+
+        return options;
+    }
+
+    /// <summary>
+    /// Gets the preference string a player with no saved format resolves to on this device.
+    /// </summary>
+    /// <param name="capabilities">Probed device capabilities, or null when unavailable.</param>
+    /// <returns>The default anchor's format id.</returns>
+    public static string GetDefaultFormatId(DeviceCapabilities? capabilities)
+    {
+        var formats = BuildFormats(capabilities);
+        return ToFormatId(ResolveDefault(formats, capabilities));
+    }
+
+    private static AudioFormat? Match(IReadOnlyList<AudioFormat> formats, string codec, int sampleRate, int bitDepth) =>
+        formats.FirstOrDefault(f =>
+            f.Codec.Equals(codec, StringComparison.OrdinalIgnoreCase) &&
+            f.SampleRate == sampleRate &&
+            f.BitDepth == bitDepth);
+
+    /// <summary>Device rates, music rates only, best first. Falls back to the static table when the probe gave us nothing.</summary>
+    private static int[] ResolveSampleRates(DeviceCapabilities? capabilities)
+    {
+        var rates = capabilities?.SupportedSampleRates?
+            .Where(r => r >= MinAdvertisedSampleRate)
+            .Distinct()
+            .OrderByDescending(r => r)
+            .ToArray();
+
+        return rates is { Length: > 0 } ? rates : FallbackSampleRates;
+    }
+
+    /// <summary>Device depths we can actually encode, best first. Falls back to the static table when the probe gave us nothing.</summary>
+    private static int[] ResolveBitDepths(DeviceCapabilities? capabilities)
+    {
+        var depths = capabilities?.SupportedBitDepths?
+            .Where(d => PcmBitDepths.Contains(d))
+            .Distinct()
+            .OrderByDescending(d => d)
+            .ToArray();
+
+        return depths is { Length: > 0 } ? depths : FallbackBitDepths;
+    }
+
+    /// <summary>
+    /// FLAC depths for a device. A device that only reports 32-bit (the PulseAudio float32
+    /// fallback) still gets 24-bit FLAC — the alternative is 16 and a repeat of #280.
+    /// </summary>
+    private static int[] FlacDepthsFor(int[] deviceDepths)
+    {
+        var supported = FlacBitDepths.Where(deviceDepths.Contains).ToArray();
+        return supported.Length > 0 ? supported : [24];
+    }
+
+    private static int NearestSampleRate(int[] rates, int target)
+    {
+        if (rates.Contains(target))
+            return target;
+
+        // Ties go to the higher rate — upsampling beats losing detail.
+        return rates.OrderBy(r => Math.Abs(r - target)).ThenByDescending(r => r).First();
+    }
+
+    private static string DescribeRate(int sampleRate) =>
+        sampleRate % 1000 == 0
+            ? $"{sampleRate / 1000}kHz"
+            : $"{sampleRate / 1000.0:0.#}kHz";
+
+    private static string DescribeFormat(AudioFormat format, AudioFormat defaultFormat)
+    {
+        var basis = format.Codec switch
+        {
+            "flac" => "Lossless compressed",
+            "pcm" => "Uncompressed",
+            "opus" => $"Lossy compressed, {OpusBitrateKbps}kbps",
+            _ => format.Codec
+        };
+
+        return ReferenceEquals(format, defaultFormat) ? $"{basis} (default)" : basis;
+    }
+}

--- a/src/MultiRoomAudio/Controllers/PlayersEndpoint.cs
+++ b/src/MultiRoomAudio/Controllers/PlayersEndpoint.cs
@@ -60,21 +60,15 @@ public static class PlayersEndpoint
         // GET /api/players/formats - Format options the selected device can actually do
         group.MapGet("/formats", (
             string? device,
-            BackendFactory backendFactory,
             DeviceMatchingService deviceMatching,
             ILoggerFactory loggerFactory) =>
         {
             var logger = loggerFactory.CreateLogger("PlayersEndpoint");
-            logger.LogDebug("API: GET /api/players/formats?device={Device}", device ?? "(none)");
+            logger.LogDebug("API: GET /api/players/formats?device={Device}", device ?? "(default)");
 
-            // The enriched device carries ALSA-probed hardware capabilities; the backend probe is
-            // one fixed hi-res table for every sink, so it is only a fallback.
-            // Null capabilities are fine - the catalog falls back to a static, explicitly bit-depthed list.
-            var capabilities = string.IsNullOrWhiteSpace(device)
-                ? null
-                : AudioFormatCatalog.CapabilitiesFor(
-                    deviceMatching.GetEnrichedDevice(device),
-                    backendFactory.GetDeviceCapabilities(device));
+            // Same resolution the player itself uses, so the options offered here are the ones it
+            // will advertise. Omitting the device means the default sink, not "no device".
+            var capabilities = deviceMatching.GetFormatCapabilities(device);
 
             return Results.Ok(new AudioFormatsResponse(
                 AudioFormatCatalog.BuildOptions(capabilities),

--- a/src/MultiRoomAudio/Controllers/PlayersEndpoint.cs
+++ b/src/MultiRoomAudio/Controllers/PlayersEndpoint.cs
@@ -58,15 +58,23 @@ public static class PlayersEndpoint
             .WithOpenApi();
 
         // GET /api/players/formats - Format options the selected device can actually do
-        group.MapGet("/formats", (string? device, BackendFactory backendFactory, ILoggerFactory loggerFactory) =>
+        group.MapGet("/formats", (
+            string? device,
+            BackendFactory backendFactory,
+            DeviceMatchingService deviceMatching,
+            ILoggerFactory loggerFactory) =>
         {
             var logger = loggerFactory.CreateLogger("PlayersEndpoint");
             logger.LogDebug("API: GET /api/players/formats?device={Device}", device ?? "(none)");
 
-            // Null capabilities are fine - the catalog falls back to a static, explicitly bit-depthed list
+            // The enriched device carries ALSA-probed hardware capabilities; the backend probe is
+            // one fixed hi-res table for every sink, so it is only a fallback.
+            // Null capabilities are fine - the catalog falls back to a static, explicitly bit-depthed list.
             var capabilities = string.IsNullOrWhiteSpace(device)
                 ? null
-                : backendFactory.GetDeviceCapabilities(device);
+                : AudioFormatCatalog.CapabilitiesFor(
+                    deviceMatching.GetEnrichedDevice(device),
+                    backendFactory.GetDeviceCapabilities(device));
 
             return Results.Ok(new AudioFormatsResponse(
                 AudioFormatCatalog.BuildOptions(capabilities),
@@ -474,10 +482,13 @@ public static class PlayersEndpoint
                             currentName, savedConfig.Volume);
                     }
 
-                    // Persist device change
+                    // Persist device change. supported_formats is derived from the device, and
+                    // SwitchDeviceAsync only swaps the pipeline - the player has to restart to
+                    // re-announce, or MA keeps offering the previous device's formats.
                     if (request.Device != null && request.Device != savedConfig.Device)
                     {
                         savedConfig.Device = request.Device;
+                        needsRestart = true;
                         logger.LogInformation("API: Player {PlayerName} device persisted to '{Device}'",
                             currentName, savedConfig.Device == "" ? "(none)" : savedConfig.Device);
                     }

--- a/src/MultiRoomAudio/Controllers/PlayersEndpoint.cs
+++ b/src/MultiRoomAudio/Controllers/PlayersEndpoint.cs
@@ -1,3 +1,4 @@
+using MultiRoomAudio.Audio;
 using MultiRoomAudio.Models;
 using MultiRoomAudio.Services;
 using MultiRoomAudio.Utilities;
@@ -56,40 +57,23 @@ public static class PlayersEndpoint
             .WithTags("Players")
             .WithOpenApi();
 
-        var environment = app.Services.GetRequiredService<EnvironmentService>();
-
-        // GET /api/players/formats - Get available audio format options (conditional)
-        // Only registered if ENABLE_ADVANCED_FORMATS is enabled
-        if (environment.EnableAdvancedFormats)
+        // GET /api/players/formats - Format options the selected device can actually do
+        group.MapGet("/formats", (string? device, BackendFactory backendFactory, ILoggerFactory loggerFactory) =>
         {
-            group.MapGet("/formats", (ILoggerFactory loggerFactory) =>
-            {
-                var logger = loggerFactory.CreateLogger("PlayersEndpoint");
-                logger.LogDebug("API: GET /api/players/formats");
+            var logger = loggerFactory.CreateLogger("PlayersEndpoint");
+            logger.LogDebug("API: GET /api/players/formats?device={Device}", device ?? "(none)");
 
-                var formats = new List<AudioFormatOption>
-                {
-                    new("flac-48000", "FLAC 48kHz", "CD quality lossless 48kHz (default, works with all MA builds)"),
-                    new("all", "All Formats", "Advertise all supported formats"),
-                    new("flac-192000", "FLAC 192kHz", "Hi-res lossless 192kHz"),
-                    new("flac-96000", "FLAC 96kHz", "Hi-res lossless 96kHz"),
-                    new("flac-44100", "FLAC 44.1kHz", "CD quality lossless 44.1kHz"),
-                    new("pcm-192000-32", "PCM 192kHz 32-bit", "Hi-res uncompressed 192kHz 32-bit"),
-                    new("pcm-96000-32", "PCM 96kHz 32-bit", "Hi-res uncompressed 96kHz 32-bit"),
-                    new("pcm-48000-32", "PCM 48kHz 32-bit", "CD quality uncompressed 48kHz 32-bit"),
-                    new("pcm-192000-24", "PCM 192kHz 24-bit", "Hi-res uncompressed 192kHz 24-bit"),
-                    new("pcm-96000-24", "PCM 96kHz 24-bit", "Hi-res uncompressed 96kHz 24-bit"),
-                    new("pcm-48000-24", "PCM 48kHz 24-bit", "CD quality uncompressed 48kHz 24-bit"),
-                    new("pcm-48000-16", "PCM 48kHz 16-bit", "Standard uncompressed 48kHz 16-bit"),
-                    new("pcm-44100-16", "PCM 44.1kHz 16-bit", "CD quality uncompressed 44.1kHz 16-bit"),
-                    new("opus-48000", "Opus 48kHz", "Efficient compressed 48kHz (256kbps)")
-                };
+            // Null capabilities are fine - the catalog falls back to a static, explicitly bit-depthed list
+            var capabilities = string.IsNullOrWhiteSpace(device)
+                ? null
+                : backendFactory.GetDeviceCapabilities(device);
 
-                return Results.Ok(new AudioFormatsResponse(formats));
-            })
-            .WithName("GetAudioFormats")
-            .WithDescription("Get list of available audio formats for player configuration (dev-only feature)");
-        }
+            return Results.Ok(new AudioFormatsResponse(
+                AudioFormatCatalog.BuildOptions(capabilities),
+                AudioFormatCatalog.GetDefaultFormatId(capabilities)));
+        })
+        .WithName("GetAudioFormats")
+        .WithDescription("Get the audio formats a device can be advertised as supporting");
 
         // GET /api/players - List all players
         group.MapGet("/", (PlayerManagerService manager, ILoggerFactory loggerFactory) =>
@@ -504,15 +488,14 @@ public static class PlayersEndpoint
                         needsRestart = true;
                     }
 
-                    // Handle advertised format change (only when advanced formats enabled)
-                    if (environment.EnableAdvancedFormats &&
-                        request.AdvertisedFormat != null &&
+                    // Handle advertised format change
+                    if (request.AdvertisedFormat != null &&
                         request.AdvertisedFormat != savedConfig.AdvertisedFormat)
                     {
                         savedConfig.AdvertisedFormat = request.AdvertisedFormat == "" ? null : request.AdvertisedFormat;
                         needsRestart = true;
                         logger.LogInformation("API: Player {PlayerName} advertised format changed to '{Format}'",
-                            currentName, savedConfig.AdvertisedFormat ?? "all");
+                            currentName, savedConfig.AdvertisedFormat ?? "(device default)");
                     }
 
                     // Handle buffer size change

--- a/src/MultiRoomAudio/Models/AudioFormatModels.cs
+++ b/src/MultiRoomAudio/Models/AudioFormatModels.cs
@@ -12,6 +12,9 @@ public record AudioFormatOption(
 /// <summary>
 /// Response containing available audio format options.
 /// </summary>
+/// <param name="Formats">Selectable formats, best quality first.</param>
+/// <param name="DefaultFormatId">Id of the format a player with no saved preference advertises.</param>
 public record AudioFormatsResponse(
-    List<AudioFormatOption> Formats
+    List<AudioFormatOption> Formats,
+    string? DefaultFormatId = null
 );

--- a/src/MultiRoomAudio/Models/PlayerConfig.cs
+++ b/src/MultiRoomAudio/Models/PlayerConfig.cs
@@ -69,9 +69,11 @@ public class PlayerCreateRequest
     public bool Persist { get; set; } = true;
 
     /// <summary>
-    /// Specific audio format to advertise. If null or empty, defaults to "flac-48000" for maximum MA compatibility.
-    /// Format string: "codec-samplerate-bitdepth" (e.g., "flac-192000", "pcm-96000-24").
-    /// UI selection only available when ENABLE_ADVANCED_FORMATS is enabled.
+    /// Format to advertise first in <c>supported_formats</c>. Null means the device default
+    /// (FLAC 48kHz at the device's best depth, capped at 24-bit).
+    /// Format string: <c>"codec-samplerate"</c> or <c>"codec-samplerate-bitdepth"</c>
+    /// (e.g. <c>"flac-48000"</c>, <c>"pcm-96000-24"</c>), or <c>"auto"</c> for the device's native best.
+    /// See <see cref="Audio.AudioFormatCatalog"/>.
     /// </summary>
     [StringLength(50, ErrorMessage = "AdvertisedFormat cannot exceed 50 characters.")]
     public string? AdvertisedFormat { get; set; }
@@ -160,9 +162,11 @@ public class PlayerUpdateRequest
     public int? BufferSizeMs { get; set; }
 
     /// <summary>
-    /// Specific audio format to advertise. If null or empty, defaults to "flac-48000" for maximum MA compatibility.
-    /// Format string: "codec-samplerate-bitdepth" (e.g., "flac-192000", "pcm-96000-24").
-    /// UI selection only available when ENABLE_ADVANCED_FORMATS is enabled.
+    /// Format to advertise first in <c>supported_formats</c>. Null means the device default
+    /// (FLAC 48kHz at the device's best depth, capped at 24-bit).
+    /// Format string: <c>"codec-samplerate"</c> or <c>"codec-samplerate-bitdepth"</c>
+    /// (e.g. <c>"flac-48000"</c>, <c>"pcm-96000-24"</c>), or <c>"auto"</c> for the device's native best.
+    /// See <see cref="Audio.AudioFormatCatalog"/>.
     /// </summary>
     [StringLength(50, ErrorMessage = "AdvertisedFormat cannot exceed 50 characters.")]
     public string? AdvertisedFormat { get; set; }

--- a/src/MultiRoomAudio/Services/DeviceMatchingService.cs
+++ b/src/MultiRoomAudio/Services/DeviceMatchingService.cs
@@ -298,6 +298,28 @@ public class DeviceMatchingService
     }
 
     /// <summary>
+    /// Resolves the capabilities used to build a device's advertised audio formats.
+    /// </summary>
+    /// <param name="deviceId">Sink name, or null/empty for the default device.</param>
+    /// <returns>ALSA-probed capabilities where available, the backend probe otherwise, or null.</returns>
+    /// <remarks>
+    /// The backend probe is one fixed hi-res table for every sink under PulseAudio, so it is
+    /// only ever a fallback. A null device means the default sink rather than "no hardware",
+    /// so its id is resolved first — otherwise those players advertise rates the default DAC
+    /// may not support.
+    /// </remarks>
+    public DeviceCapabilities? GetFormatCapabilities(string? deviceId)
+    {
+        var resolvedId = string.IsNullOrWhiteSpace(deviceId)
+            ? _backend.GetDefaultDevice()?.Id
+            : deviceId;
+
+        var enriched = string.IsNullOrWhiteSpace(resolvedId) ? null : GetEnrichedDevice(resolvedId);
+
+        return AudioFormatCatalog.CapabilitiesFor(enriched, _backend.GetDeviceCapabilities(resolvedId));
+    }
+
+    /// <summary>
     /// Get a single device by ID, enriched with alias and hidden status.
     /// Returns null if the device is not found.
     /// </summary>

--- a/src/MultiRoomAudio/Services/EnvironmentService.cs
+++ b/src/MultiRoomAudio/Services/EnvironmentService.cs
@@ -102,7 +102,7 @@ public class EnvironmentService
 
         if (_enableAdvancedFormats)
         {
-            _logger.LogInformation("ENABLE_ADVANCED_FORMATS mode enabled - per-player format selection available");
+            _logger.LogInformation("ENABLE_ADVANCED_FORMATS is set but no longer does anything - format selection is always available");
         }
 
         // Detect buffer seconds setting

--- a/src/MultiRoomAudio/Services/PlayerManagerService.cs
+++ b/src/MultiRoomAudio/Services/PlayerManagerService.cs
@@ -968,12 +968,11 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
     /// <returns>Record containing all SDK components.</returns>
     private PlayerComponents CreateSdkComponents(PlayerCreateRequest request)
     {
-        // Probe device capabilities (used for reporting in Stats for Nerds)
+        // Probe device capabilities: drives both format advertisement and Stats for Nerds reporting
         var deviceCapabilities = _backendFactory.GetDeviceCapabilities(request.Device);
 
-        // Apply format filtering (always defaults to flac-48000 for maximum compatibility)
-        var audioFormats = GetDefaultFormats();
-        audioFormats = FilterFormatsByPreference(audioFormats, request.AdvertisedFormat);
+        // Advertise everything the DAC can do, with the player's preference at index 0
+        var audioFormats = BuildAdvertisedFormats(request.Name, request.AdvertisedFormat, deviceCapabilities);
 
         // Create capabilities with player role
         var clientCapabilities = new ClientCapabilities
@@ -3258,91 +3257,36 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
         return ClientIdGenerator.Generate(name);
     }
 
-    private static List<AudioFormat> GetDefaultFormats()
-    {
-        // Advertise hi-res formats to SendSpin/Music Assistant server
-        // Server will send highest quality available that we support
-        return new List<AudioFormat>
-        {
-            // Hi-res FLAC (preferred for quality)
-            new AudioFormat { Codec = "flac", SampleRate = 192000, Channels = 2 },
-            new AudioFormat { Codec = "flac", SampleRate = 96000, Channels = 2 },
-            new AudioFormat { Codec = "flac", SampleRate = 48000, Channels = 2 },
-            new AudioFormat { Codec = "flac", SampleRate = 44100, Channels = 2 },
-            // Hi-res PCM
-            new AudioFormat { Codec = "pcm", SampleRate = 192000, Channels = 2, BitDepth = 32 },
-            new AudioFormat { Codec = "pcm", SampleRate = 96000, Channels = 2, BitDepth = 32 },
-            new AudioFormat { Codec = "pcm", SampleRate = 48000, Channels = 2, BitDepth = 32 },
-            new AudioFormat { Codec = "pcm", SampleRate = 192000, Channels = 2, BitDepth = 24 },
-            new AudioFormat { Codec = "pcm", SampleRate = 96000, Channels = 2, BitDepth = 24 },
-            new AudioFormat { Codec = "pcm", SampleRate = 48000, Channels = 2, BitDepth = 24 },
-            new AudioFormat { Codec = "pcm", SampleRate = 48000, Channels = 2, BitDepth = 16 },
-            new AudioFormat { Codec = "pcm", SampleRate = 44100, Channels = 2, BitDepth = 16 },
-            // Opus for efficiency when streaming
-            new AudioFormat { Codec = "opus", SampleRate = 48000, Channels = 2, Bitrate = 256 },
-        };
-    }
-
     /// <summary>
-    /// Filters advertised audio formats based on user preference.
-    /// Defaults to flac-48000 for maximum MA compatibility when no format specified.
+    /// Builds the format list a player advertises, derived from its DAC and ordered by the player's preference.
     /// </summary>
-    /// <param name="allFormats">List of all supported formats.</param>
-    /// <param name="advertisedFormat">Format preference string (e.g., "flac-192000", "pcm-96000-24"). If null/empty, defaults to "flac-48000".</param>
-    /// <returns>Filtered list containing only the preferred format, or all formats if preference is "all".</returns>
-    private List<AudioFormat> FilterFormatsByPreference(List<AudioFormat> allFormats, string? advertisedFormat)
+    /// <param name="playerName">Player name, for logging.</param>
+    /// <param name="advertisedFormat">Persisted preference string, or null for the device default.</param>
+    /// <param name="capabilities">Probed device capabilities, or null when unavailable.</param>
+    /// <returns>The full advertisable list with the preferred entry first.</returns>
+    private List<AudioFormat> BuildAdvertisedFormats(
+        string playerName,
+        string? advertisedFormat,
+        DeviceCapabilities? capabilities)
     {
-        // Default to flac-48000 for maximum compatibility with all MA builds
-        if (string.IsNullOrWhiteSpace(advertisedFormat))
+        var allFormats = AudioFormatCatalog.BuildFormats(capabilities);
+
+        var preferred = AudioFormatCatalog.ResolvePreferred(allFormats, advertisedFormat, capabilities);
+        if (preferred == null)
         {
-            advertisedFormat = "flac-48000";
+            preferred = AudioFormatCatalog.ResolveDefault(allFormats, capabilities);
+            _logger.LogWarning(
+                "Player '{Name}': device cannot do advertised format '{Format}', falling back to {Fallback}",
+                playerName, advertisedFormat, AudioFormatCatalog.ToFormatId(preferred));
         }
 
-        // If explicitly set to "all", return all formats
-        if (advertisedFormat.Equals("all", StringComparison.OrdinalIgnoreCase))
-        {
-            return allFormats;
-        }
+        var ordered = AudioFormatCatalog.WithPreferredFirst(allFormats, preferred);
 
-        // Parse format string (e.g., "flac-192000" or "pcm-96000-24")
-        var parts = advertisedFormat.Split('-');
-        if (parts.Length < 2)
-        {
-            _logger.LogWarning("Invalid advertised format '{Format}', using all formats", advertisedFormat);
-            return allFormats;
-        }
+        _logger.LogInformation(
+            "Player '{Name}': advertising {Count} formats, preferred {Preferred}",
+            playerName, ordered.Count, AudioFormatCatalog.ToFormatId(preferred));
 
-        var codec = parts[0].ToLowerInvariant();
-        if (!int.TryParse(parts[1], out var sampleRate))
-        {
-            _logger.LogWarning("Invalid sample rate in format '{Format}', using all formats", advertisedFormat);
-            return allFormats;
-        }
-
-        int? bitDepth = null;
-        if (parts.Length >= 3 && int.TryParse(parts[2], out var parsedBitDepth))
-        {
-            bitDepth = parsedBitDepth;
-        }
-
-        // Find matching format
-        var matchingFormat = allFormats.FirstOrDefault(f =>
-            f.Codec.Equals(codec, StringComparison.OrdinalIgnoreCase) &&
-            f.SampleRate == sampleRate &&
-            (bitDepth == null || f.BitDepth == bitDepth));
-
-        if (matchingFormat != null)
-        {
-            _logger.LogInformation(
-                "Advertising single format: {Codec} {SampleRate}Hz{BitDepth}",
-                matchingFormat.Codec,
-                matchingFormat.SampleRate,
-                matchingFormat.BitDepth.HasValue ? $" {matchingFormat.BitDepth}-bit" : "");
-            return new List<AudioFormat> { matchingFormat };
-        }
-
-        _logger.LogWarning("Format '{Format}' not found, using all formats", advertisedFormat);
-        return allFormats;
+        return ordered;
     }
 
     /// <summary>

--- a/src/MultiRoomAudio/Services/PlayerManagerService.cs
+++ b/src/MultiRoomAudio/Services/PlayerManagerService.cs
@@ -3264,25 +3264,25 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
     /// <returns>The device's ALSA-probed capabilities, or the backend's own probe when it has none.</returns>
     /// <remarks>
     /// The backend probe is a single fixed hi-res table under PulseAudio, so it must not be the
-    /// primary source — only the enriched device carries per-device hardware data.
+    /// primary source — only the enriched device carries per-device hardware data. A null device
+    /// resolves to the default sink, which has real capabilities of its own.
     /// </remarks>
     private DeviceCapabilities? ResolveDeviceCapabilities(string? deviceId)
     {
-        AudioDevice? enriched = null;
-        if (!string.IsNullOrWhiteSpace(deviceId))
+        try
         {
-            try
-            {
-                enriched = _serviceProvider.GetService<DeviceMatchingService>()?.GetEnrichedDevice(deviceId);
-            }
-            catch (Exception ex)
-            {
-                // Capability lookup must never block player creation
-                _logger.LogDebug(ex, "Could not resolve enriched capabilities for device '{Device}'", deviceId);
-            }
+            var matching = _serviceProvider.GetService<DeviceMatchingService>();
+            if (matching != null)
+                return matching.GetFormatCapabilities(deviceId);
+        }
+        catch (Exception ex)
+        {
+            // Capability lookup must never block player creation
+            _logger.LogDebug(ex, "Could not resolve enriched capabilities for device '{Device}'",
+                deviceId ?? "(default)");
         }
 
-        return AudioFormatCatalog.CapabilitiesFor(enriched, _backendFactory.GetDeviceCapabilities(deviceId));
+        return _backendFactory.GetDeviceCapabilities(deviceId);
     }
 
     /// <summary>

--- a/src/MultiRoomAudio/Services/PlayerManagerService.cs
+++ b/src/MultiRoomAudio/Services/PlayerManagerService.cs
@@ -969,7 +969,7 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
     private PlayerComponents CreateSdkComponents(PlayerCreateRequest request)
     {
         // Probe device capabilities: drives both format advertisement and Stats for Nerds reporting
-        var deviceCapabilities = _backendFactory.GetDeviceCapabilities(request.Device);
+        var deviceCapabilities = ResolveDeviceCapabilities(request.Device);
 
         // Advertise everything the DAC can do, with the player's preference at index 0
         var audioFormats = BuildAdvertisedFormats(request.Name, request.AdvertisedFormat, deviceCapabilities);
@@ -3255,6 +3255,34 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
     {
         // Use the ClientIdGenerator utility for consistent MD5-based IDs
         return ClientIdGenerator.Generate(name);
+    }
+
+    /// <summary>
+    /// Resolves the capabilities used for a player's advertised formats and stats reporting.
+    /// </summary>
+    /// <param name="deviceId">Sink name of the player's device, or null for the default device.</param>
+    /// <returns>The device's ALSA-probed capabilities, or the backend's own probe when it has none.</returns>
+    /// <remarks>
+    /// The backend probe is a single fixed hi-res table under PulseAudio, so it must not be the
+    /// primary source — only the enriched device carries per-device hardware data.
+    /// </remarks>
+    private DeviceCapabilities? ResolveDeviceCapabilities(string? deviceId)
+    {
+        AudioDevice? enriched = null;
+        if (!string.IsNullOrWhiteSpace(deviceId))
+        {
+            try
+            {
+                enriched = _serviceProvider.GetService<DeviceMatchingService>()?.GetEnrichedDevice(deviceId);
+            }
+            catch (Exception ex)
+            {
+                // Capability lookup must never block player creation
+                _logger.LogDebug(ex, "Could not resolve enriched capabilities for device '{Device}'", deviceId);
+            }
+        }
+
+        return AudioFormatCatalog.CapabilitiesFor(enriched, _backendFactory.GetDeviceCapabilities(deviceId));
     }
 
     /// <summary>

--- a/src/MultiRoomAudio/wwwroot/index.html
+++ b/src/MultiRoomAudio/wwwroot/index.html
@@ -247,7 +247,7 @@
                         </div>
                         <div class="mb-3">
                             <label for="audioDevice" class="form-label">Audio Device</label>
-                            <select class="form-select" id="audioDevice">
+                            <select class="form-select" id="audioDevice" onchange="refreshFormats(this.value, '')">
                                 <option value="">Default Device</option>
                             </select>
                             <button type="button" class="btn btn-link btn-sm p-0 mt-1" onclick="refreshDevices()">
@@ -271,12 +271,12 @@
                             </div>
                             <small class="text-muted">Player always restarts when device reconnects. This controls whether playback resumes automatically.</small>
                         </div>
-                        <div class="mb-3" id="advertisedFormatGroup" style="display: none;">
+                        <div class="mb-3" id="advertisedFormatGroup">
                             <label for="advertisedFormat" class="form-label">Advertised Format</label>
                             <select class="form-select" id="advertisedFormat">
-                                <option value="all">All Formats (default)</option>
+                                <option value="" disabled selected>Select a device first...</option>
                             </select>
-                            <small class="text-muted">Format to advertise to the server. Player will restart when changed.</small>
+                            <small class="text-muted">Preferred format offered to the server, chosen from what the device supports. Player will restart when changed.</small>
                         </div>
                     </form>
                 </div>

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -1590,7 +1590,7 @@ async function showPlayerStats(name) {
     const usesDeviceDefault = !advertised || advertised === 'all';
     const advertisedDisplay = usesDeviceDefault ? 'Device default' : advertised;
     const advertisedSubtitle = usesDeviceDefault
-        ? '<br><small class="text-muted">FLAC 48kHz at the device\'s best depth (max 24-bit)</small>'
+        ? '<br><small class="text-muted">FLAC at the device\'s best depth (max 24-bit), 48kHz or its nearest supported rate</small>'
         : '';
 
     // Output format - use device already looked up above

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -926,8 +926,21 @@ async function refreshStatus(force = false, manual = false) {
     }
 }
 
+// Map a persisted format preference onto one of this device's option ids, mirroring how the
+// server resolves it. Legacy values ("all", and two-part "codec-rate" with no bit depth) are
+// still valid on the wire but never appear verbatim in the options list.
+function resolveFormatId(saved, options, defaultFormatId) {
+    if (!saved || saved === 'all') return defaultFormatId;
+    if (options.some(o => o.id === saved)) return saved;
+
+    // "flac-48000" -> the best depth this device offers at that codec/rate (options are best-first)
+    const withDepth = options.find(o => o.id.startsWith(`${saved}-`));
+    return withDepth ? withDepth.id : saved;
+}
+
 // Populate the advertised-format dropdown from what the selected device can actually do.
 // `desiredValue` keeps a player's saved format selected even when it predates this list.
+// Returns the option id that ended up selected, or null if the fetch failed.
 async function refreshFormats(deviceId = null, desiredValue = null) {
     const formatSelect = document.getElementById('advertisedFormat');
     if (!formatSelect) return null;
@@ -953,16 +966,18 @@ async function refreshFormats(deviceId = null, desiredValue = null) {
             formatSelect.appendChild(option);
         });
 
-        // A saved format the device no longer offers must stay visible, not silently change
-        if (keepValue && !formats.some(f => f.id === keepValue)) {
+        const resolved = resolveFormatId(keepValue, formats, defaultFormatId);
+
+        // A saved format this device genuinely cannot do must stay visible, not silently change
+        if (resolved && !formats.some(f => f.id === resolved)) {
             const option = document.createElement('option');
-            option.value = keepValue;
-            option.textContent = `${keepValue} (not supported by this device)`;
+            option.value = resolved;
+            option.textContent = `${resolved} (not supported by this device)`;
             formatSelect.insertBefore(option, formatSelect.firstChild);
         }
 
-        formatSelect.value = keepValue || defaultFormatId || '';
-        return defaultFormatId;
+        formatSelect.value = resolved || defaultFormatId || '';
+        return formatSelect.value;
     } catch (error) {
         console.error('Error refreshing formats:', error);
         return null;
@@ -1132,9 +1147,11 @@ async function openEditPlayerModal(playerName) {
 
         // Populate the advertised format dropdown from this player's device.
         // An unset format means "device default" - show it as such rather than guessing an id.
+        // Track the id that was actually selected, so re-saving an untouched legacy value
+        // ("flac-48000", "all") does not read as a change and needlessly restart the player.
         const savedFormat = player.advertisedFormat || '';
-        const defaultFormatId = await refreshFormats(player.device, savedFormat);
-        document.getElementById('playerForm').dataset.originalFormat = savedFormat || defaultFormatId || '';
+        const selectedFormat = await refreshFormats(player.device, savedFormat);
+        document.getElementById('playerForm').dataset.originalFormat = selectedFormat ?? savedFormat;
 
         // Set modal to Edit mode
         document.getElementById('playerModalIcon').className = 'fas fa-edit me-2';

--- a/src/MultiRoomAudio/wwwroot/js/app.js
+++ b/src/MultiRoomAudio/wwwroot/js/app.js
@@ -4,7 +4,6 @@
 let players = {};
 let devices = [];
 let formats = [];
-let advancedFormatsEnabled = false;
 let connection = null;
 let currentBuildVersion = null; // Stored build version for comparison
 let isUserInteracting = false; // Track if user is dragging a slider
@@ -585,10 +584,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     // Load data that doesn't depend on startup completion
-    await Promise.all([
-        checkAdvancedFormats(),
-        refreshBuildInfo()
-    ]);
+    await refreshBuildInfo();
 
     // Only load player/device data if startup is already complete
     if (startupComplete) {
@@ -930,44 +926,46 @@ async function refreshStatus(force = false, manual = false) {
     }
 }
 
-async function checkAdvancedFormats() {
-    try {
-        const response = await fetch('./api/players/formats');
-        advancedFormatsEnabled = response.ok;
+// Populate the advertised-format dropdown from what the selected device can actually do.
+// `desiredValue` keeps a player's saved format selected even when it predates this list.
+async function refreshFormats(deviceId = null, desiredValue = null) {
+    const formatSelect = document.getElementById('advertisedFormat');
+    if (!formatSelect) return null;
 
-        if (advancedFormatsEnabled) {
-            document.getElementById('advertisedFormatGroup').style.display = 'block';
-        }
-    } catch (error) {
-        advancedFormatsEnabled = false;
-    }
-}
-
-async function refreshFormats() {
-    if (!advancedFormatsEnabled) return;
+    // null means "keep what's selected"; '' means "reset to the device's default"
+    const keepValue = desiredValue !== null ? desiredValue : formatSelect.value;
 
     try {
-        const response = await fetch('./api/players/formats');
+        const query = deviceId ? `?device=${encodeURIComponent(deviceId)}` : '';
+        const response = await fetch(`./api/players/formats${query}`);
         if (!response.ok) throw new Error('Failed to fetch formats');
 
         const data = await response.json();
         formats = data.formats || [];
+        const defaultFormatId = data.defaultFormatId || null;
 
-        const formatSelect = document.getElementById('advertisedFormat');
-        if (formatSelect) {
-            const currentValue = formatSelect.value;
-            formatSelect.innerHTML = '';
-            formats.forEach(format => {
-                const option = document.createElement('option');
-                option.value = format.id;
-                option.textContent = format.label;
-                option.title = format.description;
-                formatSelect.appendChild(option);
-            });
-            if (currentValue) formatSelect.value = currentValue;
+        formatSelect.replaceChildren();
+        formats.forEach(format => {
+            const option = document.createElement('option');
+            option.value = format.id;
+            option.textContent = format.label;
+            option.title = format.description;
+            formatSelect.appendChild(option);
+        });
+
+        // A saved format the device no longer offers must stay visible, not silently change
+        if (keepValue && !formats.some(f => f.id === keepValue)) {
+            const option = document.createElement('option');
+            option.value = keepValue;
+            option.textContent = `${keepValue} (not supported by this device)`;
+            formatSelect.insertBefore(option, formatSelect.firstChild);
         }
+
+        formatSelect.value = keepValue || defaultFormatId || '';
+        return defaultFormatId;
     } catch (error) {
         console.error('Error refreshing formats:', error);
+        return null;
     }
 }
 
@@ -1085,9 +1083,7 @@ async function openAddPlayerModal() {
 
     // Refresh devices and formats
     await refreshDevices();
-    if (advancedFormatsEnabled) {
-        await refreshFormats();
-    }
+    await refreshFormats(document.getElementById('audioDevice').value, '');
 
     const modal = new bootstrap.Modal(document.getElementById('playerModal'));
     modal.show();
@@ -1134,21 +1130,11 @@ async function openEditPlayerModal(playerName) {
             }
         }
 
-        // Set advertised format dropdown (if advanced formats enabled)
-        if (advancedFormatsEnabled) {
-            // Refresh formats first to populate options
-            await refreshFormats();
-
-            // Store original format for change detection (default to flac-48000 for compatibility)
-            const originalFormat = player.advertisedFormat || 'flac-48000';
-            document.getElementById('playerForm').dataset.originalFormat = originalFormat;
-
-            // Set dropdown value AFTER options are populated
-            const formatSelect = document.getElementById('advertisedFormat');
-            if (formatSelect) {
-                formatSelect.value = originalFormat;
-            }
-        }
+        // Populate the advertised format dropdown from this player's device.
+        // An unset format means "device default" - show it as such rather than guessing an id.
+        const savedFormat = player.advertisedFormat || '';
+        const defaultFormatId = await refreshFormats(player.device, savedFormat);
+        document.getElementById('playerForm').dataset.originalFormat = savedFormat || defaultFormatId || '';
 
         // Set modal to Edit mode
         document.getElementById('playerModalIcon').className = 'fas fa-edit me-2';
@@ -1205,17 +1191,12 @@ async function savePlayer() {
                 // so it doesn't affect current playback
             };
 
-            // Include advertised format if advanced formats enabled
-            if (advancedFormatsEnabled) {
-                const form = document.getElementById('playerForm');
-                const originalFormat = form.dataset.originalFormat || 'flac-48000';
-                const currentFormat = document.getElementById('advertisedFormat').value || 'flac-48000';
-
-                // Only include if changed from original
-                if (currentFormat !== originalFormat) {
-                    // Send the specific format
-                    updatePayload.advertisedFormat = currentFormat;
-                }
+            // Only send the format when the user actually changed it - it forces a restart
+            const form = document.getElementById('playerForm');
+            const originalFormat = form.dataset.originalFormat || '';
+            const currentFormat = document.getElementById('advertisedFormat').value || '';
+            if (currentFormat !== originalFormat) {
+                updatePayload.advertisedFormat = currentFormat;
             }
 
             const response = await fetch(`./api/players/${encodeURIComponent(editingName)}`, {
@@ -1292,12 +1273,9 @@ async function savePlayer() {
                 persist: true
             };
 
-            // Include advertised format if advanced formats enabled
-            if (advancedFormatsEnabled) {
-                const advertisedFormat = document.getElementById('advertisedFormat').value;
-                if (advertisedFormat) {
-                    payload.advertisedFormat = advertisedFormat;
-                }
+            const advertisedFormat = document.getElementById('advertisedFormat').value;
+            if (advertisedFormat) {
+                payload.advertisedFormat = advertisedFormat;
             }
 
             const response = await fetch('./api/players', {
@@ -1590,11 +1568,13 @@ async function showPlayerStats(name) {
     const serverAddress = player.connectedAddress || '—';
     const discoveryMethod = player.serverUrl ? 'Manual' : 'Auto-discovered';
 
-    // Advertised format display
-    const advertised = player.advertisedFormat || 'flac-48000';
-    const isAllFormats = advertised === 'all';
-    const advertisedDisplay = isAllFormats ? 'All Formats' : advertised;
-    const advertisedSubtitle = isAllFormats ? '<br><small class="text-muted">flac • pcm • opus, up to 192kHz</small>' : '';
+    // Advertised format display. Unset (and the legacy "all") both mean the device-derived default.
+    const advertised = player.advertisedFormat;
+    const usesDeviceDefault = !advertised || advertised === 'all';
+    const advertisedDisplay = usesDeviceDefault ? 'Device default' : advertised;
+    const advertisedSubtitle = usesDeviceDefault
+        ? '<br><small class="text-muted">FLAC 48kHz at the device\'s best depth (max 24-bit)</small>'
+        : '';
 
     // Output format - use device already looked up above
     const outputFormat = device

--- a/tests/MultiRoomAudio.Tests/Audio/AudioFormatCatalogTests.cs
+++ b/tests/MultiRoomAudio.Tests/Audio/AudioFormatCatalogTests.cs
@@ -33,6 +33,62 @@ public class AudioFormatCatalogTests
         return AudioFormatCatalog.WithPreferredFirst(all, preferred);
     }
 
+    private static AudioDevice Device(DeviceCapabilities? capabilities) =>
+        new(
+            Index: 0,
+            Id: "alsa_output.test",
+            Name: "Test DAC",
+            MaxChannels: 2,
+            DefaultSampleRate: 48000,
+            DefaultLowLatencyMs: 20,
+            DefaultHighLatencyMs: 100,
+            IsDefault: false,
+            Capabilities: capabilities);
+
+    /// <summary>The fixed table PulseAudioBackend returns for every sink, regardless of device.</summary>
+    private static DeviceCapabilities BackendProbe() =>
+        Caps([44100, 48000, 88200, 96000, 176400, 192000], [16, 24, 32]);
+
+    // --- Capability source ------------------------------------------------------------------
+
+    [Fact]
+    public void CapabilitiesFor_PrefersTheDevicesOwnCapabilitiesOverTheBackendProbe()
+    {
+        // The regression this guards: building formats from the backend probe advertises
+        // 192kHz on every sink, because PulseAudioBackend returns one fixed table for all of them.
+        var dac = Caps([48000], [16, 24]);
+
+        var resolved = AudioFormatCatalog.CapabilitiesFor(Device(dac), BackendProbe());
+
+        Assert.Same(dac, resolved);
+    }
+
+    [Fact]
+    public void CapabilitiesFor_A48kOnlyDeviceNeverAdvertisesHiResEvenWhenTheProbeClaimsIt()
+    {
+        var resolved = AudioFormatCatalog.CapabilitiesFor(Device(Caps([48000], [16, 24])), BackendProbe());
+
+        var formats = AudioFormatCatalog.BuildFormats(resolved);
+
+        Assert.All(formats, f => Assert.Equal(48000, f.SampleRate));
+        Assert.DoesNotContain(formats, f => f.SampleRate is 88200 or 96000 or 176400 or 192000);
+    }
+
+    [Fact]
+    public void CapabilitiesFor_FallsBackToTheBackendProbeWhenTheDeviceHasNone()
+    {
+        var probe = BackendProbe();
+
+        Assert.Same(probe, AudioFormatCatalog.CapabilitiesFor(Device(null), probe));
+        Assert.Same(probe, AudioFormatCatalog.CapabilitiesFor(null, probe));
+    }
+
+    [Fact]
+    public void CapabilitiesFor_ReturnsNullWhenNeitherSourceHasCapabilities()
+    {
+        Assert.Null(AudioFormatCatalog.CapabilitiesFor(null, null));
+    }
+
     // --- Explicit bit depth on every entry -------------------------------------------------
 
     [Fact]

--- a/tests/MultiRoomAudio.Tests/Audio/AudioFormatCatalogTests.cs
+++ b/tests/MultiRoomAudio.Tests/Audio/AudioFormatCatalogTests.cs
@@ -1,0 +1,329 @@
+using MultiRoomAudio.Audio;
+using MultiRoomAudio.Models;
+using Sendspin.SDK.Models;
+using Xunit;
+
+namespace MultiRoomAudio.Tests.Audio;
+
+/// <summary>
+/// Covers the wire contract of <c>supported_formats</c>: every flac/pcm entry carries an
+/// explicit bit depth, the list is derived from the device, and entry 0 is the preference.
+/// </summary>
+public class AudioFormatCatalogTests
+{
+    private static DeviceCapabilities Caps(int[] rates, int[] depths) =>
+        new(
+            SupportedSampleRates: rates,
+            SupportedBitDepths: depths,
+            MaxChannels: 2,
+            PreferredSampleRate: rates[^1],
+            PreferredBitDepth: depths[^1]);
+
+    private static DeviceCapabilities HiResDac() =>
+        Caps([44100, 48000, 96000, 192000], [16, 24, 32]);
+
+    private static DeviceCapabilities BasicDac() =>
+        Caps([44100, 48000], [16]);
+
+    private static List<AudioFormat> Advertise(DeviceCapabilities? caps, string? preference)
+    {
+        var all = AudioFormatCatalog.BuildFormats(caps);
+        var preferred = AudioFormatCatalog.ResolvePreferred(all, preference, caps)
+                        ?? AudioFormatCatalog.ResolveDefault(all, caps);
+        return AudioFormatCatalog.WithPreferredFirst(all, preferred);
+    }
+
+    // --- Explicit bit depth on every entry -------------------------------------------------
+
+    [Fact]
+    public void BuildFormats_GivesEveryFlacAndPcmEntryAnExplicitBitDepth()
+    {
+        foreach (var caps in new DeviceCapabilities?[] { HiResDac(), BasicDac(), null })
+        {
+            var formats = AudioFormatCatalog.BuildFormats(caps);
+
+            Assert.All(
+                formats.Where(f => f.Codec is "flac" or "pcm"),
+                f => Assert.True(f.BitDepth.HasValue, $"{f.Codec} {f.SampleRate} has no bit depth"));
+        }
+    }
+
+    [Fact]
+    public void BuildFormats_LeavesOpusWithoutABitDepth()
+    {
+        var opus = AudioFormatCatalog.BuildFormats(HiResDac()).Single(f => f.Codec == "opus");
+
+        Assert.Null(opus.BitDepth);
+        Assert.Equal(48000, opus.SampleRate);
+    }
+
+    // --- Per-device derivation -------------------------------------------------------------
+
+    [Fact]
+    public void BuildFormats_NeverAdvertisesARateTheDeviceCannotDo()
+    {
+        var formats = AudioFormatCatalog.BuildFormats(Caps([48000], [16, 24]));
+
+        Assert.All(
+            formats.Where(f => f.Codec != "opus"),
+            f => Assert.Equal(48000, f.SampleRate));
+        Assert.DoesNotContain(formats, f => f.SampleRate is 96000 or 192000);
+    }
+
+    [Fact]
+    public void BuildFormats_NeverAdvertisesADepthTheDeviceCannotDo()
+    {
+        var formats = AudioFormatCatalog.BuildFormats(Caps([48000, 96000], [16]));
+
+        Assert.All(
+            formats.Where(f => f.BitDepth.HasValue),
+            f => Assert.Equal(16, f.BitDepth));
+    }
+
+    [Fact]
+    public void BuildFormats_DropsSubMusicRates()
+    {
+        var formats = AudioFormatCatalog.BuildFormats(Caps([8000, 16000, 32000, 48000], [16]));
+
+        Assert.All(formats, f => Assert.True(f.SampleRate >= 44100));
+    }
+
+    [Fact]
+    public void BuildFormats_DiffersBetweenDevicesWithDifferentCapabilities()
+    {
+        var hiRes = AudioFormatCatalog.BuildFormats(HiResDac()).Select(AudioFormatCatalog.ToFormatId);
+        var basic = AudioFormatCatalog.BuildFormats(BasicDac()).Select(AudioFormatCatalog.ToFormatId);
+
+        Assert.NotEqual(hiRes, basic);
+    }
+
+    [Fact]
+    public void BuildFormats_AdvertisesFlacAt24BitWhenTheDeviceOnlyReports32()
+    {
+        // The PulseAudio float32 fallback: FLAC cannot carry 32-bit, and 16 would re-truncate.
+        var formats = AudioFormatCatalog.BuildFormats(Caps([48000], [32]));
+
+        Assert.All(
+            formats.Where(f => f.Codec == "flac"),
+            f => Assert.Equal(24, f.BitDepth));
+        Assert.Contains(formats, f => f.Codec == "pcm" && f.BitDepth == 32);
+    }
+
+    [Fact]
+    public void BuildFormats_FallsBackToAValidListWhenCapabilitiesAreUnavailable()
+    {
+        var formats = AudioFormatCatalog.BuildFormats(null);
+
+        Assert.NotEmpty(formats);
+        Assert.All(
+            formats.Where(f => f.Codec is "flac" or "pcm"),
+            f => Assert.True(f.BitDepth.HasValue));
+        Assert.Contains(formats, f => f.Codec == "flac" && f.SampleRate == 48000);
+    }
+
+    // --- Default anchor --------------------------------------------------------------------
+
+    [Fact]
+    public void ResolveDefault_AnchorsOnFlac48kAtTheDevicesBestDepthCappedAt24()
+    {
+        var caps = HiResDac();
+        var entry0 = Advertise(caps, null)[0];
+
+        Assert.Equal("flac", entry0.Codec);
+        Assert.Equal(48000, entry0.SampleRate);
+        Assert.Equal(24, entry0.BitDepth);
+    }
+
+    [Fact]
+    public void ResolveDefault_DoesNotUpgradeA16BitDeviceTo24()
+    {
+        var entry0 = Advertise(BasicDac(), null)[0];
+
+        Assert.Equal(16, entry0.BitDepth);
+    }
+
+    [Fact]
+    public void ResolveDefault_NeverAutoUpgradesTheSampleRateToHiRes()
+    {
+        var entry0 = Advertise(HiResDac(), null)[0];
+
+        Assert.Equal(48000, entry0.SampleRate);
+    }
+
+    [Fact]
+    public void ResolveDefault_AnchorsOnTheNearestRateWhenTheDeviceHasNo48k()
+    {
+        var entry0 = Advertise(Caps([44100, 88200, 176400], [16, 24]), null)[0];
+
+        Assert.Equal(44100, entry0.SampleRate);
+        Assert.Equal(24, entry0.BitDepth);
+    }
+
+    [Fact]
+    public void GetDefaultFormatId_MatchesTheAnchorItResolves()
+    {
+        var caps = HiResDac();
+
+        Assert.Equal("flac-48000-24", AudioFormatCatalog.GetDefaultFormatId(caps));
+        Assert.Equal("flac-48000-16", AudioFormatCatalog.GetDefaultFormatId(BasicDac()));
+    }
+
+    // --- Preference parsing and ordering ---------------------------------------------------
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("all")]
+    [InlineData("ALL")]
+    public void ResolvePreferred_TreatsNullEmptyAndAllAsTheDefaultAnchor(string? preference)
+    {
+        var caps = HiResDac();
+        var all = AudioFormatCatalog.BuildFormats(caps);
+
+        var preferred = AudioFormatCatalog.ResolvePreferred(all, preference, caps);
+
+        Assert.Same(AudioFormatCatalog.ResolveDefault(all, caps), preferred);
+    }
+
+    [Fact]
+    public void ResolvePreferred_ResolvesTheLegacyTwoPartFormAgainstTheDevice()
+    {
+        // "flac-48000" predates bit depths in the string; the device supplies the depth.
+        var entry0 = Advertise(HiResDac(), "flac-48000")[0];
+
+        Assert.Equal("flac", entry0.Codec);
+        Assert.Equal(48000, entry0.SampleRate);
+        Assert.Equal(24, entry0.BitDepth);
+    }
+
+    [Fact]
+    public void ResolvePreferred_ResolvesTheLegacyThreePartPcmForm()
+    {
+        var entry0 = Advertise(HiResDac(), "pcm-96000-24")[0];
+
+        Assert.Equal("pcm", entry0.Codec);
+        Assert.Equal(96000, entry0.SampleRate);
+        Assert.Equal(24, entry0.BitDepth);
+    }
+
+    [Fact]
+    public void ResolvePreferred_HonoursAnExplicitFlacBitDepth()
+    {
+        var entry0 = Advertise(HiResDac(), "flac-96000-16")[0];
+
+        Assert.Equal("flac", entry0.Codec);
+        Assert.Equal(96000, entry0.SampleRate);
+        Assert.Equal(16, entry0.BitDepth);
+    }
+
+    [Fact]
+    public void ResolvePreferred_AutoAnchorsOnTheDevicesNativeBest()
+    {
+        var entry0 = Advertise(HiResDac(), AudioFormatCatalog.AutoFormatId)[0];
+
+        Assert.Equal("flac", entry0.Codec);
+        Assert.Equal(192000, entry0.SampleRate);
+        Assert.Equal(24, entry0.BitDepth);
+    }
+
+    [Theory]
+    [InlineData("flac-192000")]      // rate the device cannot do
+    [InlineData("pcm-48000-24")]     // depth the device cannot do
+    [InlineData("nonsense")]
+    [InlineData("flac-notanumber")]
+    public void ResolvePreferred_ReturnsNullWhenNothingMatches(string preference)
+    {
+        var caps = BasicDac();
+        var all = AudioFormatCatalog.BuildFormats(caps);
+
+        Assert.Null(AudioFormatCatalog.ResolvePreferred(all, preference, caps));
+    }
+
+    [Fact]
+    public void Advertise_FallsBackToTheDefaultWhenThePreferenceIsUnreachable()
+    {
+        var entry0 = Advertise(BasicDac(), "flac-192000")[0];
+
+        Assert.Equal(48000, entry0.SampleRate);
+        Assert.Equal(16, entry0.BitDepth);
+    }
+
+    [Fact]
+    public void WithPreferredFirst_KeepsTheWholeListAndPreservesTheTailOrder()
+    {
+        var caps = HiResDac();
+        var all = AudioFormatCatalog.BuildFormats(caps);
+        var preferred = all.Single(f => f.Codec == "pcm" && f.SampleRate == 96000 && f.BitDepth == 24);
+
+        var ordered = AudioFormatCatalog.WithPreferredFirst(all, preferred);
+
+        Assert.Equal(all.Count, ordered.Count);
+        Assert.Same(preferred, ordered[0]);
+        Assert.Equal(all.Where(f => !ReferenceEquals(f, preferred)), ordered.Skip(1));
+    }
+
+    [Fact]
+    public void Advertise_ReturnsTheWholeListNotASingleEntry()
+    {
+        var formats = Advertise(HiResDac(), "flac-48000");
+
+        Assert.True(formats.Count > 1, "supported_formats must offer MA more than one option");
+        Assert.Contains(formats, f => f.Codec == "opus");
+        Assert.Contains(formats, f => f.SampleRate == 192000);
+    }
+
+    [Fact]
+    public void BuildFormats_OrdersFlacBeforePcmAndRatesDescending()
+    {
+        var formats = AudioFormatCatalog.BuildFormats(HiResDac());
+        var codecs = formats.Select(f => f.Codec).ToList();
+
+        Assert.Equal(0, codecs.IndexOf("flac"));
+        Assert.True(codecs.IndexOf("pcm") > codecs.LastIndexOf("flac"));
+        Assert.Equal("opus", codecs[^1]);
+
+        var flacRates = formats.Where(f => f.Codec == "flac").Select(f => f.SampleRate).ToList();
+        Assert.Equal(flacRates.OrderByDescending(r => r), flacRates);
+    }
+
+    // --- Format ids and options ------------------------------------------------------------
+
+    [Fact]
+    public void ToFormatId_RoundTripsThroughResolvePreferred()
+    {
+        var caps = HiResDac();
+        var all = AudioFormatCatalog.BuildFormats(caps);
+
+        foreach (var format in all)
+        {
+            var resolved = AudioFormatCatalog.ResolvePreferred(all, AudioFormatCatalog.ToFormatId(format), caps);
+            Assert.Same(format, resolved);
+        }
+    }
+
+    [Fact]
+    public void BuildOptions_OffersAutoPlusOnlyWhatTheDeviceCanDo()
+    {
+        var caps = BasicDac();
+        var options = AudioFormatCatalog.BuildOptions(caps);
+
+        Assert.Equal(AudioFormatCatalog.AutoFormatId, options[0].Id);
+        Assert.DoesNotContain(options, o => o.Id.Contains("192000"));
+        Assert.DoesNotContain(options, o => o.Id.EndsWith("-24"));
+
+        var ids = options.Skip(1).Select(o => o.Id);
+        Assert.Equal(AudioFormatCatalog.BuildFormats(caps).Select(AudioFormatCatalog.ToFormatId), ids);
+    }
+
+    [Fact]
+    public void BuildOptions_MarksTheDefaultAnchor()
+    {
+        var caps = HiResDac();
+        var options = AudioFormatCatalog.BuildOptions(caps);
+
+        var marked = options.Where(o => o.Description.Contains("(default)")).ToList();
+
+        Assert.Single(marked);
+        Assert.Equal(AudioFormatCatalog.GetDefaultFormatId(caps), marked[0].Id);
+    }
+}


### PR DESCRIPTION
Closes #280

## The problem

Two bugs stacked on top of each other pinned every player to FLAC 48kHz/16-bit.

`GetDefaultFormats()` left `BitDepth` null on all four `flac` entries, and
SendSpin.SDK 9.2.0 maps that onto the wire as `BitDepth = (f.BitDepth ?? 16)` —
so `bit_depth: 16` always went out, even for a 96kHz/24-bit stream.

`FilterFormatsByPreference()` then collapsed the list to a single entry,
defaulting to `flac-48000` whenever `AdvertisedFormat` was null — which it is
for essentially every existing player. The aiosendspin server takes
`compatible[0]` and holds it for the whole session, and Music Assistant builds
its per-player `preferred_sendspin_format` dropdown from what we advertise, so
a one-element array left the user with a one-option dropdown and no way, from
either side, to ask for anything else.

## The change

Add `AudioFormatCatalog`, which builds the advertised list from the device
capabilities `CreateSdkComponents()` already probes and previously used only
for Stats-for-Nerds reporting.

- Every flac and pcm entry carries an explicit bit depth. Nothing relies on the
  SDK fallback any more.
- The whole advertisable list goes out, not one entry. The preference moves an
  entry to index 0; it never truncates.
- Rates and depths come from the DAC, so a 48kHz-only card never advertises
  96kHz.
- Default anchor is FLAC 48kHz at the device's best depth, capped at 24-bit.
  The rate stays at 48kHz because buffer RAM scales with it (~11.5MB per player
  at 48kHz, ~46MB at 192kHz); depth costs LAN bandwidth but no RAM, so the
  truncation is fixed out of the box without anyone opting in.
- Format strings accept a depth on FLAC (`flac-96000-24`) and resolve a missing
  one from the device, so existing `players.yaml` values keep working untouched.
  `"auto"` is new and means the device's native best.
- The format selector is no longer gated behind `ENABLE_ADVANCED_FORMATS`, and
  its options come from the selected device plus "Auto (device native)".

The onboarding wizard is deliberately unchanged — players it creates get the
default anchor, and format stays an advanced setting changed afterwards.

## Verified

Capabilities come from the enriched device, not the backend probe. On a real
sink `/api/devices` reports `[44100, 48000, 96000, 192000]` for the Modi 3
while `PulseAudioBackend.GetDeviceCapabilities` claims
`[44100, 48000, 88200, 96000, 176400, 192000]` for every sink alike. The
`client/hello` payload now carries 21 entries over exactly the device's rates —
no phantom 88.2/176.4kHz — with entry 0 as `flac / 48000 / bit_depth 24`.

A player left on the default device gets the same treatment — the default sink's
id is resolved and enriched before probing, so it no longer falls through to the
fixed table.

A legacy `flac-48000` preference resolves its depth from the device; `auto`
anchors on the device's native best. Changing a player's format persists it,
restarts the player, and the detail view reflects it. A device change now also
requires a restart, so the new device's formats are re-announced.

190/190 tests pass (36 new), `dotnet format --verify-no-changes` is clean, and
the Release build has no new warnings.

## Not verified

The hi-res path on real hardware. Advertising a rate does not guarantee the DAC
receives it — under HAOS the PulseAudio daemon belongs to the supervisor and may
resample a 96kHz stream back to 48kHz. `pactl list sinks` and Stats-for-Nerds
`hardwareSampleRate` are the truth, and the docs now say so.

## Follow-up

`GET /api/devices/{id}/capabilities` still returns the backend's static table,
so it now visibly disagrees with `/api/devices` for the same device. That is
pre-existing, but it is the same trap this PR had to be corrected for — worth
making self-consistent separately.

`ENABLE_ADVANCED_FORMATS` no longer does anything. It is kept and documented as
deprecated rather than removed, since the brief scoped this change to dropping
the gate. Worth deleting outright in a separate pass — it also touches
`entrypoint.sh`, which reads an add-on option that was never in `config.yaml`.

