### PR TITLE
chore: upgrade SendSpin.SDK 9.2.0 -> 9.3.0

### DIFF
--- a/multiroom-audio/CHANGELOG.md
+++ b/multiroom-audio/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Changed
 - **After upgrading, existing custom sinks are renamed in Home Assistant and Music Assistant.** Sinks reload from `custom-sinks.yaml` on restart and now register their stored description verbatim, so underscores become spaces and `_and_` becomes `&`. Sink names, players and configuration are untouched - only the display name changes, and you may need to fix up entity names on the Home Assistant side
+- Audio sync correction now runs entirely inside the Sendspin SDK (upgraded to 9.3.0). The add-on used to run a second corrector of its own alongside the SDK's, so two loops chased the same timing error and the add-on's one pulled playback speed up to 20x harder than the Sendspin spec allows. Correction is now a single loop that stays inside the spec's +/-0.5% limit, escalating to a one-shot snap past ~5ms of error. Expect steadier multi-room alignment and fewer correction artifacts
+- Players now tell the server how much audio they can really hold. They used to advertise a flat 32MB - roughly 16 minutes of compressed audio, far past anything the add-on actually buffers - which licensed the server to queue audio the player would only discard unplayed, and could fill the buffer until the SDK began dropping samples. Capacity is now derived from the real decoded buffer. If you have lowered **Buffer Seconds** below 30 the advertised figure is still slightly generous, but far closer than before (#272)
 
 ## [5.2.2] - Volume Curve, MQTT Volume & Trigger Fixes
 

--- a/src/MultiRoomAudio/Audio/BufferedAudioSampleSource.cs
+++ b/src/MultiRoomAudio/Audio/BufferedAudioSampleSource.cs
@@ -1,4 +1,3 @@
-using System.Buffers;
 using Sendspin.SDK.Audio;
 using Sendspin.SDK.Models;
 
@@ -6,8 +5,8 @@ namespace MultiRoomAudio.Audio;
 
 /// <summary>
 /// Bridges <see cref="ITimedAudioBuffer"/> to <see cref="IAudioSampleSource"/>.
-/// Provides current local time to the buffer for timed sample release and
-/// implements player-controlled sync correction via frame drop/insert with interpolation.
+/// Provides current local time to the buffer for timed sample release and surfaces
+/// read/overrun diagnostics for Stats for Nerds.
 /// </summary>
 /// <remarks>
 /// <para><strong>Overview</strong></para>
@@ -27,7 +26,7 @@ namespace MultiRoomAudio.Audio;
 ///     and must complete quickly without blocking to avoid audio glitches.
 ///   </description></item>
 ///   <item><description>
-///     <see cref="Reset"/> may be called from any thread to reset correction state. It modifies
+///     <see cref="Reset"/> may be called from any thread to reset diagnostic state. It modifies
 ///     fields that are only read (not written) by the audio thread during <see cref="Read"/>,
 ///     so no lock is required - the audio thread will see the reset values on the next callback.
 ///   </description></item>
@@ -40,56 +39,28 @@ namespace MultiRoomAudio.Audio;
 ///   </description></item>
 /// </list>
 ///
-/// <para><strong>Sync Correction Algorithm</strong></para>
+/// <para><strong>Sync Correction</strong></para>
 /// <para>
-/// The Sendspin protocol delivers audio samples with precise timestamps indicating when each
-/// sample should be played. Network jitter, clock drift between sender/receiver, and audio
-/// hardware variations can cause the playback position to drift from the ideal schedule.
-/// This class measures and corrects that drift.
+/// Sync correction belongs to the SDK. <see cref="ITimedAudioBuffer.Read"/> measures the error
+/// between where playback should be (from the server timestamps) and where it actually is, then
+/// closes it itself: frame drop/insert with 3-point weighted interpolation inside the spec's
+/// +/-0.5% speed cap, escalating to a one-shot snap above ~5ms and a re-anchor above 500ms.
 /// </para>
 /// <para>
-/// <strong>Algorithm overview:</strong>
+/// This class previously ran its own corrector against <c>ReadRaw</c>, which duplicated the SDK's
+/// interpolation, exceeded the spec's speed cap by ~20x, and could not coordinate with the SDK's
+/// one-shot snap tier (added in SDK 9.3.0) - both correctors would act on the same error. Reading
+/// through <see cref="ITimedAudioBuffer.Read"/> puts the whole correction loop in one place, where
+/// the tiers already stand down for one another. Tuning lives in
+/// <c>PlayerManagerService.PulseAudioSyncOptions</c>.
 /// </para>
-/// <list type="number">
-///   <item><description>
-///     The SDK's <see cref="ITimedAudioBuffer"/> measures sync error: the difference between
-///     where playback should be (based on timestamps) and where it actually is.
-///     Positive error means playback is behind; negative means it's ahead.
-///   </description></item>
-///   <item><description>
-///     If error is within the deadband (+/- 15ms), no correction is applied. This prevents
-///     unnecessary processing when sync is acceptable.
-///   </description></item>
-///   <item><description>
-///     Beyond the deadband, we apply correction by dropping or inserting frames:
-///     <list type="bullet">
-///       <item><description>Behind schedule (positive error): DROP frames to catch up faster</description></item>
-///       <item><description>Ahead of schedule (negative error): INSERT frames to slow down</description></item>
-///     </list>
-///   </description></item>
-///   <item><description>
-///     Correction rate is proportional to error magnitude. Larger errors trigger more
-///     frequent corrections (every 10-500 frames depending on error size).
-///   </description></item>
-///   <item><description>
-///     To minimize audible artifacts, corrections use linear interpolation:
-///     <list type="bullet">
-///       <item><description>Drop: blend two frames into one: (A + B) / 2</description></item>
-///       <item><description>Insert: interpolate between last output and next input: (last + next) / 2</description></item>
-///     </list>
-///   </description></item>
-///   <item><description>
-///     The SDK is notified of all corrections via <see cref="ITimedAudioBuffer.NotifyExternalCorrection"/>
-///     so it can maintain accurate sync tracking.
-///   </description></item>
-/// </list>
 ///
 /// <para><strong>Performance Considerations</strong></para>
 /// <para>
 /// The <see cref="Read"/> method is called from a real-time audio thread. To avoid glitches:
 /// </para>
 /// <list type="bullet">
-///   <item><description>Uses <see cref="System.Buffers.ArrayPool{T}"/> to avoid GC allocations</description></item>
+///   <item><description>Reads directly into the caller's buffer - no temporary allocation</description></item>
 ///   <item><description>No locks or blocking operations</description></item>
 ///   <item><description>Diagnostic logging is rate-limited to once per second</description></item>
 /// </list>
@@ -101,32 +72,6 @@ public sealed class BufferedAudioSampleSource : IAudioSampleSource
     private readonly ILogger<BufferedAudioSampleSource>? _logger;
     private readonly int _channels;
     private readonly int _sampleRate;
-
-    // Correction threshold - within tolerance is acceptable, beyond that we correct.
-    // 15ms deadband tolerates PulseAudio latency measurement jitter while staying
-    // below the ~20-30ms threshold where multi-room delay becomes audible.
-    private const long CorrectionThresholdMicroseconds = 15_000;  // 15ms deadband
-
-    // Startup deadband - wider tolerance during first 500ms to prevent oscillation.
-    // Sync corrections still happen if error exceeds 50ms, maintaining multi-room sync.
-    // After startup period, normal 15ms deadband resumes for tighter sync.
-    private const long StartupDeadbandMicroseconds = 50_000;      // 50ms during startup
-    private const int StartupDeadbandPeriodMs = 500;              // First 500ms
-
-    // Correction rate limits (frames between corrections)
-    private const int MinCorrectionInterval = 10;   // Most aggressive: correct every 10 frames
-    private const int MaxCorrectionInterval = 500;  // Most gentle: correct every 500 frames
-
-    // Frame tracking for corrections
-    private int _framesSinceLastCorrection;
-    private float[]? _lastOutputFrame;
-
-    // Anti-oscillation: track correction direction and debounce
-    // Prevents rapid alternation between dropping and inserting when overshoots occur
-    private enum CorrectionDirection { None, Dropping, Inserting }
-    private CorrectionDirection _currentDirection = CorrectionDirection.None;
-    private int _directionChangeDebounceCounter;
-    private const int DirectionChangeDebounceFrames = 500;  // ~10ms at 48kHz stereo
 
     // Debug logging rate limiter
     private long _lastDebugLogTime;
@@ -140,22 +85,11 @@ public sealed class BufferedAudioSampleSource : IAudioSampleSource
     private long _lastSuccessfulReadTime;
     private bool _hasEverReceivedSamples;
 
-    // Correction tracking for stats
-    private long _totalDropped;
-    private long _totalInserted;
-
     // Overrun tracking - detect when SDK starts dropping samples
     private long _lastKnownDroppedSamples;
     private long _lastKnownOverrunCount;
     private bool _hasLoggedOverrunStart;
     private bool _hasLoggedStartupDiscard;
-
-    // Startup tracking for deadband widening
-    private long _correctionStartTime;  // Timestamp when first correction was considered
-
-    // Track whether _lastOutputFrame has been initialized with real audio (not zeros).
-    // Prevents interpolation artifacts when insertions happen before any audio is output.
-    private bool _lastOutputFrameInitialized;
 
     /// <inheritdoc/>
     public AudioFormat Format => _buffer.Format;
@@ -180,10 +114,6 @@ public sealed class BufferedAudioSampleSource : IAudioSampleSource
     public bool HasEverReceivedSamples => _hasEverReceivedSamples;
     /// <summary>Function to get current time in microseconds.</summary>
     public long CurrentTimeMicroseconds => _getCurrentTimeMicroseconds();
-    /// <summary>Total samples dropped for sync correction.</summary>
-    public long TotalDropped => _totalDropped;
-    /// <summary>Total samples inserted for sync correction.</summary>
-    public long TotalInserted => _totalInserted;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BufferedAudioSampleSource"/> class.
@@ -212,15 +142,14 @@ public sealed class BufferedAudioSampleSource : IAudioSampleSource
 
         _logger?.LogInformation(
             "BufferedAudioSampleSource initialized: channels={Channels}, sampleRate={SampleRate}, " +
-            "interpolation=3-point weighted with 2-point fallback",
+            "sync correction=SDK (ITimedAudioBuffer.Read)",
             _channels, _sampleRate);
     }
 
     /// <inheritdoc/>
     /// <remarks>
