### PR TITLE
ci: point Dependabot version updates at dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,16 @@
 version: 2
+
+# Feature work merges into dev and reaches main only at a release, so version
+# updates target dev to keep the two branches from drifting apart. Bumps that
+# landed straight on main previously conflicted with dev at release time.
+#
+# Note: this file is only read from the default branch (main), and Dependabot
+# SECURITY updates always target the default branch regardless of the setting
+# below - so security PRs will still open against main.
 updates:
   - package-ecosystem: "nuget"
     directory: "/src/MultiRoomAudio"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -16,12 +25,14 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
 
   - package-ecosystem: "docker"
     directory: "/docker"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5


### PR DESCRIPTION
Sets `target-branch: "dev"` on all three Dependabot ecosystems (nuget, github-actions, docker).

## Why

Dependency bumps were opening against `main` — the default branch — while all feature work goes to `dev` and only reaches `main` at a release. That left the two branches each stale on the other's upgrades.

It surfaced while cutting v5.3.0: `MultiRoomAudio.csproj` conflicted because `main` had `System.IO.Ports 10.0.11` (from #275-#278) and `dev` had `SendSpin.SDK 9.3.0`. Resolving it in either direction would have silently downgraded a package; it needed the newer of each side taken by hand.

With bumps targeting `dev`, they land where the rest of the work does and ride out with the next release.

## Why this targets `main` rather than `dev`

Dependabot reads `.github/dependabot.yml` **only from the default branch**. On `dev` it would have no effect until the next release merged it to `main`.

## Note on security updates

Dependabot *security* updates always target the default branch regardless of `target-branch`, so those will still open against `main`. That's the desired behaviour anyway — a security fix shouldn't wait for a release cycle.

No open Dependabot PRs needed retargeting; there are currently none.