-    /// Uses <see cref="ArrayPool{T}.Shared"/> to avoid allocating temporary buffers on every
-    /// audio callback. Audio threads are real-time sensitive, and GC pauses from frequent
-    /// allocations can cause audible glitches.
+    /// Reads straight into the caller's buffer: <see cref="ITimedAudioBuffer.Read"/> applies sync
+    /// correction in place, so no temporary buffer is needed on the real-time audio thread.
     /// </remarks>
     public int Read(float[] buffer, int offset, int count)
     {
@@ -233,71 +162,43 @@ public sealed class BufferedAudioSampleSource : IAudioSampleSource
             _firstReadTime = currentTime;
         }
 
-        // Initialize last output frame if needed
-        _lastOutputFrame ??= new float[_channels];
+        // Read sync-corrected samples from the timed buffer.
+        // CS0618: ITimedAudioBuffer.Read still carries an [Obsolete] attribute pointing at ReadRaw +
+        // an external ISyncCorrectionProvider. That attribute is stale on the 9.x line, which froze
+        // its published surface and so could not remove it: SDK 9.3.0 rewrote this method's own docs
+        // to describe it as the complete path ("corrects end to end and needs nothing from the
+        // caller") and put the new one-shot snap tier behind it. External correction is what we just
+        // removed - it duplicated the SDK's interpolation and could not coordinate with that tier.
+#pragma warning disable CS0618
+        var read = _buffer.Read(buffer.AsSpan(offset, count), currentTime);
+#pragma warning restore CS0618
 
-        // Rent a buffer from the pool to avoid GC allocations in the audio thread
-        var tempBuffer = ArrayPool<float>.Shared.Rent(count);
-        try
+        if (read > 0)
         {
-            // Read raw samples from the timed buffer (no SDK correction)
-            var rawRead = _buffer.ReadRaw(tempBuffer.AsSpan(0, count), currentTime);
+            _successfulReads++;
+            _lastSuccessfulReadTime = currentTime;
 
-            if (rawRead > 0)
+            // Log first successful read - important milestone
+            if (!_hasEverReceivedSamples)
             {
-                _successfulReads++;
-                _lastSuccessfulReadTime = currentTime;
-
-                // Log first successful read - important milestone
-                if (!_hasEverReceivedSamples)
-                {
-                    _hasEverReceivedSamples = true;
-                    var elapsedMs = (currentTime - _firstReadTime) / 1000.0;
-                    _logger?.LogInformation(
-                        "First samples received from buffer: elapsedMs={ElapsedMs:F1}, " +
-                        "totalReads={TotalReads}, zeroReads={ZeroReads}",
-                        elapsedMs, _totalReads, _zeroReads);
-                }
-
-                // Initialize _lastOutputFrame with real audio before any corrections.
-                // This prevents interpolation artifacts when frame insertion happens early -
-                // without this, insertions would interpolate (0 + audio) / 2 = half volume clicks.
-                if (!_lastOutputFrameInitialized && rawRead >= _channels)
-                {
-                    tempBuffer.AsSpan(0, _channels).CopyTo(_lastOutputFrame);
-                    _lastOutputFrameInitialized = true;
-                }
-
-                // Apply correction and copy to output
-                var (outputCount, dropped, inserted) = ApplyCorrectionWithInterpolation(
-                    tempBuffer, rawRead, buffer.AsSpan(offset, count));
-
-                // Notify SDK of corrections for accurate sync tracking
-                if (dropped > 0 || inserted > 0)
-                {
-                    _buffer.NotifyExternalCorrection(dropped, inserted);
-                    _totalDropped += dropped;
-                    _totalInserted += inserted;
-                }
-
-                // Fill remainder with silence if needed
-                if (outputCount < count)
-                {
-                    buffer.AsSpan(offset + outputCount, count - outputCount).Fill(0f);
-                }
-            }
-            else
-            {
-                _zeroReads++;
-                LogZeroRead(currentTime);
-
-                // Fill with silence
-                buffer.AsSpan(offset, count).Fill(0f);
+                _hasEverReceivedSamples = true;
+                var elapsedMs = (currentTime - _firstReadTime) / 1000.0;
+                _logger?.LogInformation(
+                    "First samples received from buffer: elapsedMs={ElapsedMs:F1}, " +
+                    "totalReads={TotalReads}, zeroReads={ZeroReads}",
+                    elapsedMs, _totalReads, _zeroReads);
             }
         }
-        finally
+        else
         {
-            ArrayPool<float>.Shared.Return(tempBuffer, clearArray: false);
+            _zeroReads++;
+            LogZeroRead(currentTime);
+        }
+
+        // Fill any shortfall with silence
+        if (read < count)
+        {
+            buffer.AsSpan(offset + read, count - read).Fill(0f);
         }
 
         // Check for overruns (SDK dropping samples due to buffer full)
@@ -305,236 +206,6 @@ public sealed class BufferedAudioSampleSource : IAudioSampleSource
 
         // Always return requested count to keep audio output happy
         return count;
-    }
-
-    /// <summary>
-    /// Calculates the correction interval based on sync error magnitude.
-    /// Larger errors result in more frequent corrections.
-    /// </summary>
-    /// <param name="absErrorMicroseconds">Absolute sync error in microseconds.</param>
-    /// <returns>Number of frames between corrections.</returns>
-    private static int CalculateCorrectionInterval(long absErrorMicroseconds)
-    {
-        // Formula: interval = 500000 / absError
-        // At 10ms (10000μs): 500000/10000 = 50 frames
-        // At 50ms (50000μs): 500000/50000 = 10 frames
-        // At 5ms (5000μs): 500000/5000 = 100 frames
-        if (absErrorMicroseconds <= 0)
-        {
-            return MaxCorrectionInterval;
-        }
-
-        var interval = (int)(500_000 / absErrorMicroseconds);
-        return Math.Clamp(interval, MinCorrectionInterval, MaxCorrectionInterval);
-    }
-
-    /// <summary>
-    /// Applies sync correction with interpolation to minimize audible artifacts.
-    /// Uses 3-point weighted interpolation when sufficient lookahead is available in the input buffer,
-    /// falling back to 2-point linear interpolation otherwise.
-    /// </summary>
-    /// <returns>Tuple of (output sample count, samples dropped, samples inserted).</returns>
-    private (int OutputCount, int SamplesDropped, int SamplesInserted) ApplyCorrectionWithInterpolation(
-        float[] input, int inputCount, Span<float> output)
-    {
-        var syncError = _buffer.SmoothedSyncErrorMicroseconds;
-        var absError = Math.Abs((long)syncError);
-
-        // Track when corrections start being considered for startup deadband
-        var currentTime = _getCurrentTimeMicroseconds();
-        if (_correctionStartTime == 0)
-        {
-            _correctionStartTime = currentTime;
-        }
-
-        // Use wider deadband during startup to prevent oscillation while maintaining sync.
-        // After startup period, normal 15ms deadband resumes for tighter multi-room sync.
-        var elapsedMs = (currentTime - _correctionStartTime) / 1000.0;
-        var deadband = elapsedMs < StartupDeadbandPeriodMs
-            ? StartupDeadbandMicroseconds
-            : CorrectionThresholdMicroseconds;
-
-        // No correction needed if within deadband - reset direction tracking
-        if (absError < deadband)
-        {
-            _currentDirection = CorrectionDirection.None;
-            _directionChangeDebounceCounter = 0;
-
-            // Just copy input to output
-            var toCopy = Math.Min(inputCount, output.Length);
-            input.AsSpan(0, toCopy).CopyTo(output);
-
-            // Save last frame for potential future corrections
-            if (toCopy >= _channels)
-            {
-                input.AsSpan(toCopy - _channels, _channels).CopyTo(_lastOutputFrame);
-            }
-
-            return (toCopy, 0, 0);
-        }
-
-        // Determine desired direction based on error sign
-        var desiredDirection = syncError > 0 ? CorrectionDirection.Dropping : CorrectionDirection.Inserting;
-
-        // Check if direction would change (anti-oscillation debounce)
-        if (_currentDirection != CorrectionDirection.None && _currentDirection != desiredDirection)
-        {
-            // Direction change detected - apply debounce
-            _directionChangeDebounceCounter++;
-
-            if (_directionChangeDebounceCounter < DirectionChangeDebounceFrames)
-            {
-                // Still in debounce period - don't correct, just copy
-                var toCopy = Math.Min(inputCount, output.Length);
-                input.AsSpan(0, toCopy).CopyTo(output);
-                if (toCopy >= _channels)
-                {
-                    input.AsSpan(toCopy - _channels, _channels).CopyTo(_lastOutputFrame);
-                }
-                return (toCopy, 0, 0);
-            }
-
-            // Debounce satisfied - allow direction change
-            _directionChangeDebounceCounter = 0;
-        }
-        else
-        {
-            // Same direction or first correction - reset debounce counter
-            _directionChangeDebounceCounter = 0;
-        }
-
-        // Update current direction
-        _currentDirection = desiredDirection;
-
-        // Calculate correction rate based on error magnitude
-        var correctionInterval = CalculateCorrectionInterval(absError);
-        var shouldDrop = desiredDirection == CorrectionDirection.Dropping;
-        var shouldInsert = desiredDirection == CorrectionDirection.Inserting;
-
-        // Process frame by frame
-        var inputPos = 0;
-        var outputPos = 0;
-        var samplesDropped = 0;
-        var samplesInserted = 0;
-
-        while (outputPos < output.Length)
-        {
-            var remainingInput = inputCount - inputPos;
-            _framesSinceLastCorrection++;
-
-            // Check if we should DROP a frame (read two, output one interpolated)
-            if (shouldDrop && _framesSinceLastCorrection >= correctionInterval)
-            {
-                _framesSinceLastCorrection = 0;
-
-                if (remainingInput >= _channels * 2)
-                {
-                    var frameAStart = inputPos;
-                    var frameBStart = inputPos + _channels;
-                    var outputSpan = output.Slice(outputPos, _channels);
-
-                    // Use 3-point weighted interpolation if we have lookahead available
-                    if (remainingInput >= _channels * 3)
-                    {
-                        // 3-point weighted: A=0.25, B=0.5, C=0.25 (Gaussian-like kernel)
-                        // Smoother blend that considers the frame after the drop point
-                        var frameCStart = inputPos + _channels * 2;
-                        for (int i = 0; i < _channels; i++)
-                        {
-                            outputSpan[i] = input[frameAStart + i] * 0.25f
-                                          + input[frameBStart + i] * 0.5f
-                                          + input[frameCStart + i] * 0.25f;
-                        }
-                    }
-                    else
-                    {
-                        // Fallback: 2-point linear interpolation (A + B) / 2
-                        for (int i = 0; i < _channels; i++)
-                        {
-                            outputSpan[i] = (input[frameAStart + i] + input[frameBStart + i]) * 0.5f;
-                        }
-                    }
-
-                    // Consume both input frames (A and B)
-                    inputPos += _channels * 2;
-
-                    // Save as last output frame
-                    outputSpan.CopyTo(_lastOutputFrame);
-
-                    outputPos += _channels;
-                    samplesDropped += _channels;
-                    continue;
-                }
-            }
-
-            // Check if we should INSERT a frame (output interpolated without consuming)
-            if (shouldInsert && _framesSinceLastCorrection >= correctionInterval)
-            {
-                _framesSinceLastCorrection = 0;
-
-                if (output.Length - outputPos >= _channels)
-                {
-                    var outputSpan = output.Slice(outputPos, _channels);
-
-                    // Use true lookahead if we have two frames available
-                    if (remainingInput >= _channels * 2)
-                    {
-                        // Interpolate between current and next frame (true lookahead)
-                        // Better than using stale _lastOutputFrame from previous callback
-                        var currentStart = inputPos;
-                        var nextStart = inputPos + _channels;
-                        for (int i = 0; i < _channels; i++)
-                        {
-                            outputSpan[i] = (input[currentStart + i] + input[nextStart + i]) * 0.5f;
-                        }
-
-                        // Save interpolated frame
-                        outputSpan.CopyTo(_lastOutputFrame);
-                    }
-                    else if (remainingInput >= _channels)
-                    {
-                        // Fallback: use last output frame + current input
-                        for (int i = 0; i < _channels; i++)
-                        {
-                            outputSpan[i] = (_lastOutputFrame![i] + input[inputPos + i]) * 0.5f;
-                        }
-
-                        // Save interpolated frame
-                        outputSpan.CopyTo(_lastOutputFrame);
-                    }
-                    else
-                    {
-                        // Fallback: duplicate last frame
-                        _lastOutputFrame.AsSpan().CopyTo(outputSpan);
-                    }
-
-                    outputPos += _channels;
-                    samplesInserted += _channels;
-                    continue;
-                }
-            }
-
-            // Normal frame: copy from input to output
-            if (remainingInput < _channels)
-            {
-                break; // No more input
-            }
-
-            if (output.Length - outputPos < _channels)
-            {
-                break; // No more output space
-            }
-
-            var frameSpan = output.Slice(outputPos, _channels);
-            input.AsSpan(inputPos, _channels).CopyTo(frameSpan);
-            inputPos += _channels;
-
-            // Save as last output frame
-            frameSpan.CopyTo(_lastOutputFrame);
-            outputPos += _channels;
-        }
-
-        return (outputPos, samplesDropped, samplesInserted);
     }
 
     /// <summary>
@@ -662,23 +333,11 @@ public sealed class BufferedAudioSampleSource : IAudioSampleSource
     }
 
     /// <summary>
-    /// Resets correction state. Call when buffer is cleared or playback restarts.
+    /// Resets diagnostic state. Call when buffer is cleared or playback restarts.
     /// </summary>
     public void Reset()
     {
-        _framesSinceLastCorrection = 0;
-        _lastOutputFrame = null;
-        _lastOutputFrameInitialized = false;
-        _totalDropped = 0;
-        _totalInserted = 0;
         _hasLoggedOverrunStart = false;  // Allow ERROR level logging on next overrun
         _hasLoggedStartupDiscard = false;  // Allow startup-discard INFO on next playback
-
-        // Reset anti-oscillation state
-        _currentDirection = CorrectionDirection.None;
-        _directionChangeDebounceCounter = 0;
-
-        // Reset startup deadband tracking so next playback gets the wider deadband
-        _correctionStartTime = 0;
     }
 }

--- a/src/MultiRoomAudio/MultiRoomAudio.csproj
+++ b/src/MultiRoomAudio/MultiRoomAudio.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <!-- Core SDK for Sendspin protocol -->
-    <PackageReference Include="SendSpin.SDK" Version="9.2.0" />
+    <PackageReference Include="SendSpin.SDK" Version="9.3.0" />
     <PackageReference Include="System.IO.Ports" Version="10.0.10" />
 
     <!-- USB HID support for HID relay boards -->

--- a/src/MultiRoomAudio/Services/PlayerManagerService.cs
+++ b/src/MultiRoomAudio/Services/PlayerManagerService.cs
@@ -130,18 +130,6 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
     #region Constants
 
     /// <summary>
-    /// Buffer capacity announced to the Sendspin server (in bytes).
-    ///
-    /// Per protocol spec: "buffer_capacity: max size in bytes of compressed audio
-    /// messages in the buffer that are yet to be played"
-    ///
-    /// The server sends audio chunks as far ahead as this capacity allows.
-    /// At typical Opus bitrates (~128kbps), 32MB = many minutes of audio.
-    /// This large value ensures the server always has audio ready to send.
-    /// </summary>
-    private const int ServerAnnouncedBufferCapacityBytes = 32_000_000;
-
-    /// <summary>
     /// Local circular buffer capacity for decompressed PCM audio (in milliseconds).
     ///
     /// This is the TimedAudioBuffer size - how much decoded audio we can hold locally.
@@ -149,8 +137,8 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
     /// uninterrupted playback during network hiccups and lightweight reconnects. At 48kHz
     /// stereo float32, 30s is approximately 11MB per player.
     ///
-    /// Note: This is DIFFERENT from ServerAnnouncedBufferCapacityBytes which controls
-    /// how far ahead the server sends compressed audio.
+    /// Note: This is DIFFERENT from the advertised buffer_capacity, which controls how far
+    /// ahead the server sends compressed audio and is derived by the SDK (see below).
     /// </summary>
     private readonly int _localBufferCapacityMs;
 
@@ -168,18 +156,17 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
     private const int PlaybackStartThresholdMs = 250;
 
     /// <summary>
-    /// Sync correction options tuned for PulseAudio's timing characteristics.
-    /// Uses a high threshold for Tier 3 (frame drop/insert) to prefer smooth rate adjustment.
+    /// Sync correction options for the SDK's corrector (<c>ITimedAudioBuffer.Read</c>).
     /// </summary>
+    /// <remarks>
+    /// Deadband, speed cap and the one-shot snap threshold are left at the SDK defaults, which
+    /// carry the spec's limits (+/-0.5% speed cap, 100us deadband, 5ms snap). Only the values we
+    /// deliberately differ on are set here. MaxSpeedCorrection and ResamplingThresholdMicroseconds
+    /// are deliberately unset: both are inert on this path - the buffer self-applies correction as
+    /// frame stepping rather than driving a resampler, and a value above the spec cap is clamped.
+    /// </remarks>
     internal static readonly SyncCorrectionOptions PulseAudioSyncOptions = new()
     {
-        // Use 4% max correction (matches CLI) for more responsive adjustment
-        MaxSpeedCorrection = 0.04,
-
-        // Set high threshold to prefer rate adjustment over frame drop/insert (Tier 3)
-        // SDK handles sync correction via TimedAudioBuffer's rate adjustment
-        ResamplingThresholdMicroseconds = 200_000,  // 200ms (vs default 15ms)
-
         // Re-anchor at 500ms (same as default)
         ReanchorThresholdMicroseconds = 500_000,
 
@@ -981,7 +968,13 @@ public class PlayerManagerService : IAsyncDisposable, IDisposable
             ClientName = request.Name,
             Roles = new List<string> { "controller@v1", "player@v1", "metadata@v1" },
             AudioFormats = audioFormats,
-            BufferCapacity = ServerAnnouncedBufferCapacityBytes,
+
+            // BufferCapacity is left unset so the SDK derives it from what our decoded buffer can
+            // actually hold, for whichever advertised codec packs the most audio into a byte. The
+            // spec makes buffer_capacity a promise the server may fill toward, so over-advertising
+            // just licenses it to queue audio we would discard unplayed. Caveat on the 9.x line:
+            // the SDK's derivation assumes its own 30s default buffer and has no public hook for
+            // ours, so BUFFER_SECONDS below 30 over-advertises (degrades to buffer overruns).
             InitialVolume = request.Volume,
             InitialMuted = false, // Players start unmuted
 

--- a/tests/MultiRoomAudio.Tests/FakeTimedAudioBuffer.cs
+++ b/tests/MultiRoomAudio.Tests/FakeTimedAudioBuffer.cs
@@ -6,7 +6,7 @@ namespace MultiRoomAudio.Tests;
 /// <summary>
 /// Minimal <see cref="ITimedAudioBuffer"/> test double for exercising
 /// <see cref="MultiRoomAudio.Audio.BufferedAudioSampleSource"/>'s read and overrun-detection paths.
-/// <see cref="ReadRaw"/> returns a full buffer of silence; <see cref="GetStats"/> returns the
+/// <see cref="Read"/> returns a full buffer of silence; <see cref="GetStats"/> returns the
 /// caller-supplied snapshot. Members not used by those paths throw.
 /// </summary>
 internal sealed class FakeTimedAudioBuffer : ITimedAudioBuffer
@@ -21,7 +21,7 @@ internal sealed class FakeTimedAudioBuffer : ITimedAudioBuffer
 
     public AudioFormat Format { get; }
 
-    public int ReadRaw(Span<float> destination, long currentTimeMicroseconds)
+    public int Read(Span<float> destination, long currentTimeMicroseconds)
     {
         destination.Clear();
         return destination.Length;
@@ -29,13 +29,10 @@ internal sealed class FakeTimedAudioBuffer : ITimedAudioBuffer
 
     public AudioBufferStats GetStats() => _stats;
 
-    public double SmoothedSyncErrorMicroseconds => 0;
-
-    public void NotifyExternalCorrection(int droppedSamples, int insertedSamples)
-    {
-    }
-
     // --- Unused by the sample-source read/overrun path ---
+    public int ReadRaw(Span<float> destination, long currentTimeMicroseconds) => throw new NotSupportedException();
+    public double SmoothedSyncErrorMicroseconds => throw new NotSupportedException();
+    public void NotifyExternalCorrection(int droppedSamples, int insertedSamples) => throw new NotSupportedException();
     public SyncCorrectionOptions SyncOptions => throw new NotSupportedException();
     public double BufferedMilliseconds => throw new NotSupportedException();
     public double TargetBufferMilliseconds { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
@@ -53,7 +50,6 @@ internal sealed class FakeTimedAudioBuffer : ITimedAudioBuffer
     }
 
     public void Write(ReadOnlySpan<float> samples, long timestampMicroseconds) => throw new NotSupportedException();
-    public int Read(Span<float> destination, long currentTimeMicroseconds) => throw new NotSupportedException();
     public void ReportExternalPlaybackRate(double rate) => throw new NotSupportedException();
     public void NotifyReconnect() => throw new NotSupportedException();
     public void Clear() => throw new NotSupportedException();

--- a/tests/MultiRoomAudio.Tests/SyncAlignmentTests.cs
+++ b/tests/MultiRoomAudio.Tests/SyncAlignmentTests.cs
@@ -17,11 +17,12 @@ namespace MultiRoomAudio.Tests;
 /// simulated session and read at a simulated playback clock.
 /// </para>
 /// <para>
-/// Note: the buffer's internal <c>Read</c> path self-anchors its startup baseline, so an output
-/// prefill does not leak into its sync error — that failure mode lives on the external
-/// <c>ReadRaw</c> + sample-source path (our <c>BufferedAudioSampleSource</c>) and is why
-/// <c>USE_AUDIO_CLOCK</c> defaults off. These tests therefore cover what the buffer level can prove:
-/// our sync options hold a drift-free schedule without hunting, and correct a genuine drift.
+/// These tests exercise the same <c>Read</c> path the app uses. The buffer owns the whole correction
+/// loop: it measures the error and closes it itself with frame drop/insert inside the spec's
+/// +/-0.5% speed cap, escalating to a one-shot snap above ~5ms. <c>TargetPlaybackRate</c> therefore
+/// stays 1.0 throughout - correction is expressed as frame stepping, not as a rate for a resampler
+/// we do not have - so these tests assert on the outcome (final sync error and the correction
+/// actually applied) rather than on a recommended rate.
 /// </para>
 /// </remarks>
 public class SyncAlignmentTests
@@ -37,7 +38,15 @@ public class SyncAlignmentTests
 
     public SyncAlignmentTests(ITestOutputHelper output) => _output = output;
 
-    private readonly record struct SessionResult(double FinalSyncErrorMs, long NetCorrectionSamples, double TargetPlaybackRate);
+    private readonly record struct SessionResult(
+        double FinalSyncErrorMs,
+        long NetCorrectionSamples,
+        long TotalSamplesOutput,
+        double TargetPlaybackRate)
+    {
+        /// <summary>Correction applied, as a fraction of all samples output.</summary>
+        public double CorrectionFraction => Math.Abs(NetCorrectionSamples) / (double)TotalSamplesOutput;
+    }
 
     /// <param name="clockDriftFactor">
     /// Playback-clock rate relative to the server schedule. 1.0 = perfect; 1.01 = clock runs 1% fast.
@@ -79,49 +88,63 @@ public class SyncAlignmentTests
         var stats = buffer.GetStats();
         var net = stats.SamplesInsertedForSync - stats.SamplesDroppedForSync;
         var finalErrMs = buffer.SyncErrorMicroseconds / 1000.0;
+        var totalOutput = (long)totalReads * ChunkSamples;
+
+        var result = new SessionResult(finalErrMs, net, totalOutput, buffer.TargetPlaybackRate);
 
         _output.WriteLine(
             $"drift={clockDriftFactor:F3} -> inserted={stats.SamplesInsertedForSync} " +
-            $"dropped={stats.SamplesDroppedForSync} net={net} rate={buffer.TargetPlaybackRate:F4} " +
-            $"finalErr={finalErrMs:F1}ms");
+            $"dropped={stats.SamplesDroppedForSync} net={net} " +
+            $"correction={result.CorrectionFraction:P3} of {totalOutput} samples " +
+            $"rate={buffer.TargetPlaybackRate:F4} finalErr={finalErrMs:F1}ms");
 
-        return new SessionResult(finalErrMs, net, buffer.TargetPlaybackRate);
+        return result;
     }
 
     // Margin covering the harness's one-callback (10ms) granularity floor.
     private const double InSyncToleranceMs = 15.0;
 
     /// <summary>
-    /// Control: a perfectly drift-free session holds the server schedule (sync error ≈ 0) and the
-    /// corrector does not hunt — zero net drop/insert correction. Guards against a sync-options
-    /// regression that would make a steady stream over-correct (audible artifacts, drift off sync).
+    /// Control: a perfectly drift-free session holds the server schedule and the corrector does not
+    /// hunt - any correction it applies stays a negligible fraction of the stream. Guards against a
+    /// sync-options regression that would make a steady stream over-correct (audible artifacts).
     /// </summary>
     [Fact]
-    public void DriftFree_HoldsSchedule_WithNoSpuriousCorrection()
+    public void DriftFree_HoldsSchedule_WithoutHunting()
     {
         var result = RunSession(clockDriftFactor: 1.0, seconds: 20);
 
         Assert.True(
             Math.Abs(result.FinalSyncErrorMs) < InSyncToleranceMs,
             $"drift-free playback should hold the schedule, but settled {result.FinalSyncErrorMs:F1}ms off");
-        Assert.Equal(0, result.NetCorrectionSamples);
-        Assert.Equal(1.0, result.TargetPlaybackRate); // no correction recommended
+
+        // A drift-free stream needs at most a one-off startup alignment. Sustained correction on a
+        // steady stream is hunting; the spec's own cap is 0.5% of samples, so anything at or above
+        // that is the corrector working continuously rather than settling.
+        Assert.True(
+            result.CorrectionFraction < 0.005,
+            $"drift-free playback should not hunt, but corrected {result.CorrectionFraction:P3} of the stream");
     }
 
     /// <summary>
-    /// A genuine playback-clock drift is detected and the buffer recommends a rate correction
-    /// (<c>TargetPlaybackRate</c> moves off 1.0) while tracking a non-zero sync error. Guards that our
-    /// sync options actually track real drift. (Closing the correction loop — resampling to the
-    /// recommended rate — is the sample-source's job, exercised by the app, not this buffer harness.)
+    /// A genuine playback-clock drift is corrected, not merely detected: the buffer drops samples to
+    /// track the fast clock and brings the session back onto the server schedule. Guards that our
+    /// sync options actually close the loop on real drift.
     /// </summary>
     [Fact]
-    public void ClockDrift_IsDetected_AndRateCorrectionRecommended()
+    public void ClockDrift_IsCorrected_BackOntoSchedule()
     {
         var result = RunSession(clockDriftFactor: 1.01, seconds: 20); // 1% fast playback clock
 
-        Assert.NotEqual(1.0, result.TargetPlaybackRate);
         Assert.True(
-            Math.Abs(result.FinalSyncErrorMs) > InSyncToleranceMs,
-            $"a 1% clock drift should register a clear sync error, got {result.FinalSyncErrorMs:F1}ms");
+            Math.Abs(result.FinalSyncErrorMs) < InSyncToleranceMs,
+            $"a 1% clock drift should be corrected back onto schedule, got {result.FinalSyncErrorMs:F1}ms");
+
+        // A 1% fast playback clock consumes audio faster than the schedule, so the buffer must DROP
+        // to keep up - net correction is negative and tracks the drift magnitude.
+        Assert.True(
+            result.NetCorrectionSamples < 0,
+            $"a fast playback clock should drop samples, but net correction was {result.NetCorrectionSamples}");
+        Assert.InRange(result.CorrectionFraction, 0.005, 0.02); // ~1% drift, generous either side
     }
 }


### PR DESCRIPTION
Hands sync correction back to the SDK, and stops over-advertising buffer capacity to the server.

## Sync correction

`BufferedAudioSampleSource` ran its own frame drop/insert corrector against `ReadRaw`. That was already redundant with the SDK's corrector, and 9.3.0 makes it actively wrong: the SDK gains a **one-shot snap tier** that the external corrector cannot coordinate with, so both loops would act on the same measured error.

The app's corrector also overstepped the protocol. It adjusted at up to ~20x the spec's ±0.5% speed cap, using its own 3-point interpolation that duplicated what the SDK already does.

Switching the read from `ReadRaw` to `ITimedAudioBuffer.Read` puts the entire correction loop in one place, where the tiers already stand down for one another. That removes ~330 lines: the corrector itself, its anti-oscillation debounce, the startup deadband, and the `ArrayPool` staging buffer that only existed to serve the external path.

`MaxSpeedCorrection` and `ResamplingThresholdMicroseconds` drop out of `PulseAudioSyncOptions` as inert on this path — the buffer applies correction as frame stepping rather than driving a resampler, and a value above the spec cap is clamped anyway.

### On the `[Obsolete]` suppression

`Read` still carries an `[Obsolete]` attribute pointing at `ReadRaw` plus an external `ISyncCorrectionProvider`. That attribute is **stale**: the 9.x line froze its published surface and so could not remove it, while 9.3.0 rewrote the method's own docs to describe it as the complete path ("corrects end to end and needs nothing from the caller") and put the new snap tier behind it. External correction is precisely what this PR removes. Suppressed at the call site with that reasoning recorded inline.

## Buffer capacity

Players advertised a flat `buffer_capacity` of 32MB — roughly **16 minutes** of Opus, far past what the decoded buffer can hold. The spec makes `buffer_capacity` a promise the server may fill toward, so over-advertising only licensed it to queue audio the player would discard unplayed.

It is now left unset so the SDK derives it from real capacity. This is likely relevant to #272, where the buffer fills to `bufferedMs=18033` against a `targetMs=250` until the SDK starts dropping samples. Not marked as closing that issue — the reporter's primary symptom (never reaching scheduled start) isn't proven fixed by this alone.

**Caveat on the 9.x line:** the SDK's derivation assumes its own 30s default buffer and exposes no public hook for ours, so `BUFFER_SECONDS` below 30 still over-advertises — by far less than 32MB did, but not exactly. Recorded in a comment at the call site.

## Tests

`SyncAlignmentTests` now exercise the same `Read` path the app uses, and assert on outcome — final sync error, and correction actually applied as a fraction of the stream — rather than on a recommended `TargetPlaybackRate` that stays 1.0 when correction is expressed as frame stepping.

- `DriftFree_HoldsSchedule_WithoutHunting` — a steady stream settles without sustained correction
- `ClockDrift_IsCorrected_BackOntoSchedule` — a 1% fast clock is dropped back onto schedule, not merely detected

## Verification

- Release build: succeeds, 0 errors
- `dotnet test -c Release`: **190/190 passing**
- Merged cleanly with the DAC format advertisement work (#288); verified the two compose — the SDK derives capacity from the most byte-efficient advertised codec, which is Opus both before and after that change

## Notes for review

- Two pre-existing warnings are untouched and unrelated: `CS8767` in `FakeTimedAudioBuffer` (confirmed present under 9.2.0 as well) and `CS8604` in `HidInputDeviceDetector`
- [CLAUDE.md](../blob/dev/CLAUDE.md) justifies `USE_AUDIO_CLOCK` defaulting off partly with "no output-prefill offset". That failure mode lived on the `ReadRaw` path removed here — the SDK's `Read` self-anchors its startup baseline. The default is likely still right on VM-resilience grounds, but the stated rationale may want a revisit. Left alone as out of scope.
